### PR TITLE
Fixing a Flaky Job Test

### DIFF
--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/JobsControllerDetailedTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/JobsControllerDetailedTests.java
@@ -357,16 +357,7 @@ public class JobsControllerDetailedTests extends ControllerTestCase {
         .log("Processing...\n")
         .build();
 
-    Job jobCompleted = Job.builder()
-        .id(0L)
-        .createdBy(user)
-        .createdAt(null)
-        .updatedAt(null)
-        .status("complete")
-        .log("Processing...Done\n")
-        .build();
-
-    when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobRunning).thenReturn(jobCompleted);
+    when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobRunning);
 
     doNothing().when(updateUserService).attachRosterStudentsAllUsers();
 


### PR DESCRIPTION
In this PR, I remove the "completed" return of the updateAllRosters test. This is because it creates a race condition -- since the test completes almost instantly, it occasionally returns completed rather than running, failing the test. As a result, I remove the "completed" save return, ensuring that it returns "running." The job actually running and completing is verified in a different file.