### PR TITLE
Pc GitHub login button

### DIFF
--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -116,18 +116,16 @@ const apiCurrentUserFixturesWithGithub = {
       ...apiCurrentUserFixtures.adminUser.user, // Reuse the admin user from above
       githubId: 123456, // Adding a Github ID to simulate Github login
       githubLogin: "phtcon-github", // Simulating a Github login
-    }
-  }, 
+    },
+  },
   userOnly: {
     user: {
       ...apiCurrentUserFixtures.userOnly.user, // Reuse the admin user from above
       githubId: 654321, // Adding a Github ID to simulate Github login
       githubLogin: "cgaucho-github", // Simulating a Github login
-    }
-  }
-
-}
-
+    },
+  },
+};
 
 const currentUserFixtures = {
   adminUser: {
@@ -174,7 +172,7 @@ const currentUserFixturesWithGithub = {
         "SCOPE_https://www.googleapis.com/auth/userinfo.email",
         "ROLE_USER",
         "ROLE_ADMIN",
-        "ROLE_GITHUB"
+        "ROLE_GITHUB",
       ],
     },
   },
@@ -187,7 +185,7 @@ const currentUserFixturesWithGithub = {
         "ROLE_USER",
         "SCOPE_https://www.googleapis.com/auth/userinfo.profile",
         "SCOPE_https://www.googleapis.com/auth/userinfo.email",
-        "ROLE_GITHUB"
+        "ROLE_GITHUB",
       ],
     },
   },
@@ -197,5 +195,9 @@ const currentUserFixturesWithGithub = {
   },
 };
 
-
-export { currentUserFixtures, currentUserFixturesWithGithub, apiCurrentUserFixtures, apiCurrentUserFixturesWithGithub };
+export {
+  currentUserFixtures,
+  currentUserFixturesWithGithub,
+  apiCurrentUserFixtures,
+  apiCurrentUserFixturesWithGithub,
+};

