### PR TITLE
pc - add code to fix umail addresses, handle upserts, and link users at upload time

### DIFF
--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -69,6 +69,7 @@ jobs:
         path: target/pit-reports/* 
 
     - name: Get PR number
+      if: always() # always upload artifacts, even if tests fail
       id: get-pr-num
       run: |
         echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -58,6 +58,7 @@ jobs:
         path: target/pit-reports/* 
 
     - name: Get PR number
+      if: always() # always upload artifacts, even if tests fail
       id: get-pr-num
       run: |
         echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -156,7 +156,6 @@ public class RosterStudentsController extends ApiController {
             existingStudentObj.setLastName(student.getLastName());
             if (!existingStudentObj.getEmail().equals(convertedEmail)) {
                 existingStudentObj.setEmail(convertedEmail);
-                existingStudentObj.setUser(null);
             }
             existingStudentObj = rosterStudentRepository.save(existingStudentObj);
             updateUserService.attachUserToRosterStudent(existingStudentObj);

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -26,6 +26,7 @@ import edu.ucsb.cs156.frontiers.enums.RosterStatus;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.services.UpdateUserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -49,6 +50,9 @@ public class RosterStudentsController extends ApiController {
 
     @Autowired
     private CourseRepository courseRepository;
+
+    @Autowired
+    private UpdateUserService updateUserService;
 
     /**
      * This method creates a new RosterStudent.
@@ -144,20 +148,27 @@ public class RosterStudentsController extends ApiController {
     public InsertStatus upsertStudent(RosterStudent student, Course course) {
         Optional<RosterStudent> existingStudent = rosterStudentRepository.findByCourseIdAndStudentId(course.getId(),
                 student.getStudentId());
+        String convertedEmail = student.getEmail().replace("@umail.ucsb.edu","@ucsb.edu");
         if (existingStudent.isPresent()) {
             RosterStudent existingStudentObj = existingStudent.get();
+            existingStudentObj.setRosterStatus(RosterStatus.ROSTER);
             existingStudentObj.setFirstName(student.getFirstName());
             existingStudentObj.setLastName(student.getLastName());
-            existingStudentObj.setEmail(student.getEmail());
-            rosterStudentRepository.save(existingStudentObj);
+            if (!existingStudentObj.getEmail().equals(convertedEmail)) {
+                existingStudentObj.setEmail(convertedEmail);
+                existingStudentObj.setUser(null);
+            }
+            existingStudentObj = rosterStudentRepository.save(existingStudentObj);
+            updateUserService.attachUserToRosterStudent(existingStudentObj);
             return InsertStatus.UPDATED;
         } else {
             student.setCourse(course);
+            student.setEmail(convertedEmail);
             student.setRosterStatus(RosterStatus.ROSTER);
             student.setOrgStatus(OrgStatus.NONE);
-            rosterStudentRepository.save(student);
+            student = rosterStudentRepository.save(student);
+            updateUserService.attachUserToRosterStudent(student);
             return InsertStatus.INSERTED;
         }
-
     }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/UpdateUserService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/UpdateUserService.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.frontiers.services;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,19 @@ public class UpdateUserService {
         Iterable<User> allUsers = userRepository.findAll();
         for (User user : allUsers) {
             attachRosterStudents(user);
+        }
+    }
+
+    /**
+     * This method attaches a SingleRoster student to the User based on their email.
+     */
+    public void attachUserToRosterStudent(RosterStudent rosterStudent) {
+        String email = rosterStudent.getEmail();
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+        if (optionalUser.isPresent()) {
+            User matchedUser = optionalUser.get();
+            rosterStudent.setUser(matchedUser);
+            rosterStudentRepository.save(rosterStudent);
         }
     }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -215,7 +215,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         private final String sampleCSVContents = """
                         Enrl Cd,Perm #,Grade,Final Units,Student Last,Student First Middle,Quarter,Course ID,Section,Meeting Time(s) / Location(s),Email,ClassLevel,Major1,Major2,Date/Time,Pronoun
 
-                        08235,A123456,,4.0,GAUCHO,CHRIS FAKE,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,cgaucho@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,
+                        08235,A123456,,4.0,GAUCHO,CHRIS FAKE,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,cgaucho@ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,
                         08250,A987654,,4.0,DEL PLAYA,LAUREN,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,ldelplaya@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,She (She/Her/Hers)
                         08243,1234567,,4.0,TARDE,SABADO,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,sabadotarde@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,He (He/Him/His)
                         """;
