### PR TITLE
Adding the Ability to Link a Course to a Github App Installation

### DIFF
--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,5 +1,7 @@
 GOOGLE_CLIENT_ID=see-instructions-in-readme
 GOOGLE_CLIENT_SECRET=see-instructions-in-readme
+GITHUB_CLIENT_ID=see-instructions-in-readme
+GITHUB_CLIENT_SECRET=see-instructions-in-readme
 ADMIN_EMAILS=phtcon@ucsb.edu
 
 CHROMATIC_PROJECT_TOKEN=see-instructions-in-readme

--- a/docs/github-app-setup-localhost.md
+++ b/docs/github-app-setup-localhost.md
@@ -24,7 +24,7 @@ In the first callback URL, fill in `http://localhost:8080/api/courses/link`. For
 
 Click the checkbox for "Request user authorization (OAuth) during installation"
 
-![image](https://github.com/user-attachments/assets/7b52701a-6108-4d54-832e-0db0f2d1d1e5)
+![image](https://github.com/user-attachments/assets/a06af72c-e08d-4f47-bd6a-91b5d1aef65f)
 
 
 Scroll down to permissions, and under repository, set the following accesses:
@@ -109,6 +109,4 @@ Select "Install" next to "ucsb-cs156". It must be an organization, not a user, a
 
 Select "All Repositories". Then, select "Install and Authorize." This should take you to your localhost application link. This should redirect you to a blank page, with the url http://localhost:8080/courses/success.
 
-Stop your application, and then run it again with `mvn spring-boot:run`.
-
-Try the endpoint http://localhost:8080/api/installations/testStudentRepos to test creating and pushing a student repo, or http://localhost:8080/api/installations/provideToken to get a github application token.
+The org name and installation ID should now be visible in the h2 console.

--- a/docs/github-app-setup-localhost.md
+++ b/docs/github-app-setup-localhost.md
@@ -1,0 +1,114 @@
+# Installing on Localhost
+First, clone the repository. This can be done with the following command:
+```bash
+git clone git@github.com:ucsb-cs156/proj-frontiers.git
+```
+Then, obtain a set of Google Cloud Credentials. Directions for obtaining these can be found [here](https://ucsb-cs156.github.io/topics/oauth/oauth_google_setup.html).
+Next, we'll set up the Github App. To do so, go to https://github.com/
+
+Then, click your profile icon. Click "Settings". Then, Click "Developer Settings", on the bottom of the toolbar on the left.
+
+Select "New Github App". Fill in an appropriate name, and write it down. You will need it later.
+![image](https://github.com/user-attachments/assets/3d0fe501-318c-4907-a267-eff44f06f17a)
+
+
+For the homepage url, fill in `http://localhost:8080`.
+
+![image](https://github.com/user-attachments/assets/bec66087-ca4a-4fc4-af3d-9ad663c24eb2)
+
+
+For Callback URLs, select "Add Callback URL"
+
+
+In the first callback URL, fill in `http://localhost:8080/api/courses/link`. For the second URL, fill in `http://localhost:8080/login/oauth2/code/github`.
+
+Click the checkbox for "Request user authorization (OAuth) during installation"
+
+![image](https://github.com/user-attachments/assets/7b52701a-6108-4d54-832e-0db0f2d1d1e5)
+
+
+Scroll down to permissions, and under repository, set the following accesses:
+- Administration: Read and Write
+- Contents: Read and Write
+- Metadata: Read-only
+- Workflows: Read and Write
+
+Under Organization, select the following permissions:
+- Administration: Read and Write
+
+Then, scroll further and uncheck "Active" under "Webhooks"
+
+![image](https://github.com/user-attachments/assets/74119317-b1a5-40c8-88ce-d7e394f7e5a6)
+
+
+Then, scroll further and under "Where can this Github App be installed?" select "Any Account"
+
+Click "Create".
+
+Now, Select "Generate Client Secret". Copy this client secret to a safe location, you will use it in a few minutes. Copy the Client ID as well.
+
+![image](https://github.com/user-attachments/assets/856cf882-b6f3-44a5-b70b-115531bb8cae)
+
+
+Scroll down to "Private Keys" and select "Generate a Private Key"
+
+![image](https://github.com/user-attachments/assets/7c2b958a-f912-4972-af63-9ff2c30339cd)
+
+
+Though we will now start using other applications, keep this Github window open. You'll need it later.
+
+This will download a private key to your computer. Move this file into the repository directory. Importantly, **Do not commit this file**.
+
+Next, we will switch the standard of the key we just downloaded so Java can understand it.
+To do so, open a terminal in the repository folder, and run the following command, replacing `<file-name>` with the name of the key.
+```bash
+openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in <file-name> -out pkcs8.key
+```
+
+Next, create a copy of `secrets.yaml.EXAMPLE` with the following command:
+```bash
+cp secrets.yaml.EXAMPLE secrets.yaml
+```
+
+Now, we're going to take the key we generated and place it into secrets.yaml. Output the key into the terminal with the following command:
+```bash
+cat pkcs8.key
+```
+
+Copy the output from this command, and paste it into secrets.yaml, replacing add your key here with the output. The file should now look like this:
+```yaml
+app:
+  private:
+    key: "-----BEGIN PRIVATE KEY-----
+<Your Key>
+-----END PRIVATE KEY-----
+"
+```
+
+Next, we'll fill in `.env`. Create a copy of it with:
+```bash
+cp .env.EXAMPLE .env
+```
+
+Fill in your Google secrets, from the article at the beginning. Additionally, fill in your Github Client ID and Client Secret, named `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_ID`, and `GITHUB_CLIENT_SECRET` respectively.
+Additionally, make sure your email is on the list of admin emails.
+
+Next, start your project:
+```bash
+mvn spring-boot:run
+```
+
+Now, create a course via swagger-ui. Make note of the ID.
+
+Next, go to the url `http://localhost:8080/api/courses/redirect?courseId=<id>`, where ID is your course's ID.
+
+Select "Install" next to "ucsb-cs156". It must be an organization, not a user, as the API differs for user repositories.
+
+![image](https://github.com/user-attachments/assets/f08c5c1a-efca-4b67-be2f-9c0120099752)
+
+
+Select "All Repositories". Then, select "Install and Authorize." This should take you to your localhost application link. This should redirect you to a blank page, with the url http://localhost:8080/courses/success.
+
+Stop your application, and then run it again with `mvn spring-boot:run`.
+
+Try the endpoint http://localhost:8080/api/installations/testStudentRepos to test creating and pushing a student repo, or http://localhost:8080/api/installations/provideToken to get a github application token.

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -1,9 +1,19 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.services.JwtService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +28,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.client.RestTemplate;
 
 @Tag(name = "Course")
 @RequestMapping("/api/courses")
@@ -27,6 +38,12 @@ public class CoursesController extends ApiController {
     
     @Autowired
     private CourseRepository courseRepository;
+
+    @Autowired private JwtService jwtService;
+
+    @Autowired private RestTemplateBuilder restTemplateBuilder;
+
+    @Autowired private ObjectMapper objectMapper;
 
      /**
      * This method creates a new Course.
@@ -74,5 +91,60 @@ public class CoursesController extends ApiController {
         Iterable<Course> courses = courseRepository.findAll();
         return courses;
     }
+
+    @Operation(summary = "Authorize a Course to a Github Course")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/redirect")
+    public ResponseEntity<Void> linkCourse(@Parameter Long courseId) throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException {
+        RestTemplate restTemplate = restTemplateBuilder.build();
+        String token = jwtService.getJwt();
+        HttpHeaders requestHeaders = new HttpHeaders();
+        requestHeaders.add("Authorization", "Bearer " + token);
+        requestHeaders.add("Accept", "application/vnd.github+json");
+        requestHeaders.add("X-GitHub-Api-Version", "2022-11-28");
+        String ENDPOINT = "https://api.github.com/app";
+        HttpEntity<String> newEntity = new HttpEntity<>(requestHeaders);
+        ResponseEntity<String> response = restTemplate.exchange(ENDPOINT, HttpMethod.GET,  newEntity, String.class);
+
+        JsonNode responseJson = objectMapper.readTree(response.getBody());
+
+        String newUrl = responseJson.get("html_url").toString().replaceAll("\"", "") + "/installations/new?state="+courseId;
+        //found this convenient solution here: https://stackoverflow.com/questions/29085295/spring-mvc-restcontroller-and-redirect
+        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).header(HttpHeaders.LOCATION, newUrl).build();
+    }
+
+    @Operation(summary = "Link a Course to a Github Course")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("link")
+    public ResponseEntity<Void> addInstallation(@Parameter(name = "installationId") @RequestParam Optional<String> installation_id,
+                                                @Parameter(name = "setupAction") @RequestParam String setup_action,
+                                                @Parameter(name = "code") @RequestParam String code,
+                                                @Parameter(name = "state") @RequestParam Long state) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+        if(installation_id.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).header(HttpHeaders.LOCATION, "/courses/nopermissions").build();
+        }else {
+            RestTemplate restTemplate = restTemplateBuilder.build();
+            String token = jwtService.getJwt();
+            String ENDPOINT = "https://api.github.com/app/installations/" + installation_id;
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("Authorization", "Bearer " + token);
+            headers.add("Accept", "application/vnd.github+json");
+            headers.add("X-GitHub-Api-Version", "2022-11-28");
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+            ResponseEntity<String> response = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class);
+            JsonNode responseJson = objectMapper.readTree(response.getBody());
+
+            String orgName = responseJson.get("account").get("login").asText();
+
+            Course course = courseRepository.findById(state).orElseThrow(() -> new EntityNotFoundException(Course.class, state));
+            course.setInstallationId(installation_id.get());
+            course.setOrgName(orgName);
+            courseRepository.save(course);
+        }
+
+        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).header(HttpHeaders.LOCATION, "/courses/success").build();
+    }
+
 
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -40,12 +40,6 @@ public class CoursesController extends ApiController {
     @Autowired
     private CourseRepository courseRepository;
 
-    @Autowired private JwtService jwtService;
-
-    @Autowired private RestTemplateBuilder restTemplateBuilder;
-
-    @Autowired private ObjectMapper objectMapper;
-
     @Autowired private OrganizationLinkerService linkerService;
 
      /**
@@ -116,11 +110,11 @@ public class CoursesController extends ApiController {
         if(installation_id.isEmpty()) {
             return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).header(HttpHeaders.LOCATION, "/courses/nopermissions").build();
         }else {
-            String orgName = linkerService.getOrgName(installation_id.get());
             Course course = courseRepository.findById(state).orElseThrow(() -> new EntityNotFoundException(Course.class, state));
             if(!course.getCreator().equals(getCurrentUser().getUser())) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
             }else{
+                String orgName = linkerService.getOrgName(installation_id.get());
                 course.setInstallationId(installation_id.get());
                 course.setOrgName(orgName);
                 courseRepository.save(course);

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -3,12 +3,14 @@ package edu.ucsb.cs156.frontiers.controllers;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.errors.InvalidInstallationTypeException;
 import edu.ucsb.cs156.frontiers.services.JwtService;
 import edu.ucsb.cs156.frontiers.services.OrganizationLinkerService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,11 +18,7 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.*;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.models.CurrentUser;
@@ -89,8 +87,8 @@ public class CoursesController extends ApiController {
         return courses;
     }
 
-    @Operation(summary = "Authorize a Course to a Github Course")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @Operation(summary = "Authorize Frontiers to a Github Course")
+    @PreAuthorize("hasRole('ROLE_PROFESSOR')")
     @GetMapping("/redirect")
     public ResponseEntity<Void> linkCourse(@Parameter Long courseId) throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException {
         String newUrl = linkerService.getRedirectUrl();
@@ -101,7 +99,7 @@ public class CoursesController extends ApiController {
 
 
     @Operation(summary = "Link a Course to a Github Course")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PreAuthorize("hasRole('ROLE_PROFESSOR')")
     @GetMapping("link")
     public ResponseEntity<Void> addInstallation(@Parameter(name = "installationId") @RequestParam Optional<String> installation_id,
                                                 @Parameter(name = "setupAction") @RequestParam String setup_action,
@@ -111,7 +109,7 @@ public class CoursesController extends ApiController {
             return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).header(HttpHeaders.LOCATION, "/courses/nopermissions").build();
         }else {
             Course course = courseRepository.findById(state).orElseThrow(() -> new EntityNotFoundException(Course.class, state));
-            if(!course.getCreator().equals(getCurrentUser().getUser())) {
+            if(!(course.getCreator().getId() ==getCurrentUser().getUser().getId())) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
             }else{
                 String orgName = linkerService.getOrgName(installation_id.get());
@@ -121,6 +119,20 @@ public class CoursesController extends ApiController {
                 return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).header(HttpHeaders.LOCATION, "/courses/success").build();
             }
         }
+    }
+
+    /**
+     * This method handles the InvalidInstallationTypeException.
+     * @param e the exception
+     * @return a map with the type and message of the exception
+     */
+    @ExceptionHandler({ InvalidInstallationTypeException.class })
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Object handleInvalidInstallationType(Throwable e) {
+        return Map.of(
+                "type", e.getClass().getSimpleName(),
+                "message", e.getMessage()
+        );
     }
 
 

--- a/src/main/java/edu/ucsb/cs156/frontiers/errors/InvalidInstallationTypeException.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/errors/InvalidInstallationTypeException.java
@@ -1,0 +1,7 @@
+package edu.ucsb.cs156.frontiers.errors;
+
+public class InvalidInstallationTypeException extends RuntimeException {
+    public InvalidInstallationTypeException (String type){
+        super("Invalid installation type: " + type + ". Frontiers can only be linked to organizations");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerService.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.frontiers.services;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.frontiers.errors.InvalidInstallationTypeException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
@@ -56,7 +57,10 @@ public class OrganizationLinkerService {
         HttpEntity<String> entity = new HttpEntity<>(headers);
         ResponseEntity<String> response = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class);
         JsonNode responseJson = objectMapper.readTree(response.getBody());
-
+        String type = responseJson.get("account").get("type").asText();
+        if(!type.equals("Organization")){
+            throw new InvalidInstallationTypeException(type);
+        }
         String orgName = responseJson.get("account").get("login").asText();
         return orgName;
     }

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerService.java
@@ -14,12 +14,10 @@ import org.springframework.web.client.RestTemplate;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
-import java.util.Optional;
 
 @Service
 public class OrganizationLinkerService {
-    @Autowired
-    RestTemplateBuilder restTemplateBuilder;
+    private RestTemplate restTemplate;
 
     @Autowired
     JwtService jwtService;
@@ -27,8 +25,11 @@ public class OrganizationLinkerService {
     @Autowired
     ObjectMapper objectMapper;
 
+    public OrganizationLinkerService(RestTemplateBuilder restTemplateBuilder) {
+        restTemplate = restTemplateBuilder.build();
+    }
+
     public String getRedirectUrl() throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
-        RestTemplate restTemplate = restTemplateBuilder.build();
         String token = jwtService.getJwt();
         HttpHeaders requestHeaders = new HttpHeaders();
         requestHeaders.add("Authorization", "Bearer " + token);
@@ -45,7 +46,6 @@ public class OrganizationLinkerService {
     }
 
     public String getOrgName(String installation_id) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
-        RestTemplate restTemplate = restTemplateBuilder.build();
         String token = jwtService.getJwt();
         String ENDPOINT = "https://api.github.com/app/installations/" + installation_id;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,7 @@ server.compression.enabled=false
 spring.mvc.format.date-time=iso
 
 app.oauth.login=${OAUTH_LOGIN:${env.OAUTH_LOGIN:/oauth2/authorization/google}}
+app.client.id=${GITHUB_CLIENT_ID:${env.GITHUB_CLIENT_ID:github_client_id_unset}}
 
 spring.jpa.hibernate.ddl-auto=none
 spring.liquibase.change-log=db/migration/changelog-master.json

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
@@ -1,9 +1,11 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
+import edu.ucsb.cs156.frontiers.services.OrganizationLinkerService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -15,18 +17,20 @@ import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.services.CurrentUserService;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @Slf4j
 @WebMvcTest(controllers = CoursesController.class)
@@ -38,6 +42,9 @@ public class CoursesControllerTests extends ControllerTestCase {
 
     @Autowired
     private CurrentUserService currentUserService;
+
+    @MockitoBean
+    private OrganizationLinkerService linkerService;
 
     /**
      * Test the POST endpoint
@@ -117,6 +124,117 @@ public class CoursesControllerTests extends ControllerTestCase {
 
         String responseString = response.getResponse().getContentAsString();
         String expectedJson = mapper.writeValueAsString(java.util.List.of(course1, course2));
+        assertEquals(expectedJson, responseString);
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    public void testRedirect() throws Exception {
+        doReturn("https://github.com/app/app1").when(linkerService).getRedirectUrl();
+
+        String expectedUrl = "https://github.com/app/app1/installations/new?state=1";
+        MvcResult response = mockMvc.perform(get("/api/courses/redirect")
+                    .param("courseId", "1"))
+                .andExpect(status().isMovedPermanently())
+                .andReturn();
+
+        String responseUrl = response.getResponse().getHeader(HttpHeaders.LOCATION);
+
+        assertEquals(expectedUrl, responseUrl);
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    public void testLinkCourseSuccessfully() throws Exception {
+        User user = currentUserService.getCurrentUser().getUser();
+        Course course1 = Course.builder()
+                .courseName("CS156")
+                .term("S25")
+                .school("UCSB")
+                .creator(user)
+                .id(1L)
+                .build();
+        Course course2 = Course.builder()
+                .courseName("CS156")
+                .orgName("ucsb-cs156-s25")
+                .term("S25")
+                .school("UCSB")
+                .creator(user)
+                .installationId("1234")
+                .orgName("ucsb-cs156-s25")
+                .id(1L)
+                .build();
+
+        doReturn(Optional.of(course1)).when(courseRepository).findById(eq(1L));
+        doReturn("ucsb-cs156-s25").when(linkerService).getOrgName("1234");
+        MvcResult response = mockMvc.perform(get("/api/courses/link")
+                .param("installation_id", "1234")
+                .param("setup_action", "install")
+                .param("code", "abcdefg")
+                .param("state", "1"))
+                .andExpect(status().isMovedPermanently())
+                .andReturn();
+
+        String responseUrl = response.getResponse().getHeader(HttpHeaders.LOCATION);
+        verify(courseRepository, times(1)).save(eq(course2));
+        assertEquals("/courses/success",  responseUrl);
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    public void testNoPerms() throws Exception {
+
+        MvcResult response = mockMvc.perform(get("/api/courses/link")
+                        .param("setup_action", "request")
+                        .param("code", "abcdefg")
+                        .param("state", "1"))
+                .andExpect(status().isMovedPermanently())
+                .andReturn();
+
+        String responseUrl = response.getResponse().getHeader(HttpHeaders.LOCATION);
+        assertEquals("/courses/nopermissions",  responseUrl);
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    public void testNotCreator() throws Exception {
+        User separateUser = User.builder().id(2L).build();
+        Course course1 = Course.builder()
+                .courseName("CS156")
+                .term("S25")
+                .school("UCSB")
+                .creator(separateUser)
+                .id(1L)
+                .build();
+
+        doReturn(Optional.of(course1)).when(courseRepository).findById(eq(1L));
+        doReturn("ucsb-cs156-s25").when(linkerService).getOrgName("1234");
+        MvcResult response = mockMvc.perform(get("/api/courses/link")
+                        .param("installation_id", "1234")
+                        .param("setup_action", "install")
+                        .param("code", "abcdefg")
+                        .param("state", "1"))
+                .andExpect(status().isForbidden())
+                .andReturn();
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    public void testCourseLinkNotFound() throws Exception {
+
+        doReturn(Optional.empty()).when(courseRepository).findById(eq(1L));
+        MvcResult response = mockMvc.perform(get("/api/courses/link")
+                        .param("installation_id", "1234")
+                        .param("setup_action", "install")
+                        .param("code", "abcdefg")
+                        .param("state", "1"))
+                .andExpect(status().isNotFound())
+                .andReturn();
+        String responseString = response.getResponse().getContentAsString();
+        Map<String, String> expectedMap = Map.of(
+                "type", "EntityNotFoundException",
+                "message", "Course with id 1 not found");
+        String expectedJson = mapper.writeValueAsString(expectedMap);
         assertEquals(expectedJson, responseString);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerServiceTests.java
@@ -1,0 +1,84 @@
+package edu.ucsb.cs156.frontiers.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.frontiers.services.wiremock.WiremockService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RestClientTest(OrganizationLinkerService.class)
+@AutoConfigureDataJpa
+public class OrganizationLinkerServiceTests {
+    @Autowired
+    private OrganizationLinkerService organizationLinkerService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @MockitoBean
+    private WiremockService wiremockService;
+
+    @Test
+    public void testRedirectUrl() throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+        String appUrl = "https://github.com/apps/octoapp";
+        String apiResponse = String.format("""
+                {
+                  "id": 1,
+                  "slug": "octoapp",
+                  "client_id": "Iv1.ab1112223334445c",
+                  "node_id": "MDExOkludGVncmF0aW9uMQ==",
+                  "html_url": "%s"
+                }
+                """, appUrl);
+
+        doReturn("definitely.real.jwt").when(jwtService).getJwt();
+        mockRestServiceServer.expect(requestTo("https://api.github.com/app"))
+                .andExpect(header("Authorization", "Bearer definitely.real.jwt" ))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andRespond(withSuccess(apiResponse, MediaType.APPLICATION_JSON));
+
+        String actualUrl = organizationLinkerService.getRedirectUrl();
+        assertEquals(appUrl, actualUrl);
+    }
+
+    @Test
+    public void testGetOrgName() throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+        String orgName = "ucsb-cs156";
+        String apiResponse = String.format("""
+                {
+                  "id": 1,
+                  "account":{
+                    "login" : "%s"
+                  }
+                }
+                """, orgName);
+
+        doReturn("definitely.real.jwt").when(jwtService).getJwt();
+        mockRestServiceServer.expect(requestTo("https://api.github.com/app/installations/123456"))
+                .andExpect(header("Authorization", "Bearer definitely.real.jwt" ))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andRespond(withSuccess(apiResponse, MediaType.APPLICATION_JSON));
+
+        String actualUrl = organizationLinkerService.getOrgName("123456");
+        assertEquals(orgName, actualUrl);
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerServiceTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.frontiers.services;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.frontiers.errors.InvalidInstallationTypeException;
 import edu.ucsb.cs156.frontiers.services.wiremock.WiremockService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +15,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -65,7 +67,8 @@ public class OrganizationLinkerServiceTests {
                 {
                   "id": 1,
                   "account":{
-                    "login" : "%s"
+                    "login" : "%s",
+                    "type" : "Organization"
                   }
                 }
                 """, orgName);
@@ -77,8 +80,37 @@ public class OrganizationLinkerServiceTests {
                 .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
                 .andRespond(withSuccess(apiResponse, MediaType.APPLICATION_JSON));
 
-        String actualUrl = organizationLinkerService.getOrgName("123456");
-        assertEquals(orgName, actualUrl);
+        String actualOrgName = organizationLinkerService.getOrgName("123456");
+        assertEquals(orgName, actualOrgName);
+    }
+
+    @Test
+    public void testNotAnOrganization() throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+        String orgName = "githubuser1";
+        String apiResponse = String.format("""
+                {
+                  "id": 1,
+                  "account":{
+                    "login" : "%s",
+                    "type" : "User"
+                  }
+                }
+                """, orgName);
+
+        String expectedMessage = "Invalid installation type: User. Frontiers can only be linked to organizations";
+
+        doReturn("definitely.real.jwt").when(jwtService).getJwt();
+        mockRestServiceServer.expect(requestTo("https://api.github.com/app/installations/123456"))
+                .andExpect(header("Authorization", "Bearer definitely.real.jwt" ))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andRespond(withSuccess(apiResponse, MediaType.APPLICATION_JSON));
+
+        Exception thrownException = assertThrows(InvalidInstallationTypeException.class, () -> {
+            organizationLinkerService.getOrgName("123456");
+        });
+
+        assertEquals(expectedMessage, thrownException.getMessage());
     }
 
 }


### PR DESCRIPTION
In this PR, I add the ability to link a course and a github app installation together. There are two endpoints for this: one external redirect to github, with the courseId saved as the state, and an incoming one where Github provides the installation id.

Since students will not be admins on the github organization as they write code, there is a carveout in the incoming endpoint, where it simply informs students they don't have the permissions to link the two together. The `/api/courses/link` endpoint also redirects, but to the frontend depending on whether it was successful or not.

The steps for creating an app are documents in docs/github-app-setup-localhost.md

Currently deployed to https://proj-frontiers-division7.dokku-00.cs.ucsb.edu/

Merge before #40.