--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -13,6 +13,8 @@ const apiCurrentUserFixtures = {
       locale: "en",
       hostedDomain: "ucsb.edu",
       admin: true,
+      githubId: 0,
+      githubLogin: null,
     },
     roles: [
       {
@@ -61,6 +63,8 @@ const apiCurrentUserFixtures = {
       locale: "en",
       hostedDomain: null,
       admin: false,
+      githubId: 0,
+      githubLogin: null,
     },
     roles: [
       {
@@ -106,6 +110,25 @@ const apiCurrentUserFixtures = {
   },
 };
 
+const apiCurrentUserFixturesWithGithub = {
+  adminUser: {
+    user: {
+      ...apiCurrentUserFixtures.adminUser.user, // Reuse the admin user from above
+      githubId: 123456, // Adding a Github ID to simulate Github login
+      githubLogin: "phtcon-github", // Simulating a Github login
+    }
+  }, 
+  userOnly: {
+    user: {
+      ...apiCurrentUserFixtures.userOnly.user, // Reuse the admin user from above
+      githubId: 654321, // Adding a Github ID to simulate Github login
+      githubLogin: "cgaucho-github", // Simulating a Github login
+    }
+  }
+
+}
+
+
 const currentUserFixtures = {
   adminUser: {
     loggedIn: true,
@@ -139,4 +162,40 @@ const currentUserFixtures = {
   },
 };
 
-export { currentUserFixtures, apiCurrentUserFixtures };
+const currentUserFixturesWithGithub = {
+  adminUser: {
+    loggedIn: true,
+    root: {
+      ...apiCurrentUserFixturesWithGithub.adminUser,
+      rolesList: [
+        "ROLE_MEMBER",
+        "SCOPE_openid",
+        "SCOPE_https://www.googleapis.com/auth/userinfo.profile",
+        "SCOPE_https://www.googleapis.com/auth/userinfo.email",
+        "ROLE_USER",
+        "ROLE_ADMIN",
+        "ROLE_GITHUB"
+      ],
+    },
+  },
+  userOnly: {
+    loggedIn: true,
+    root: {
+      ...apiCurrentUserFixturesWithGithub.userOnly,
+      rolesList: [
+        "SCOPE_openid",
+        "ROLE_USER",
+        "SCOPE_https://www.googleapis.com/auth/userinfo.profile",
+        "SCOPE_https://www.googleapis.com/auth/userinfo.email",
+        "ROLE_GITHUB"
+      ],
+    },
+  },
+  notLoggedIn: {
+    loggedIn: false,
+    root: {},
+  },
+};
+
+
+export { currentUserFixtures, currentUserFixturesWithGithub, apiCurrentUserFixtures, apiCurrentUserFixturesWithGithub };

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -65,6 +65,8 @@ export default function AppNavbar({
                 currentUser={currentUser}
                 systemInfo={systemInfo}
               />
+            </Nav>
+            <Nav className="ml-auto">
               <GoogleLogin
                 currentUser={currentUser}
                 systemInfo={systemInfo}

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -15,8 +15,8 @@ export default function AppNavbar({
     <>
       {(currentUrl.startsWith("http://localhost:3000") ||
         currentUrl.startsWith("http://127.0.0.1:3000")) && (
-          <AppNavbarLocalhost url={currentUrl} />
-        )}
+        <AppNavbarLocalhost url={currentUrl} />
+      )}
       <Navbar
         expand="xl"
         variant="dark"
@@ -61,10 +61,7 @@ export default function AppNavbar({
               )}
             </Nav>
             <Nav className="ml-auto">
-              <GithubLogin
-                currentUser={currentUser}
-                systemInfo={systemInfo}
-              />
+              <GithubLogin currentUser={currentUser} systemInfo={systemInfo} />
             </Nav>
             <Nav className="ml-auto">
               <GoogleLogin

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 import AppNavbarLocalhost from "main/components/Nav/AppNavbarLocalhost";
 import GoogleLogin from "main/components/Nav/GoogleLogin";
+import GithubLogin from "main/components/Nav/GithubLogin";
 
 export default function AppNavbar({
   currentUser,
@@ -14,8 +15,8 @@ export default function AppNavbar({
     <>
       {(currentUrl.startsWith("http://localhost:3000") ||
         currentUrl.startsWith("http://127.0.0.1:3000")) && (
-        <AppNavbarLocalhost url={currentUrl} />
-      )}
+          <AppNavbarLocalhost url={currentUrl} />
+        )}
       <Navbar
         expand="xl"
         variant="dark"
@@ -60,6 +61,10 @@ export default function AppNavbar({
               )}
             </Nav>
             <Nav className="ml-auto">
+              <GithubLogin
+                currentUser={currentUser}
+                systemInfo={systemInfo}
+              />
               <GoogleLogin
                 currentUser={currentUser}
                 systemInfo={systemInfo}

--- a/frontend/src/main/components/Nav/GithubLogin.js
+++ b/frontend/src/main/components/Nav/GithubLogin.js
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 export default function GithubLogin({ currentUser, systemInfo }) {
   var githubOauthLogin = systemInfo?.githubOauthLogin || "/oauth2/authorization/github";
   if (!currentUser || !currentUser.loggedIn ) {
-    return <> </>
+    return <span data-testid="GithubLogin-logged-out" />
   }
   console.log("GithubLogin: currentUser = ", currentUser);
   if (currentUser.root.user.githubLogin) {

--- a/frontend/src/main/components/Nav/GithubLogin.js
+++ b/frontend/src/main/components/Nav/GithubLogin.js
@@ -7,7 +7,6 @@ export default function GithubLogin({ currentUser, systemInfo }) {
   if (!currentUser || !currentUser.loggedIn) {
     return <span data-testid="GithubLogin-logged-out" />;
   }
-  console.log("GithubLogin: currentUser = ", currentUser);
   if (currentUser.root.user.githubLogin) {
     return (
       <>

--- a/frontend/src/main/components/Nav/GithubLogin.js
+++ b/frontend/src/main/components/Nav/GithubLogin.js
@@ -1,0 +1,22 @@
+import { Button, Navbar } from "react-bootstrap";
+import { Link } from "react-router-dom";
+
+export default function GithubLogin({ currentUser, systemInfo }) {
+  var githubOauthLogin = systemInfo?.githubOauthLogin || "/oauth2/authorization/github";
+  if (!currentUser || !currentUser.loggedIn ) {
+    return <> </>
+  }
+  console.log("GithubLogin: currentUser = ", currentUser);
+  if (currentUser.root.user.githubLogin) {
+    return ( <>
+      <Navbar.Text className="me-3" as={Link} to="/profile">
+        Github: {currentUser.root.user.githubLogin}
+      </Navbar.Text>
+    </>) 
+  }
+  return (
+    <>
+      <Button href={githubOauthLogin}>Connect Github</Button>
+    </>
+  );
+}

--- a/frontend/src/main/components/Nav/GithubLogin.js
+++ b/frontend/src/main/components/Nav/GithubLogin.js
@@ -2,17 +2,20 @@ import { Button, Navbar } from "react-bootstrap";
 import { Link } from "react-router-dom";
 
 export default function GithubLogin({ currentUser, systemInfo }) {
-  var githubOauthLogin = systemInfo?.githubOauthLogin || "/oauth2/authorization/github";
-  if (!currentUser || !currentUser.loggedIn ) {
-    return <span data-testid="GithubLogin-logged-out" />
+  var githubOauthLogin =
+    systemInfo?.githubOauthLogin || "/oauth2/authorization/github";
+  if (!currentUser || !currentUser.loggedIn) {
+    return <span data-testid="GithubLogin-logged-out" />;
   }
   console.log("GithubLogin: currentUser = ", currentUser);
   if (currentUser.root.user.githubLogin) {
-    return ( <>
-      <Navbar.Text className="me-3" as={Link} to="/profile">
-        Github: {currentUser.root.user.githubLogin}
-      </Navbar.Text>
-    </>) 
+    return (
+      <>
+        <Navbar.Text className="me-3" as={Link} to="/profile">
+          Github: {currentUser.root.user.githubLogin}
+        </Navbar.Text>
+      </>
+    );
   }
   return (
     <>

--- a/frontend/src/stories/components/Nav/AppNavbar.stories.js
+++ b/frontend/src/stories/components/Nav/AppNavbar.stories.js
@@ -1,4 +1,7 @@
-import { apiCurrentUserFixtures, apiCurrentUserFixturesWithGithub } from "fixtures/currentUserFixtures";
+import {
+  apiCurrentUserFixtures,
+  apiCurrentUserFixturesWithGithub,
+} from "fixtures/currentUserFixtures";
 import AppNavbar from "main/components/Nav/AppNavbar";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
@@ -23,14 +26,13 @@ const Template = (args) => {
   return <AppNavbar {...args} />;
 };
 
-
 export const LoggedOut = Template.bind({});
 LoggedOut.parameters = {
   currentUser: {
     loggedIn: false,
   },
   systemInfo: null,
-  doLogout: () => { },
+  doLogout: () => {},
 };
 
 export const LoggedInUserNoGithub = Template.bind({});
@@ -91,7 +93,7 @@ LoggedInAdminWithGithub.args = {
     window.alert("Logging out");
     console.log("Logged out");
   },
-}
+};
 
 export const Localhost3000 = Template.bind({});
 Localhost3000.args = {

--- a/frontend/src/stories/components/Nav/GithubLogin.stories.js
+++ b/frontend/src/stories/components/Nav/GithubLogin.stories.js
@@ -1,10 +1,10 @@
 import { apiCurrentUserFixtures, apiCurrentUserFixturesWithGithub } from "fixtures/currentUserFixtures";
-import AppNavbar from "main/components/Nav/AppNavbar";
+import GithubLogin from "main/components/Nav/GithubLogin";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 export default {
-  title: "components/Nav/AppNavbar",
-  component: AppNavbar,
+  title: "components/Nav/GithubLogin",
+  component: GithubLogin,
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
     layout: "centered",
@@ -19,10 +19,7 @@ export default {
 
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 
-const Template = (args) => {
-  return <AppNavbar {...args} />;
-};
-
+const Template = (args) => <GithubLogin {...args} />;
 
 export const LoggedOut = Template.bind({});
 LoggedOut.parameters = {
@@ -91,19 +88,4 @@ LoggedInAdminWithGithub.args = {
     window.alert("Logging out");
     console.log("Logged out");
   },
-}
-
-export const Localhost3000 = Template.bind({});
-Localhost3000.args = {
-  currentUrl: "http://localhost:3000",
-};
-
-export const LocalhostNumeric3000 = Template.bind({});
-LocalhostNumeric3000.args = {
-  currentUrl: "http://127.0.0.1:3000",
-};
-
-export const Localhost8080 = Template.bind({});
-Localhost8080.args = {
-  currentUrl: "http://localhost:8080",
 };

--- a/frontend/src/stories/components/Nav/GithubLogin.stories.js
+++ b/frontend/src/stories/components/Nav/GithubLogin.stories.js
@@ -1,4 +1,7 @@
-import { apiCurrentUserFixtures, apiCurrentUserFixturesWithGithub } from "fixtures/currentUserFixtures";
+import {
+  apiCurrentUserFixtures,
+  apiCurrentUserFixturesWithGithub,
+} from "fixtures/currentUserFixtures";
 import GithubLogin from "main/components/Nav/GithubLogin";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
@@ -27,7 +30,7 @@ LoggedOut.parameters = {
     loggedIn: false,
   },
   systemInfo: null,
-  doLogout: () => { },
+  doLogout: () => {},
 };
 
 export const LoggedInUserNoGithub = Template.bind({});

--- a/frontend/src/tests/components/Nav/GithubLogin.test.js
+++ b/frontend/src/tests/components/Nav/GithubLogin.test.js
@@ -35,6 +35,33 @@ describe("GithubLogin tests", () => {
     expect(loginButton).toBeInTheDocument();
   });
 
+  test("default link is the correct value", async () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GithubLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Connect Github");
+    // Check if the button is rendered with the overridden link
+    const loginButton = screen.getByRole("button", {
+      name: "Connect Github",
+    });
+    expect(loginButton).toBeInTheDocument();
+    // Ensure the login button has the correct href
+    expect(loginButton).toHaveAttribute("href", "/oauth2/authorization/github"); // This checks if the overridden URL is used
+  });
+
   test("link can be overridden via systemInfo", async () => {
     const currentUser = currentUserFixtures.userOnly;
 

--- a/frontend/src/tests/components/Nav/GithubLogin.test.js
+++ b/frontend/src/tests/components/Nav/GithubLogin.test.js
@@ -35,6 +35,41 @@ describe("GithubLogin tests", () => {
     expect(loginButton).toBeInTheDocument();
   });
 
+  test("link can be overridden via systemInfo", async () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    const overriddenSystemInfo = {
+      ...systemInfo, // Spread the existing system info
+      githubOauthLogin: "/oauth2/authorization/custom-github", // Override the oauth login URL
+    };
+
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GithubLogin
+            currentUser={currentUser}
+            systemInfo={overriddenSystemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Connect Github");
+    // Check if the button is rendered with the overridden link
+    const loginButton = screen.getByRole("button", {
+      name: "Connect Github",
+    });
+    expect(loginButton).toBeInTheDocument();
+    // Ensure the login button has the correct href
+    expect(loginButton).toHaveAttribute(
+      "href",
+      "/oauth2/authorization/custom-github",
+    ); // This checks if the overridden URL is used
+  });
+
   test("renders correctly for user logged into Google but not Github", async () => {
     const currentUser = currentUserFixtures.userOnly;
 

--- a/frontend/src/tests/components/Nav/GithubLogin.test.js
+++ b/frontend/src/tests/components/Nav/GithubLogin.test.js
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures, currentUserFixturesWithGithub } from "fixtures/currentUserFixtures";
+
+import GithubLogin from "main/components/Nav/GithubLogin";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+describe("GithubLogin tests", () => {
+  const queryClient = new QueryClient();
+
+  const systemInfo = systemInfoFixtures.showingNeither; // Default system info for tests
+
+  test("renders correctly when not logged in to Google", async () => {
+    const currentUser = { loggedIn: false };
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GithubLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Check for the login button
+    const loginButton = screen.getByTestId("GithubLogin-logged-out");
+    expect(loginButton).toBeInTheDocument();
+  });
+
+
+  test("renders correctly for user logged into Google but not Github", async () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GithubLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Connect Github");
+  });
+
+  test("renders correctly for user logged into Google but not Github", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GithubLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Connect Github");
+  });
+
+  test("renders correctly for user logged into Google and Github", async () => {
+    const currentUser = currentUserFixturesWithGithub.userOnly;
+
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GithubLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Github: cgaucho-github");
+  });
+
+  test("renders correctly for user logged into Google but not Github", async () => {
+    const currentUser = currentUserFixturesWithGithub.adminUser;
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GithubLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Github: phtcon-github");
+  });
+
+
+});

--- a/frontend/src/tests/components/Nav/GithubLogin.test.js
+++ b/frontend/src/tests/components/Nav/GithubLogin.test.js
@@ -45,7 +45,7 @@ describe("GithubLogin tests", () => {
     await screen.findByText("Connect Github");
   });
 
-  test("renders correctly for user logged into Google but not Github", async () => {
+  test("renders correctly for admin logged into Google but not Github", async () => {
     const currentUser = currentUserFixtures.adminUser;
     const doLogin = jest.fn();
 
@@ -76,7 +76,7 @@ describe("GithubLogin tests", () => {
     await screen.findByText("Github: cgaucho-github");
   });
 
-  test("renders correctly for user logged into Google but not Github", async () => {
+  test("renders correctly for admin logged into Google and Github", async () => {
     const currentUser = currentUserFixturesWithGithub.adminUser;
     const doLogin = jest.fn();
 

--- a/frontend/src/tests/components/Nav/GithubLogin.test.js
+++ b/frontend/src/tests/components/Nav/GithubLogin.test.js
@@ -1,7 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import { currentUserFixtures, currentUserFixturesWithGithub } from "fixtures/currentUserFixtures";
+import {
+  currentUserFixtures,
+  currentUserFixturesWithGithub,
+} from "fixtures/currentUserFixtures";
 
 import GithubLogin from "main/components/Nav/GithubLogin";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
@@ -18,7 +21,11 @@ describe("GithubLogin tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <GithubLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+          <GithubLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -28,7 +35,6 @@ describe("GithubLogin tests", () => {
     expect(loginButton).toBeInTheDocument();
   });
 
-
   test("renders correctly for user logged into Google but not Github", async () => {
     const currentUser = currentUserFixtures.userOnly;
 
@@ -37,7 +43,11 @@ describe("GithubLogin tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <GithubLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+          <GithubLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -52,7 +62,11 @@ describe("GithubLogin tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <GithubLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+          <GithubLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -68,7 +82,11 @@ describe("GithubLogin tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <GithubLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+          <GithubLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -83,13 +101,15 @@ describe("GithubLogin tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <GithubLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+          <GithubLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
 
     await screen.findByText("Github: phtcon-github");
   });
-
-
 });

--- a/frontend/src/tests/components/Nav/GoogleLogin.test.js
+++ b/frontend/src/tests/components/Nav/GoogleLogin.test.js
@@ -19,7 +19,11 @@ describe("GoogleLogin tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <GoogleLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+          <GoogleLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -34,7 +38,11 @@ describe("GoogleLogin tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <GoogleLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+          <GoogleLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -49,7 +57,11 @@ describe("GoogleLogin tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <GoogleLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+          <GoogleLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );

--- a/frontend/src/tests/components/Nav/GoogleLogin.test.js
+++ b/frontend/src/tests/components/Nav/GoogleLogin.test.js
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+import GoogleLogin from "main/components/Nav/GoogleLogin";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+describe("GoogleLogin tests", () => {
+  const queryClient = new QueryClient();
+
+  const systemInfo = systemInfoFixtures.showingNeither; // Default system info for tests
+
+  test("renders correctly for regular logged in user", async () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GoogleLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Welcome, pconrad.cis@gmail.com");
+  });
+
+  test("renders correctly for admin user", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GoogleLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Welcome, phtcon@ucsb.edu");
+  });
+
+  test("renders login button when not logged in", async () => {
+    const currentUser = { loggedIn: false };
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GoogleLogin currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Check for the login button
+    const loginButton = screen.getByText("Log In");
+    expect(loginButton).toBeInTheDocument();
+    expect(loginButton).toHaveAttribute("href", "/oauth2/authorization/google");
+  });
+});


### PR DESCRIPTION
In this PR, we add a button to the Navigation bar that appears only when the user is logged into Google first.

This button starts the Github OAuth flow to login to Github.

When Github is logged in, instead of showing the Connect Github button, the navigation bar shows the github login.

## Screenshots

## Before:

Logged out: 

<img width="1369" alt="image" src="https://github.com/user-attachments/assets/4490326d-7270-426d-8180-785b140b8387" />

Logged In:

<img width="1306" alt="image" src="https://github.com/user-attachments/assets/c1c989d2-1069-4750-aa67-0daecdff1a9c" />


## After: 

Logged Out: 

<img width="1337" alt="image" src="https://github.com/user-attachments/assets/f073f0f5-4bc4-47c9-82ec-2471cd7b0ab7" />

Logged in to Google, but not Github:

<img width="1371" alt="image" src="https://github.com/user-attachments/assets/8ced6ec1-0ed5-4a1b-8a62-2d681f7d9a58" />

Logged into both:

<img width="1351" alt="image" src="https://github.com/user-attachments/assets/7c05d076-a161-4c1d-bed4-a31ae46ba417" />