@@ -231,7 +231,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                                 .firstName("Chris")
                                 .lastName("Gaucho")
                                 .studentId("A123456")
-                                .email("cgaucho@umail.ucsb.edu")
+                                .email("cgaucho@ucsb.edu")
                                 .course(course1)
                                 .rosterStatus(RosterStatus.MANUAL)
                                 .orgStatus(OrgStatus.NONE)

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -17,6 +17,7 @@ import edu.ucsb.cs156.frontiers.enums.RosterStatus;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import edu.ucsb.cs156.frontiers.services.CurrentUserService;
+import edu.ucsb.cs156.frontiers.services.UpdateUserService;
 import lombok.extern.slf4j.Slf4j;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -52,6 +53,9 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
 
         @Autowired
         private CurrentUserService currentUserService;
+
+        @MockitoBean
+        private UpdateUserService updateUserService;
 
         Course course1 = Course.builder()
                         .id(1L)
@@ -222,33 +226,66 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
 
                 // arrange
 
-                RosterStudent rs2After = RosterStudent.builder()
+                RosterStudent rs1BeforeWithId = RosterStudent.builder()
+                                .id(1L)
+                                .firstName("Chris")
+                                .lastName("Gaucho")
+                                .studentId("A123456")
+                                .email("cgaucho@umail.ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.MANUAL)
+                                .orgStatus(OrgStatus.NONE)
+                                .build();
+
+                RosterStudent rs1AfterWithId = RosterStudent.builder()
+                                .id(1L)
+                                .firstName("CHRIS FAKE")
+                                .lastName("GAUCHO")
+                                .studentId("A123456")
+                                .email("cgaucho@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.NONE)
+                                .build();
+
+                RosterStudent rs2BeforeWithId = RosterStudent.builder()
+                                .id(2L)
+                                .firstName("Lauren")
+                                .lastName("Del Playa")
+                                .studentId("A987654")
+                                .email("ldelplaya@umail.ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.NONE)
+                                .build();
+
+                RosterStudent rs2AfterWithId = RosterStudent.builder()
                                 .id(2L)
                                 .course(course1)
                                 .firstName("LAUREN")
                                 .lastName("DEL PLAYA")
-                                .email("ldelplaya@umail.ucsb.edu")
+                                .email("ldelplaya@ucsb.edu")
                                 .studentId("A987654")
                                 .rosterStatus(RosterStatus.ROSTER)
                                 .orgStatus(OrgStatus.NONE)
                                 .build();
 
-                RosterStudent rs3Before = RosterStudent.builder()
+                RosterStudent rs3NoId = RosterStudent.builder()
                                 .course(course1)
                                 .firstName("SABADO")
                                 .lastName("TARDE")
-                                .email("sabadotarde@umail.ucsb.edu")
+                                .email("sabadotarde@ucsb.edu")
                                 .studentId("1234567")
                                 .rosterStatus(RosterStatus.ROSTER)
                                 .orgStatus(OrgStatus.NONE)
                                 .build();
 
-                RosterStudent rs3After = RosterStudent.builder()
+                RosterStudent rs3WithId = RosterStudent.builder()
                                 .id(3L)
                                 .course(course1)
                                 .firstName("SABADO")
                                 .lastName("TARDE")
-                                .email("sabadotarde@umail.ucsb.edu")
+                                .email("sabadotarde@ucsb.edu")
                                 .studentId("1234567")
                                 .rosterStatus(RosterStatus.ROSTER)
                                 .orgStatus(OrgStatus.NONE)
@@ -262,15 +299,15 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
 
                 when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));
                 when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("A123456")))
-                                .thenReturn(Optional.of(rs1));
+                                .thenReturn(Optional.of(rs1BeforeWithId));
                 when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("A987654")))
-                                .thenReturn(Optional.of(rs2));
+                                .thenReturn(Optional.of(rs2BeforeWithId));
                 when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("1234567")))
                                 .thenReturn(Optional.empty());
 
-                when(rosterStudentRepository.save(eq(rs1))).thenReturn(rs1);
-                when(rosterStudentRepository.save(eq(rs2))).thenReturn(rs2After);
-                when(rosterStudentRepository.save(eq(rs3Before))).thenReturn(rs3After);
+                when(rosterStudentRepository.save(eq(rs1AfterWithId))).thenReturn(rs1AfterWithId);
+                when(rosterStudentRepository.save(eq(rs2AfterWithId))).thenReturn(rs2AfterWithId);
+                when(rosterStudentRepository.save(eq(rs3NoId))).thenReturn(rs3WithId);
 
                 // act
 
