### PR TITLE
pc - refactor courseId param (old name course_id)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -65,12 +65,12 @@ public class RosterStudentsController extends ApiController {
             @Parameter(name = "firstName") @RequestParam String firstName,
             @Parameter(name = "lastName") @RequestParam String lastName,
             @Parameter(name = "email") @RequestParam String email,
-            @Parameter(name = "course_id") @RequestParam Long course_id) throws EntityNotFoundException {
+            @Parameter(name = "courseId") @RequestParam Long courseId) throws EntityNotFoundException {
 
         // Get Course or else throw an error
 
-        Course course = courseRepository.findById(course_id)
-                .orElseThrow(() -> new EntityNotFoundException(Course.class, course_id));
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
 
         RosterStudent rosterStudent = RosterStudent.builder()
                 .studentId(studentId)
@@ -95,9 +95,9 @@ public class RosterStudentsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/course")
     public Iterable<RosterStudent> rosterStudentForCourse(
-            @Parameter(name = "course_id") @RequestParam Long course_id) throws EntityNotFoundException {
-        courseRepository.findById(course_id).orElseThrow(() -> new EntityNotFoundException(Course.class, course_id));
-        Iterable<RosterStudent> rosterStudents = rosterStudentRepository.findByCourseId(course_id);
+            @Parameter(name = "courseId") @RequestParam Long courseId) throws EntityNotFoundException {
+        courseRepository.findById(courseId).orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
+        Iterable<RosterStudent> rosterStudents = rosterStudentRepository.findByCourseId(courseId);
         return rosterStudents;
     }
 
@@ -105,7 +105,7 @@ public class RosterStudentsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping(value = "/upload/egrades", consumes = { "multipart/form-data" })
     public Map<String, String> uploadRosterStudents(
-            @Parameter(name = "course_id") @RequestParam Long courseId,
+            @Parameter(name = "courseId") @RequestParam Long courseId,
             @Parameter(name = "file") @RequestParam("file") MultipartFile file)
             throws JsonProcessingException, IOException, CsvException {
 

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -12,7 +12,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import edu.ucsb.cs156.frontiers.ControllerTestCase;
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
-import edu.ucsb.cs156.frontiers.entities.User;
 import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.enums.RosterStatus;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
@@ -38,13 +37,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.mockito.Mock;
-
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 
 @Slf4j
@@ -108,7 +100,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                                 .param("firstName", "Chris")
                                 .param("lastName", "Gaucho")
                                 .param("email", "cgaucho@example.org")
-                                .param("course_id", "1"))
+                                .param("courseId", "1"))
                                 .andExpect(status().isOk())
                                 .andReturn();
 
@@ -143,7 +135,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                                 .param("firstName", "Chris")
                                 .param("lastName", "Gaucho")
                                 .param("email", "cgaucho@example.org")
-                                .param("course_id", "1"))
+                                .param("courseId", "1"))
                                 .andExpect(status().isNotFound())
                                 .andReturn();
 
@@ -174,7 +166,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 // act
 
                 MvcResult response = mockMvc.perform(get("/api/rosterstudents/course")
-                                .param("course_id", "1"))
+                                .param("courseId", "1"))
                                 .andExpect(status().isOk())
                                 .andReturn();
 
@@ -198,7 +190,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 // act
 
                 MvcResult response = mockMvc.perform(get("/api/rosterstudents/course")
-                                .param("course_id", "1"))
+                                .param("courseId", "1"))
                                 .andExpect(status().isNotFound())
                                 .andReturn();
 


### PR DESCRIPTION
In this PR, we refactor the courseId parameter; previously it was inconsistent (`courseId` vs. `course_id`).