### PR TITLE
suppress javadoc warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <app.package>edu.ucsb.cs156.frontiers</app.package>
     <app.packagePath>edu/ucsb/cs156/frontiers</app.packagePath>
     <targetClasses>${targetClasses:edu.ucsb.cs156.*}</targetClasses>
+    <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
   </properties>
 
   <!-- (22) <dependencyManagement/> -->


### PR DESCRIPTION
In this PR we suppress javadoc warnings by adding this property in pom.xml

```
<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
```