@@ -287,9 +324,9 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 verify(rosterStudentRepository, atLeastOnce()).findByCourseIdAndStudentId(eq(1L), eq("A123456"));
                 verify(rosterStudentRepository, atLeastOnce()).findByCourseIdAndStudentId(eq(1L), eq("A987654"));
                 verify(rosterStudentRepository, atLeastOnce()).findByCourseIdAndStudentId(eq(1L), eq("1234567"));
-                verify(rosterStudentRepository, atLeastOnce()).save(eq(rs1));
-                verify(rosterStudentRepository, atLeastOnce()).save(eq(rs2After));
-                verify(rosterStudentRepository, atLeastOnce()).save(eq(rs3Before));
+                verify(rosterStudentRepository, atLeastOnce()).save(eq(rs1AfterWithId));
+                verify(rosterStudentRepository, atLeastOnce()).save(eq(rs2AfterWithId));
+                verify(rosterStudentRepository, atLeastOnce()).save(eq(rs3NoId));
 
                 String responseString = response.getResponse().getContentAsString();
                 Map<String, String> expectedMap = Map.of(

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -309,6 +310,10 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 when(rosterStudentRepository.save(eq(rs2AfterWithId))).thenReturn(rs2AfterWithId);
                 when(rosterStudentRepository.save(eq(rs3NoId))).thenReturn(rs3WithId);
 
+                doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs1AfterWithId));               
+                doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs2AfterWithId));
+                doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs3WithId));
+
                 // act
 
                 MvcResult response = mockMvc
@@ -327,6 +332,10 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 verify(rosterStudentRepository, atLeastOnce()).save(eq(rs1AfterWithId));
                 verify(rosterStudentRepository, atLeastOnce()).save(eq(rs2AfterWithId));
                 verify(rosterStudentRepository, atLeastOnce()).save(eq(rs3NoId));
+
+                verify(updateUserService, times(1)).attachUserToRosterStudent(eq(rs1AfterWithId));
+                verify(updateUserService, times(1)).attachUserToRosterStudent(eq(rs2AfterWithId));
+                verify(updateUserService, times(1)).attachUserToRosterStudent(eq(rs3WithId));
 
                 String responseString = response.getResponse().getContentAsString();
                 Map<String, String> expectedMap = Map.of(

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/UpdateUserServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/UpdateUserServiceTests.java
@@ -13,7 +13,12 @@ import org.mockito.MockitoAnnotations;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
 
 public class UpdateUserServiceTests {
@@ -85,4 +90,42 @@ public class UpdateUserServiceTests {
         assertEquals(user1, student1.getUser());
         assertEquals(user2, student2.getUser());
     }
+
+    @Test
+    public void testAttachUserToRosterStudent_userExists() {
+        // Arrange
+        String email = "test@example.com";
+        User user = User.builder().email(email).build();
+
+        RosterStudent rosterStudent = new RosterStudent();
+        rosterStudent.setEmail(email);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        // Act
+        updateUserService.attachUserToRosterStudent(rosterStudent);
+
+        // Assert
+        verify(userRepository, times(1)).findByEmail(email);
+        verify(rosterStudentRepository, times(1)).save(rosterStudent);
+        assertEquals(rosterStudent.getUser(), user);
+    }
+
+    @Test
+    public void testAttachUserToRosterStudent_userDoesNotExist() {
+        // Arrange
+        String email = "test@example.com";
+        RosterStudent rosterStudent = new RosterStudent();
+        rosterStudent.setEmail(email);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        // Act
+        updateUserService.attachUserToRosterStudent(rosterStudent);
+
+        // Assert
+        verify(userRepository, times(1)).findByEmail(email);
+        verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
+        assertNull(rosterStudent.getUser());
+    }        
 }


### PR DESCRIPTION
This PR addresses two issues:

* when an egrades file contains an `@umail.ucsb.edu` address, it needs to be converted into a `@ucsb.edu` address.
* RosterStudents and Users should be linked when a new User is created and when a RosterStudent is created or updated.

Deployed at: https://frontiers-qa.dokku-00.cs.ucsb.edu
