### PR TITLE
Adding the Ability to Accept Webhooks

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/config/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
                     userInfo.oidcUserService(googleSignInService).userService(githubSignInService)))
         .csrf(csrf -> csrf
             .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-            .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
+            .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()).ignoringRequestMatchers("/api/webhooks/github"))
         .addFilterAfter(new CsrfCookieFilter(), BasicAuthenticationFilter.class)
         .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
         .logout(logout -> logout.logoutRequestMatcher(new AntPathRequestMatcher("/logout")).logoutSuccessUrl("/"));

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
@@ -1,0 +1,32 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/webhooks")
+public class WebhookController {
+
+    private ObjectMapper mapper;
+
+    public WebhookController(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @PostMapping("/github")
+    public ResponseEntity<String> createGitHubWebhook(@RequestBody String body) throws JsonProcessingException {
+        System.out.println(body);
+        JsonNode jsonBody = mapper.readTree(body);
+        if(jsonBody.get("action").toString().equals("member_added")){
+            String githubLogin = jsonBody.get("membership").get("user").get("login").toString();
+        }
+        return  ResponseEntity.ok().body("success");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
@@ -13,17 +13,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/webhooks")
 public class WebhookController {
-
-    private ObjectMapper mapper;
-
-    public WebhookController(ObjectMapper mapper) {
-        this.mapper = mapper;
-    }
+    
 
     @PostMapping("/github")
-    public ResponseEntity<String> createGitHubWebhook(@RequestBody String body) throws JsonProcessingException {
-        System.out.println(body);
-        JsonNode jsonBody = mapper.readTree(body);
+    public ResponseEntity<String> createGitHubWebhook(@RequestBody JsonNode jsonBody) throws JsonProcessingException {
         if(jsonBody.get("action").toString().equals("member_added")){
             String githubLogin = jsonBody.get("membership").get("user").get("login").toString();
         }

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
@@ -39,8 +39,8 @@ public class WebhookController {
 
         if(jsonBody.has("action")){
             if(jsonBody.get("action").asText().equals("member_added")){
-                String githubLogin = jsonBody.get("membership").get("user").get("login").toString();
-                String installationId = jsonBody.get("installation").get("id").toString();
+                String githubLogin = jsonBody.get("membership").get("user").get("login").asText();
+                String installationId = jsonBody.get("installation").get("id").asText();
                 Optional<Course> course = courseRepository.findByInstallationId(installationId);
                 Optional<User> user = userRepository.findByGithubLogin(githubLogin);
                 if(course.isPresent() && user.isPresent()){

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
@@ -3,7 +3,6 @@ package edu.ucsb.cs156.frontiers.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.entities.User;
@@ -11,6 +10,7 @@ import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Optional;
 
+@Tag(name = "Webhooks Controller")
 @RestController
 @RequestMapping("/api/webhooks")
 public class WebhookController {

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
@@ -41,7 +41,7 @@ public class WebhookController {
             if(jsonBody.get("action").asText().equals("member_added")){
                 String githubLogin = jsonBody.get("membership").get("user").get("login").toString();
                 String installationId = jsonBody.get("installation").get("id").toString();
-                Optional<Course> course = courseRepository.findCourseByInstallationId(installationId);
+                Optional<Course> course = courseRepository.findByInstallationId(installationId);
                 Optional<User> user = userRepository.findByGithubLogin(githubLogin);
                 if(course.isPresent() && user.isPresent()){
                     Optional<RosterStudent> student = rosterStudentRepository.findByCourseAndUser(course.get(), user.get());

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
@@ -4,21 +4,55 @@ package edu.ucsb.cs156.frontiers.controllers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Optional;
+
 @RestController
 @RequestMapping("/api/webhooks")
 public class WebhookController {
-    
+
+
+    private final CourseRepository courseRepository;
+    private final UserRepository userRepository;
+    private final RosterStudentRepository rosterStudentRepository;
+
+    public WebhookController(CourseRepository courseRepository, UserRepository userRepository, RosterStudentRepository rosterStudentRepository) {
+        this.courseRepository = courseRepository;
+        this.userRepository = userRepository;
+        this.rosterStudentRepository = rosterStudentRepository;
+    }
 
     @PostMapping("/github")
     public ResponseEntity<String> createGitHubWebhook(@RequestBody JsonNode jsonBody) throws JsonProcessingException {
-        if(jsonBody.get("action").toString().equals("member_added")){
-            String githubLogin = jsonBody.get("membership").get("user").get("login").toString();
+
+        if(jsonBody.has("action")){
+            if(jsonBody.get("action").asText().equals("member_added")){
+                String githubLogin = jsonBody.get("membership").get("user").get("login").toString();
+                String installationId = jsonBody.get("installation").get("id").toString();
+                Optional<Course> course = courseRepository.findCourseByInstallationId(installationId);
+                Optional<User> user = userRepository.findByGithubLogin(githubLogin);
+                if(course.isPresent() && user.isPresent()){
+                    Optional<RosterStudent> student = rosterStudentRepository.findByCourseAndUser(course.get(), user.get());
+                    if(student.isPresent()){
+                        RosterStudent updatedStudent = student.get();
+                        updatedStudent.setOrgStatus(OrgStatus.MEMBER);
+                        rosterStudentRepository.save(updatedStudent);
+                        return ResponseEntity.ok(updatedStudent.toString());
+                    }
+                }
+            }
         }
         return  ResponseEntity.ok().body("success");
     }

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/CourseRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/CourseRepository.java
@@ -4,7 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import edu.ucsb.cs156.frontiers.entities.Course;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface CourseRepository extends JpaRepository<Course,Long>
 {
-    
+
+    Optional<Course> findCourseByInstallationId(String installationId);
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/CourseRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/CourseRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface CourseRepository extends JpaRepository<Course,Long>
 {
 
-    Optional<Course> findCourseByInstallationId(String installationId);
+    Optional<Course> findByInstallationId(String installationId);
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/RosterStudentRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/RosterStudentRepository.java
@@ -2,6 +2,8 @@ package edu.ucsb.cs156.frontiers.repositories;
 
 import java.util.Optional;
 
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
@@ -13,4 +15,6 @@ public interface RosterStudentRepository extends JpaRepository<RosterStudent, Lo
     List<RosterStudent> findAllByEmail(String email);
     public Iterable<RosterStudent> findByCourseId(Long courseId);
     public Optional<RosterStudent> findByCourseIdAndStudentId(Long courseId, String studentId);
+
+    Optional<RosterStudent> findByCourseAndUser(Course course, User user);
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/UserRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/UserRepository.java
@@ -20,4 +20,6 @@ public interface UserRepository extends CrudRepository<User, Long> {
   Optional<User> findByEmail(String email);
 
   Optional<User> findByGoogleSub(String googleSub);
+
+  Optional<User> findByGithubLogin(String githubLogin);
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/WebhookControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/WebhookControllerTests.java
@@ -1,0 +1,236 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = WebhookController.class)
+public class WebhookControllerTests extends ControllerTestCase {
+    @MockitoBean
+    UserRepository userRepository;
+
+    @MockitoBean
+    RosterStudentRepository rosterStudentRepository;
+
+    @MockitoBean
+    CourseRepository  courseRepository;
+
+    @Test
+    public void successfulWebhook() throws Exception {
+        User user = User.builder().githubLogin("testLogin").build();
+        Course course = Course.builder().installationId("1234").build();
+        RosterStudent student = RosterStudent.builder().user(user).course(course).build();
+        RosterStudent updated = RosterStudent.builder().user(user).course(course).orgStatus(OrgStatus.MEMBER).build();
+
+        doReturn(Optional.of(user)).when(userRepository).findByGithubLogin(contains("testLogin"));
+        doReturn(Optional.of(course)).when(courseRepository).findByInstallationId(contains("1234"));
+        doReturn(Optional.of(student)).when(rosterStudentRepository).findByCourseAndUser(eq(course), eq(user));
+        doReturn(updated).when(rosterStudentRepository).save(eq(updated));
+
+        String sendBody = """
+                {
+                "action" : "member_added",
+                "membership": {
+                    "user": {
+                        "login": "testLogin"
+                    }
+                },
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                .content(sendBody)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(userRepository, times(1)).findByGithubLogin(contains("testLogin"));
+        verify(rosterStudentRepository, times(1)).findByCourseAndUser(eq(course), eq(user));
+        verify(courseRepository, times(1)).findByInstallationId(contains("1234"));
+        verify(rosterStudentRepository, times(1)).save(eq(updated));
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals(updated.toString(), actualBody);
+    }
+
+    @Test
+    public void noStudent() throws Exception {
+        User user = User.builder().githubLogin("testLogin").build();
+        Course course = Course.builder().installationId("1234").build();
+
+        doReturn(Optional.of(user)).when(userRepository).findByGithubLogin(contains("testLogin"));
+        doReturn(Optional.of(course)).when(courseRepository).findByInstallationId(contains("1234"));
+        doReturn(Optional.empty()).when(rosterStudentRepository).findByCourseAndUser(eq(course), eq(user));
+
+        String sendBody = """
+                {
+                "action" : "member_added",
+                "membership": {
+                    "user": {
+                        "login": "testLogin"
+                    }
+                },
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(userRepository, times(1)).findByGithubLogin(contains("testLogin"));
+        verify(rosterStudentRepository, times(1)).findByCourseAndUser(eq(course), eq(user));
+        verify(courseRepository, times(1)).findByInstallationId(contains("1234"));
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void noUser() throws Exception {
+        Course course = Course.builder().installationId("1234").build();
+
+        doReturn(Optional.empty()).when(userRepository).findByGithubLogin(contains("testLogin"));
+        doReturn(Optional.of(course)).when(courseRepository).findByInstallationId(contains("1234"));
+
+        String sendBody = """
+                {
+                "action" : "member_added",
+                "membership": {
+                    "user": {
+                        "login": "testLogin"
+                    }
+                },
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(userRepository, times(1)).findByGithubLogin(contains("testLogin"));
+        verify(rosterStudentRepository, times(0)).findByCourseAndUser(any(), any());
+        verify(courseRepository, times(1)).findByInstallationId(contains("1234"));
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void noCourse() throws Exception {
+        User user = User.builder().githubLogin("testLogin").build();
+
+        doReturn(Optional.of(user)).when(userRepository).findByGithubLogin(contains("testLogin"));
+        doReturn(Optional.empty()).when(courseRepository).findByInstallationId(contains("1234"));
+
+        String sendBody = """
+                {
+                "action" : "member_added",
+                "membership": {
+                    "user": {
+                        "login": "testLogin"
+                    }
+                },
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(userRepository, times(1)).findByGithubLogin(contains("testLogin"));
+        verify(rosterStudentRepository, times(0)).findByCourseAndUser(any(), any());
+        verify(courseRepository, times(1)).findByInstallationId(contains("1234"));
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void action_wrong() throws Exception {
+        String sendBody = """
+                {
+                "action" : "member_invited",
+                "membership": {
+                    "user": {
+                        "login": "testLogin"
+                    }
+                },
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(userRepository, times(0)).findByGithubLogin(contains("testLogin"));
+        verify(rosterStudentRepository, times(0)).findByCourseAndUser(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(contains("1234"));
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void no_action() throws Exception {
+        String sendBody = """
+                {
+                "membership": {
+                    "user": {
+                        "login": "testLogin"
+                    }
+                },
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(userRepository, times(0)).findByGithubLogin(contains("testLogin"));
+        verify(rosterStudentRepository, times(0)).findByCourseAndUser(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(contains("1234"));
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+}


### PR DESCRIPTION
In this PR, I add the ability for the application to accept webhooks from GitHub.

In this case, it is used for detecting accepted membership invites.

In order to allow the request to be successful, I disable CSRF-protection on the endpoint to prevent GitHub from being marked unauthorized.

The webhook URL is /api/webhooks/github.

Has full test and mutation coverage. Merge after #21 

Deployed to https://proj-frontiers-division7.dokku-00.cs.ucsb.edu/