### PR TITLE
pc - CSV Download of Roster Students by course

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CSVDownloadsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CSVDownloadsController.java
@@ -1,0 +1,86 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import com.opencsv.bean.StatefulBeanToCsvBuilder;
+import com.opencsv.exceptions.CsvDataTypeMismatchException;
+import com.opencsv.exceptions.CsvRequiredFieldEmptyException;
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.models.RosterStudentDTO;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.services.RosterStudentDTOService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+@Tag(name = "CSV Downloads")
+@RequestMapping("/api/csv")
+@RestController
+@Slf4j
+public class CSVDownloadsController extends ApiController {
+
+  @Autowired
+  private CourseRepository courseRepository;
+
+  @Autowired
+  private RosterStudentDTOService rosterStudentDTOService;
+
+  @Operation(summary = "Download CSV File of Roster Students", description = "Returns a CSV file as a response", responses = {
+      @ApiResponse(responseCode = "200", description = "CSV file", content = @Content(mediaType = "text/csv", schema = @Schema(type = "string", format = "binary"))),
+      @ApiResponse(responseCode = "500", description = "Internal Server Error")
+  })
+  @GetMapping(value = "/rosterstudents", produces = "text/csv")
+  public ResponseEntity<StreamingResponseBody> csvForQuarter(
+      @Parameter(name = "courseId", description = "course id", example = "1") @RequestParam Long courseId,
+      @Parameter(name = "testException", description = "test exception", example = "CsvDataTypeMismatchException") @RequestParam(required = false, defaultValue = "") String testException)
+      throws Exception, IOException {
+    Course course = courseRepository.findById(courseId)
+        .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
+    StreamingResponseBody stream = (outputStream) -> {
+
+      List<RosterStudentDTO> list = rosterStudentDTOService.getRosterStudentDTOs(courseId);
+
+      try (Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+        try {
+          if (testException.equals("CsvDataTypeMismatchException")) {
+            throw new CsvDataTypeMismatchException("test exception");
+          }
+          new StatefulBeanToCsvBuilder<RosterStudentDTO>(writer).build().write(list);
+        } catch (CsvDataTypeMismatchException | CsvRequiredFieldEmptyException e) {
+          log.error("Error writing CSV file", e);
+          throw new IOException("Error writing CSV file: " + e.getMessage());
+        }
+      }
+    };
+
+    return ResponseEntity.ok()
+        .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
+        .header(
+            HttpHeaders.CONTENT_DISPOSITION,
+            String.format("attachment;filename=%s_roster.csv", course.getCourseName()))
+        .header(HttpHeaders.CONTENT_TYPE, "text/csv; charset=UTF-8")
+        .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.CONTENT_DISPOSITION)
+        .body(stream);
+  }
+
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTO.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTO.java
@@ -1,0 +1,60 @@
+package edu.ucsb.cs156.frontiers.models;
+
+
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.enums.RosterStatus;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+/**
+ * This is a DTO class that represents a student in the roster.
+ * It is used to transfer data between the server and the client.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RosterStudentDTO {
+ 
+    private Long id;
+
+    private Long courseId;
+    
+    private String studentId;
+    private String firstName;
+    private String lastName;
+    private String email;
+
+    private long userId;
+    private int userGithubId;
+    private String userGithubLogin;
+
+    @Enumerated(EnumType.STRING)
+    private RosterStatus rosterStatus;
+
+    @Enumerated(EnumType.STRING)
+    private OrgStatus orgStatus;
+
+
+    public static RosterStudentDTO from(RosterStudent student) {
+        return RosterStudentDTO.builder()
+                .id(student.getId())
+                .courseId(student.getCourse().getId())
+                .studentId(student.getStudentId())
+                .firstName(student.getFirstName())
+                .lastName(student.getLastName())
+                .email(student.getEmail())
+                .userId(student.getUser().getId())
+                .userGithubId(student.getUser().getGithubId())
+                .userGithubLogin(student.getUser().getGithubLogin())
+                .rosterStatus(student.getRosterStatus())
+                .orgStatus(student.getOrgStatus())
+                .build();
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOService.java
@@ -1,0 +1,37 @@
+package edu.ucsb.cs156.frontiers.services;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.models.RosterStudentDTO;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+
+@Service
+public class RosterStudentDTOService {
+
+
+    @Autowired
+    private RosterStudentRepository rosterStudentRepository;
+
+    /**
+     * This method gets a list of RosterStudentDTOs based on the courseId
+     * 
+     * @param courseId if of the course
+     * @return a list of RosterStudentDTOs
+     */
+    public List<RosterStudentDTO> getRosterStudentDTOs(Long courseId) {
+        Iterable<RosterStudent> matchedStudents = rosterStudentRepository.findByCourseId(courseId);
+        
+        return StreamSupport.stream(matchedStudents.spliterator(), false)
+            .map(RosterStudentDTO::from)
+            .collect(Collectors.toList());
+
+    }
+
+   
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CSVDownloadsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CSVDownloadsControllerTests.java
@@ -1,0 +1,106 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.enums.RosterStatus;
+import edu.ucsb.cs156.frontiers.models.RosterStudentDTO;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.services.RosterStudentDTOService;
+
+public class CSVDownloadsControllerTests {
+
+    @Mock
+    private RosterStudentDTOService rosterStudentDTOService = mock(RosterStudentDTOService.class);
+
+    @Mock
+    private CourseRepository courseRepository = mock(CourseRepository.class);
+
+    @InjectMocks
+    private CSVDownloadsController csvDownloadsController;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testRosterStudentsCSV_failure() throws Exception {
+        when(courseRepository.findById(1L)).thenReturn(java.util.Optional.empty());
+
+        ResponseEntity<StreamingResponseBody> response = csvDownloadsController.csvForQuarter(1L, "");
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    public void testRosterStudentsCSV_success() throws Exception {
+
+        // Arrange
+        Course course = Course.builder()
+                .id(1L)
+                .courseName("ucsb-cs156-s25")
+                .term("S25")
+                .school("UCSB")
+                .build();
+
+        RosterStudentDTO rosterStudentDTO = RosterStudentDTO.builder()
+                .id(42L)
+                .courseId(course.getId())
+                .studentId("12345")
+                .firstName("Chris")
+                .lastName("Gaucho")
+                .email("cgaucho@ucsb.edu")
+                .userId(102L)
+                .userGithubId(12345)
+                .userGithubLogin("cgaucho")
+                .rosterStatus(RosterStatus.ROSTER)
+                .orgStatus(OrgStatus.NONE)
+                .build();
+
+        when(courseRepository.findById(1L)).thenReturn(java.util.Optional.of(course));
+        when(rosterStudentDTOService.getRosterStudentDTOs(eq(1L))).thenReturn(List.of(rosterStudentDTO));
+
+        ResponseEntity<StreamingResponseBody> response = csvDownloadsController.csvForQuarter(1L, "");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("text/csv;charset=UTF-8", response.getHeaders().getContentType().toString());
+        String expectedFilename = "ucsb-cs156-s25_roster.csv";
+        String expectedContentDisposition = "attachment;filename=" + expectedFilename;
+        String actualContentDisposition = response.getHeaders().get(HttpHeaders.CONTENT_DISPOSITION).get(0);
+        assertEquals(expectedContentDisposition, actualContentDisposition);
+
+        StreamingResponseBody body = response.getBody();
+        assertNotNull(body);
+
+        OutputStream outputStream = new ByteArrayOutputStream();
+        body.writeTo(outputStream);
+        String csvOutput = outputStream.toString();
+
+        String expectedCSVOutput = """
+                "COURSEID","EMAIL","FIRSTNAME","ID","LASTNAME","ORGSTATUS","ROSTERSTATUS","STUDENTID","USERGITHUBID","USERGITHUBLOGIN","USERID"
+                "1","cgaucho@ucsb.edu","Chris","42","Gaucho","NONE","ROSTER","12345","12345","cgaucho","102"
+                """;
+
+        assertEquals(expectedCSVOutput, csvOutput);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTOTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTOTests.java
@@ -1,0 +1,55 @@
+package edu.ucsb.cs156.frontiers.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.enums.RosterStatus;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test class for the RosterStudentDTO class.
+ */
+
+public class RosterStudentDTOTests {
+
+    @Test
+    public void test_from() {
+        // Arrange
+        Course course = new Course();
+        course.setId(1L);
+
+        User user = User.builder().build();
+        user.setId(2L);
+        user.setGithubId(12345);
+        user.setGithubLogin("testuser");
+
+        RosterStudent rosterStudent = new RosterStudent();
+        rosterStudent.setId(3L);
+        rosterStudent.setCourse(course);
+        rosterStudent.setStudentId("U123456");
+        rosterStudent.setFirstName("John");
+        rosterStudent.setLastName("Doe");
+        rosterStudent.setEmail("johndoe@example.com");
+        rosterStudent.setUser(user);
+        rosterStudent.setRosterStatus(RosterStatus.ROSTER);
+        rosterStudent.setOrgStatus(OrgStatus.NONE);
+
+        // Act
+        RosterStudentDTO dto = RosterStudentDTO.from(rosterStudent);
+
+        // Assert
+        assertEquals(3L, dto.getId());
+        assertEquals(1L, dto.getCourseId());
+        assertEquals("U123456", dto.getStudentId());
+        assertEquals("John", dto.getFirstName());
+        assertEquals("Doe", dto.getLastName());
+        assertEquals("johndoe@example.com", dto.getEmail());
+        assertEquals(2L, dto.getUserId());
+        assertEquals(12345, dto.getUserGithubId());
+        assertEquals("testuser", dto.getUserGithubLogin());
+        assertEquals(RosterStatus.ROSTER, dto.getRosterStatus());
+        assertEquals(OrgStatus.NONE, dto.getOrgStatus());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOServiceTests.java
@@ -1,0 +1,81 @@
+package edu.ucsb.cs156.frontiers.services;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.enums.RosterStatus;
+import edu.ucsb.cs156.frontiers.models.RosterStudentDTO;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+/**
+ * This class contains unit tests for the RosterStudentDTOService class.
+ */
+
+public class RosterStudentDTOServiceTests {
+
+    @Mock
+    private RosterStudentRepository rosterStudentRepository;
+
+    @InjectMocks
+    private RosterStudentDTOService rosterStudentDTOService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void test_getRosterStudentDTOById_success() {
+        // Arrange
+        Course course = new Course();
+        course.setId(1L);
+
+        User user = User.builder().build();
+        user.setId(2L);
+        user.setGithubId(12345);
+        user.setGithubLogin("testuser");
+
+        RosterStudent rosterStudent = new RosterStudent();
+        rosterStudent.setId(3L);
+        rosterStudent.setCourse(course);
+        rosterStudent.setStudentId("U123456");
+        rosterStudent.setFirstName("John");
+        rosterStudent.setLastName("Doe");
+        rosterStudent.setEmail("johndoe@example.com");
+        rosterStudent.setUser(user);
+        rosterStudent.setRosterStatus(RosterStatus.ROSTER);
+        rosterStudent.setOrgStatus(OrgStatus.NONE);
+
+        when(rosterStudentRepository.findByCourseId(1L)).thenReturn(List.of(rosterStudent));
+
+        // Act
+        List<RosterStudentDTO> dtos = rosterStudentDTOService.getRosterStudentDTOs(1L);
+        // Assert
+        assertEquals(1, dtos.size());
+        RosterStudentDTO dto = dtos.get(0);
+        assertEquals(3L, dto.getId());
+        assertEquals(1L, dto.getCourseId());
+        assertEquals("U123456", dto.getStudentId());
+        assertEquals("John", dto.getFirstName());
+        assertEquals("Doe", dto.getLastName());
+        assertEquals("johndoe@example.com", dto.getEmail());
+        assertEquals(2L, dto.getUserId());
+        assertEquals(12345, dto.getUserGithubId());
+        assertEquals("testuser", dto.getUserGithubLogin());
+        assertEquals(RosterStatus.ROSTER, dto.getRosterStatus());
+        assertEquals(OrgStatus.NONE, dto.getOrgStatus());
+    }
+
+  
+}


### PR DESCRIPTION
In this PR, we add a controller endpoint that allows a CSV Download of the roster students for a given course.