### PR TITLE
pc - hotfix to repair infinite loop in json serialization

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/Course.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/Course.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.List;
 
 @Data
@@ -26,6 +28,7 @@ public class Course {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
+    @JsonIgnore
     private User creator;
 
     private String courseName;

--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/User.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.List;
 
 /**
@@ -35,6 +37,7 @@ public class User {
   private String githubLogin;
   private String studentId;
 
+  @JsonIgnore
   @OneToMany(mappedBy = "user")
   @Fetch(FetchMode.JOIN)
   private List<RosterStudent> linkedStudents;


### PR DESCRIPTION
In this PR, we put `@JsonIgnore` on two fields to repair an emergency infinite loop in the json serialization.