### PR TITLE
Creating Simple Student Repos

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
+import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import lombok.extern.slf4j.Slf4j;
@@ -50,6 +51,20 @@ public abstract class ApiController {
     return Map.of(
       "type", e.getClass().getSimpleName(),
       "message", e.getMessage()
+    );
+  }
+
+  /**
+   * This method handles the NoLinkedOrganizationException.
+   * @param e the exception
+   * @return a map with the type and message of the exception
+   */
+  @ExceptionHandler({ NoLinkedOrganizationException.class })
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public Object handleNoLinkedOrgException(Throwable e) {
+    return Map.of(
+            "type", e.getClass().getSimpleName(),
+            "message", e.getMessage()
     );
   }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RepositoryController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RepositoryController.java
@@ -9,6 +9,7 @@ import edu.ucsb.cs156.frontiers.jobs.CreateStudentRepositoriesJob;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.services.RepositoryService;
 import edu.ucsb.cs156.frontiers.services.jobs.JobService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -17,7 +18,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Optional;
 
+
+@Tag(name = "Repository Controller")
 @RestController
 @RequestMapping("/api/repos")
 public class RepositoryController extends ApiController {
@@ -33,7 +37,7 @@ public class RepositoryController extends ApiController {
 
     @PostMapping("/createRepos")
     @PreAuthorize("hasRole('ROLE_PROFESSOR')")
-    public Job createRepos(@RequestParam Long courseId, @RequestParam String repoPrefix) {
+    public Job createRepos(@RequestParam Long courseId, @RequestParam String repoPrefix, @RequestParam Optional<Boolean> isPrivate) {
         Course course = courseRepository.findById(courseId).orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
         if (getCurrentUser().getUser().getId() == course.getCreator().getId()) {
             if (course.getOrgName() == null || course.getInstallationId() == null) {
@@ -41,6 +45,7 @@ public class RepositoryController extends ApiController {
             } else {
                 CreateStudentRepositoriesJob job = CreateStudentRepositoriesJob.builder()
                         .repositoryPrefix(repoPrefix)
+                        .isPrivate(isPrivate.orElse(false))
                         .repositoryService(repositoryService)
                         .course(course)
                         .build();

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RepositoryController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RepositoryController.java
@@ -1,0 +1,53 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.Job;
+import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
+import edu.ucsb.cs156.frontiers.jobs.CreateStudentRepositoriesJob;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.services.RepositoryService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/repos")
+public class RepositoryController extends ApiController {
+
+    @Autowired
+    RepositoryService repositoryService;
+
+    @Autowired
+    JobService jobService;
+
+    @Autowired
+    CourseRepository courseRepository;
+
+    @PostMapping("/createRepos")
+    @PreAuthorize("hasRole('ROLE_PROFESSOR')")
+    public Job createRepos(@RequestParam Long courseId, @RequestParam String repoPrefix) {
+        Course course = courseRepository.findById(courseId).orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
+        if (getCurrentUser().getUser().getId() == course.getCreator().getId()) {
+            if (course.getOrgName() == null || course.getInstallationId() == null) {
+                throw new NoLinkedOrganizationException(course.getCourseName());
+            } else {
+                CreateStudentRepositoriesJob job = CreateStudentRepositoriesJob.builder()
+                        .repositoryPrefix(repoPrefix)
+                        .repositoryService(repositoryService)
+                        .course(course)
+                        .build();
+                return jobService.runAsJob(job);
+            }
+        } else {
+            throw new AccessDeniedException("You do not have permission to create student repositories on this course");
+        }
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/errors/NoLinkedOrganizationException.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/errors/NoLinkedOrganizationException.java
@@ -1,0 +1,7 @@
+package edu.ucsb.cs156.frontiers.errors;
+
+public class NoLinkedOrganizationException extends RuntimeException{
+    public NoLinkedOrganizationException (String courseName){
+        super("No linked GitHub Organization to " + courseName + ". Please link a GitHub Organization first.");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentRepositoriesJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentRepositoriesJob.java
@@ -1,0 +1,27 @@
+package edu.ucsb.cs156.frontiers.jobs;
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.services.RepositoryService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobContext;
+import edu.ucsb.cs156.frontiers.services.jobs.JobContextConsumer;
+import lombok.Builder;
+
+@Builder
+public class CreateStudentRepositoriesJob implements JobContextConsumer {
+    Course course;
+    RepositoryService repositoryService;
+    String repositoryPrefix;
+
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+        ctx.log("Processing...");
+        for(RosterStudent student : course.getRosterStudents()){
+            if(student.getUser() != null && student.getUser().getGithubLogin() != null && student.getOrgStatus() == OrgStatus.MEMBER){
+                repositoryService.createStudentRepository(course.getInstallationId(), course.getOrgName(), student, repositoryPrefix);
+            }
+        }
+        ctx.log("Done");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentRepositoriesJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentRepositoriesJob.java
@@ -13,13 +13,14 @@ public class CreateStudentRepositoriesJob implements JobContextConsumer {
     Course course;
     RepositoryService repositoryService;
     String repositoryPrefix;
+    Boolean isPrivate;
 
     @Override
     public void accept(JobContext ctx) throws Exception {
         ctx.log("Processing...");
         for(RosterStudent student : course.getRosterStudents()){
             if(student.getUser() != null && student.getUser().getGithubLogin() != null && student.getOrgStatus() == OrgStatus.MEMBER){
-                repositoryService.createStudentRepository(course.getInstallationId(), course.getOrgName(), student, repositoryPrefix);
+                repositoryService.createStudentRepository(course.getInstallationId(), course.getOrgName(), student, repositoryPrefix, isPrivate);
             }
         }
         ctx.log("Done");

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/RepositoryService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/RepositoryService.java
@@ -1,0 +1,69 @@
+package edu.ucsb.cs156.frontiers.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class RepositoryService {
+    private final JwtService  jwtService;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper mapper;
+
+    public RepositoryService(JwtService jwtService, RestTemplateBuilder restTemplateBuilder, ObjectMapper mapper) {
+        this.jwtService = jwtService;
+        this.restTemplate = restTemplateBuilder.build();
+        this.mapper = mapper;
+    }
+
+    public void createStudentRepository(String installationId, String orgName, RosterStudent student, String repoPrefix) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+        String newRepoName = repoPrefix+"-"+student.getUser().getGithubLogin();
+        String token = jwtService.getInstallationToken(installationId);
+        String existenceEndpoint = "https://api.github.com/repos/"+orgName+"/"+newRepoName;
+        String createEndpoint = "https://api.github.com/orgs/"+orgName+"/repos";
+        String provisionEndpoint = "https://api.github.com/"+orgName+"/"+newRepoName+"/collaborators/"+student.getUser().getGithubLogin();
+
+        HttpHeaders existenceHeaders = new HttpHeaders();
+        existenceHeaders.add("Authorization", "Bearer " + token);
+        existenceHeaders.add("Accept", "application/vnd.github+json");
+        existenceHeaders.add("X-GitHub-Api-Version", "2022-11-28");
+
+        HttpEntity<String> existenceEntity = new HttpEntity<>(existenceHeaders);
+
+        try {
+            restTemplate.exchange(existenceEndpoint, HttpMethod.GET, existenceEntity, String.class);
+        } catch(HttpClientErrorException e){
+            if(e.getStatusCode().equals(HttpStatus.NOT_FOUND)){
+                HttpHeaders createHeaders = new HttpHeaders();
+                createHeaders.add("Authorization", "Bearer " + token);
+                createHeaders.add("Accept", "application/vnd.github+json");
+                createHeaders.add("X-GitHub-Api-Version", "2022-11-28");
+
+                Map<String, Object> body  = new HashMap<>();
+                body.put("name", newRepoName);
+                String bodyAsJson =  mapper.writeValueAsString(body);
+
+                HttpEntity<String> createEntity = new HttpEntity<>(bodyAsJson, createHeaders);
+
+                restTemplate.exchange(createEndpoint, HttpMethod.POST, createEntity, String.class);
+                Map<String, Object> provisionBody  = new HashMap<>();
+                provisionBody.put("permission", "admin");
+                String provisionAsJson =  mapper.writeValueAsString(provisionBody);
+
+                HttpEntity<String> provisionEntity = new HttpEntity<>(provisionAsJson, createHeaders);
+                restTemplate.exchange(provisionEndpoint, HttpMethod.PUT, provisionEntity, String.class);
+            }
+        }
+
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/RepositoryService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/RepositoryService.java
@@ -26,12 +26,12 @@ public class RepositoryService {
         this.mapper = mapper;
     }
 
-    public void createStudentRepository(String installationId, String orgName, RosterStudent student, String repoPrefix) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+    public void createStudentRepository(String installationId, String orgName, RosterStudent student, String repoPrefix, Boolean isPrivate) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
         String newRepoName = repoPrefix+"-"+student.getUser().getGithubLogin();
         String token = jwtService.getInstallationToken(installationId);
         String existenceEndpoint = "https://api.github.com/repos/"+orgName+"/"+newRepoName;
         String createEndpoint = "https://api.github.com/orgs/"+orgName+"/repos";
-        String provisionEndpoint = "https://api.github.com/"+orgName+"/"+newRepoName+"/collaborators/"+student.getUser().getGithubLogin();
+        String provisionEndpoint = "https://api.github.com/repos/"+orgName+"/"+newRepoName+"/collaborators/"+student.getUser().getGithubLogin();
 
         HttpHeaders existenceHeaders = new HttpHeaders();
         existenceHeaders.add("Authorization", "Bearer " + token);
@@ -51,6 +51,7 @@ public class RepositoryService {
 
                 Map<String, Object> body  = new HashMap<>();
                 body.put("name", newRepoName);
+                body.put("private",  isPrivate);
                 String bodyAsJson =  mapper.writeValueAsString(body);
 
                 HttpEntity<String> createEntity = new HttpEntity<>(bodyAsJson, createHeaders);

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/ApiControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/ApiControllerTests.java
@@ -59,5 +59,18 @@ public class ApiControllerTests extends ControllerTestCase {
                 assertEquals("String with id 7 not found", json.get("message"));
         }
 
+        @Test
+        public void test_dummy_controller_returns_no_linked_org() throws Exception {
+                // act
+                MvcResult response = mockMvc.perform(get("/dummycontroller/noorg?courseName=course"))
+                        .andExpect(status().isBadRequest()).andReturn();
+
+                // assert
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("NoLinkedOrganizationException", json.get("type"));
+                assertEquals("No linked GitHub Organization to course. Please link a GitHub Organization first.", json.get("message"));
+        }
+
 }
 

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/DummyController.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/DummyController.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
+import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,5 +24,9 @@ public class DummyController extends ApiController {
             return "String1";
         }
         throw new EntityNotFoundException(String.class, id);
+    }
+    @GetMapping("/noorg")
+    public String noOrg(@RequestParam String courseName) throws EntityNotFoundException {
+        throw new NoLinkedOrganizationException(courseName);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RepositoryControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RepositoryControllerTests.java
@@ -1,0 +1,115 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.Job;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.jobs.CreateStudentRepositoriesJob;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.services.CurrentUserService;
+import edu.ucsb.cs156.frontiers.services.RepositoryService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@WebMvcTest(controllers = RepositoryController.class)
+@AutoConfigureDataJpa
+public class RepositoryControllerTests extends ControllerTestCase {
+    @MockitoBean
+    private CourseRepository  courseRepository;
+
+    @MockitoBean
+    private JobService service;
+
+    @MockitoBean
+    private RepositoryService repositoryService;
+
+    @Autowired
+    private CurrentUserService  currentUserService;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    public void not_the_creator() throws Exception {
+        Course course = Course.builder().creator(User.builder().build()).build();
+        doReturn(Optional.of(course)).when(courseRepository).findById(eq(2L));
+        MvcResult response = mockMvc.perform(post("/api/repos/createRepos")
+                .with(csrf())
+                .param("courseId", "2")
+                .param("repoPrefix", "repo1")
+        ).andExpect(status().isForbidden())
+        .andReturn();
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    public void not_registered_org() throws Exception {
+        Course course = Course.builder().courseName("course").creator(currentUserService.getUser()).build();
+        doReturn(Optional.of(course)).when(courseRepository).findById(eq(2L));
+        MvcResult response = mockMvc.perform(post("/api/repos/createRepos")
+                        .with(csrf())
+                        .param("courseId", "2")
+                        .param("repoPrefix", "repo1")
+                ).andExpect(status().isBadRequest())
+                .andReturn();
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("NoLinkedOrganizationException", json.get("type"));
+        assertEquals("No linked GitHub Organization to course. Please link a GitHub Organization first.", json.get("message"));
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    public void job_actually_fires() throws Exception {
+        Course course = Course.builder().id(2L).orgName("ucsb-cs156").installationId("1234").courseName("course").creator(currentUserService.getUser()).build();
+        doReturn(Optional.of(course)).when(courseRepository).findById(eq(2L));
+        Job job = Job.builder().status("processing").build();
+        doReturn(job).when(service).runAsJob(any(CreateStudentRepositoriesJob.class));
+        MvcResult response = mockMvc.perform(post("/api/repos/createRepos")
+                        .with(csrf())
+                        .param("courseId", "2")
+                        .param("repoPrefix", "repo1")
+                ).andExpect(status().isOk())
+                .andReturn();
+
+        String expectedJson = objectMapper.writeValueAsString(job);
+        String actualJson = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    public void notFound() throws Exception {
+        Course course = Course.builder().courseName("course").creator(currentUserService.getUser()).build();
+        doReturn(Optional.empty()).when(courseRepository).findById(eq(2L));
+        MvcResult response = mockMvc.perform(post("/api/repos/createRepos")
+                        .with(csrf())
+                        .param("courseId", "2")
+                        .param("repoPrefix", "repo1")
+                ).andExpect(status().isNotFound())
+                .andReturn();
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("Course with id 2 not found", json.get("message"));
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RepositoryControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RepositoryControllerTests.java
@@ -80,6 +80,22 @@ public class RepositoryControllerTests extends ControllerTestCase {
 
     @Test
     @WithMockUser(roles = {"ADMIN"})
+    public void just_no_install_id() throws Exception {
+        Course course = Course.builder().courseName("course").orgName("ucsb-cs156").creator(currentUserService.getUser()).build();
+        doReturn(Optional.of(course)).when(courseRepository).findById(eq(2L));
+        MvcResult response = mockMvc.perform(post("/api/repos/createRepos")
+                        .with(csrf())
+                        .param("courseId", "2")
+                        .param("repoPrefix", "repo1")
+                ).andExpect(status().isBadRequest())
+                .andReturn();
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("NoLinkedOrganizationException", json.get("type"));
+        assertEquals("No linked GitHub Organization to course. Please link a GitHub Organization first.", json.get("message"));
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
     public void job_actually_fires() throws Exception {
         Course course = Course.builder().id(2L).orgName("ucsb-cs156").installationId("1234").courseName("course").creator(currentUserService.getUser()).build();
         doReturn(Optional.of(course)).when(courseRepository).findById(eq(2L));

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentRepositoriesJobTest.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentRepositoriesJobTest.java
@@ -1,0 +1,124 @@
+package edu.ucsb.cs156.frontiers.jobs;
+
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.Job;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.services.RepositoryService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CreateStudentRepositoriesJobTest {
+
+    @Mock
+    private RepositoryService service;
+
+    Job jobStarted = Job.builder().build();
+    JobContext ctx = new JobContext(null, jobStarted);
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testCreateStudentRepository() throws Exception {
+        Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+        User user = User.builder().githubLogin("studentLogin").build();
+        RosterStudent student = RosterStudent.builder().user(user).orgStatus(OrgStatus.MEMBER).build();
+        course.setRosterStudents(List.of(student));
+
+        doNothing().when(service).createStudentRepository(contains("1234"), contains("ucsb-cs156"), eq(student), contains("repo-prefix"));
+
+        var repoJob = spy(CreateStudentRepositoriesJob.builder()
+                .repositoryService(service)
+                .repositoryPrefix("repo-prefix")
+                .course(course)
+                .build());
+
+        repoJob.accept(ctx);
+        String expected = """
+                Processing...
+                Done""";
+        assertEquals(expected, jobStarted.getLog());
+
+        verify(service, times(1)).createStudentRepository(contains("1234"), contains("ucsb-cs156"), eq(student), contains("repo-prefix"));
+    }
+
+    @Test
+    public void expectDoesntCallForNoUser() throws Exception {
+        Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+        RosterStudent student = RosterStudent.builder().build();
+        course.setRosterStudents(List.of(student));
+        var repoJob = spy(CreateStudentRepositoriesJob.builder()
+                .repositoryService(service)
+                .repositoryPrefix("repo-prefix")
+                .course(course)
+                .build());
+
+        repoJob.accept(ctx);
+        String expected = """
+                Processing...
+                Done""";
+        assertEquals(expected, jobStarted.getLog());
+
+        verify(service, times(0)).createStudentRepository(any(),any(),any(),any());
+    }
+
+    @Test
+    public void expectDoesntCallForNoLogin() throws Exception {
+        Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+        User user = User.builder().build();
+        RosterStudent student = RosterStudent.builder().user(user).build();
+        course.setRosterStudents(List.of(student));
+
+        var repoJob = spy(CreateStudentRepositoriesJob.builder()
+                .repositoryService(service)
+                .repositoryPrefix("repo-prefix")
+                .course(course)
+                .build());
+
+        repoJob.accept(ctx);
+        String expected = """
+                Processing...
+                Done""";
+        assertEquals(expected, jobStarted.getLog());
+
+        verify(service, times(0)).createStudentRepository(any(),any(),any(),any());
+    }
+
+    @Test
+    public void expectDoesntCallForNotMember() throws Exception {
+        Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+        RosterStudent student = RosterStudent.builder().orgStatus(OrgStatus.NONE).build();
+        course.setRosterStudents(List.of(student));
+        var repoJob = spy(CreateStudentRepositoriesJob.builder()
+                .repositoryService(service)
+                .repositoryPrefix("repo-prefix")
+                .course(course)
+                .build());
+
+        repoJob.accept(ctx);
+        String expected = """
+                Processing...
+                Done""";
+        assertEquals(expected, jobStarted.getLog());
+
+        verify(service, times(0)).createStudentRepository(any(), any(), any(), any());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/RepositoryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/RepositoryServiceTests.java
@@ -1,0 +1,124 @@
+package edu.ucsb.cs156.frontiers.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.services.wiremock.WiremockService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.client.ExpectedCount;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+@RestClientTest(RepositoryService.class)
+@AutoConfigureDataJpa
+public class RepositoryServiceTests {
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @MockitoBean
+    private WiremockService wiremockService;
+
+    @Autowired
+    RepositoryService repositoryService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setup() throws Exception{
+        doReturn("real.installation.token").when(jwtService).getInstallationToken(contains("1234"));
+    }
+
+    @Test
+    public void repo_already_exists_test() throws Exception{
+        mockRestServiceServer
+                .expect(requestTo("https://api.github.com/repos/ucsb-cs156/repo1-student1"))
+                .andExpect(header("Authorization", "Bearer real.installation.token"))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess());
+
+        User user = User.builder().githubLogin("student1").build();
+        RosterStudent student = RosterStudent.builder().user(user).build();
+
+        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1");
+        mockRestServiceServer.verify();
+    }
+
+    @Test
+    public void successfully_creates_repo() throws Exception{
+        mockRestServiceServer
+                .expect(requestTo("https://api.github.com/repos/ucsb-cs156/repo1-student1"))
+                .andExpect(header("Authorization", "Bearer real.installation.token"))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withResourceNotFound());
+
+        Map<String, Object> createBody =  new HashMap<>();
+        createBody.put("name", "repo1-student1");
+        String createBodyJson =  objectMapper.writeValueAsString(createBody);
+
+        mockRestServiceServer
+                .expect(requestTo("https://api.github.com/orgs/ucsb-cs156/repos"))
+                .andExpect(header("Authorization", "Bearer real.installation.token"))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().json(createBodyJson))
+                .andRespond(withSuccess());
+
+        Map<String, Object> provisionBody =  new HashMap<>();
+        provisionBody.put("permission", "admin");
+        String provisionBodyJson =  objectMapper.writeValueAsString(provisionBody);
+        mockRestServiceServer
+                .expect(requestTo("https://api.github.com/ucsb-cs156/repo1-student1/collaborators/student1"))
+                .andExpect(header("Authorization", "Bearer real.installation.token"))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andExpect(method(HttpMethod.PUT))
+                .andExpect(content().json(provisionBodyJson))
+                .andRespond(withSuccess());
+
+        User user = User.builder().githubLogin("student1").build();
+        RosterStudent student = RosterStudent.builder().user(user).build();
+
+        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1");
+
+        mockRestServiceServer.verify();
+    }
+
+    @Test
+    public void exits_if_not_not_found() throws Exception{
+        mockRestServiceServer
+                .expect(requestTo("https://api.github.com/repos/ucsb-cs156/repo1-student1"))
+                .andExpect(header("Authorization", "Bearer real.installation.token"))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withForbiddenRequest());
+
+        User user = User.builder().githubLogin("student1").build();
+        RosterStudent student = RosterStudent.builder().user(user).build();
+
+        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1");
+        mockRestServiceServer.verify();
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/RepositoryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/RepositoryServiceTests.java
@@ -58,12 +58,12 @@ public class RepositoryServiceTests {
         User user = User.builder().githubLogin("student1").build();
         RosterStudent student = RosterStudent.builder().user(user).build();
 
-        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1");
+        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1", false);
         mockRestServiceServer.verify();
     }
 
     @Test
-    public void successfully_creates_repo() throws Exception{
+    public void successfully_creates_repo_public() throws Exception{
         mockRestServiceServer
                 .expect(requestTo("https://api.github.com/repos/ucsb-cs156/repo1-student1"))
                 .andExpect(header("Authorization", "Bearer real.installation.token"))
@@ -74,6 +74,7 @@ public class RepositoryServiceTests {
 
         Map<String, Object> createBody =  new HashMap<>();
         createBody.put("name", "repo1-student1");
+        createBody.put("private", false);
         String createBodyJson =  objectMapper.writeValueAsString(createBody);
 
         mockRestServiceServer
@@ -89,7 +90,7 @@ public class RepositoryServiceTests {
         provisionBody.put("permission", "admin");
         String provisionBodyJson =  objectMapper.writeValueAsString(provisionBody);
         mockRestServiceServer
-                .expect(requestTo("https://api.github.com/ucsb-cs156/repo1-student1/collaborators/student1"))
+                .expect(requestTo("https://api.github.com/repos/ucsb-cs156/repo1-student1/collaborators/student1"))
                 .andExpect(header("Authorization", "Bearer real.installation.token"))
                 .andExpect(header("Accept", "application/vnd.github+json"))
                 .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
@@ -100,10 +101,55 @@ public class RepositoryServiceTests {
         User user = User.builder().githubLogin("student1").build();
         RosterStudent student = RosterStudent.builder().user(user).build();
 
-        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1");
+        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1", false);
 
         mockRestServiceServer.verify();
     }
+
+    @Test
+    public void successfully_creates_repo_private() throws Exception{
+        mockRestServiceServer
+                .expect(requestTo("https://api.github.com/repos/ucsb-cs156/repo1-student1"))
+                .andExpect(header("Authorization", "Bearer real.installation.token"))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withResourceNotFound());
+
+        Map<String, Object> createBody =  new HashMap<>();
+        createBody.put("name", "repo1-student1");
+        createBody.put("private", true);
+        String createBodyJson =  objectMapper.writeValueAsString(createBody);
+
+        mockRestServiceServer
+                .expect(requestTo("https://api.github.com/orgs/ucsb-cs156/repos"))
+                .andExpect(header("Authorization", "Bearer real.installation.token"))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().json(createBodyJson))
+                .andRespond(withSuccess());
+
+        Map<String, Object> provisionBody =  new HashMap<>();
+        provisionBody.put("permission", "admin");
+        String provisionBodyJson =  objectMapper.writeValueAsString(provisionBody);
+        mockRestServiceServer
+                .expect(requestTo("https://api.github.com/repos/ucsb-cs156/repo1-student1/collaborators/student1"))
+                .andExpect(header("Authorization", "Bearer real.installation.token"))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andExpect(method(HttpMethod.PUT))
+                .andExpect(content().json(provisionBodyJson))
+                .andRespond(withSuccess());
+
+        User user = User.builder().githubLogin("student1").build();
+        RosterStudent student = RosterStudent.builder().user(user).build();
+
+        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1", true);
+
+        mockRestServiceServer.verify();
+    }
+
 
     @Test
     public void exits_if_not_not_found() throws Exception{
@@ -118,7 +164,7 @@ public class RepositoryServiceTests {
         User user = User.builder().githubLogin("student1").build();
         RosterStudent student = RosterStudent.builder().user(user).build();
 
-        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1");
+        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1", false);
         mockRestServiceServer.verify();
     }
 }


### PR DESCRIPTION
In this PR, I add the ability to create student repos. Once a course is linked to an organization, any RosterStudent with a linked User with a GithubLogin and the status of MEMBER will have a repository created for them. This is achieved by the endpoint starting a job. The Job picks students with the above qualities, and runs a service, which will check if the repo exists, if not create it, then add the student as a collaborator.

This is currently deployed to https://frontiers-qa.dokku-00.cs.ucsb.edu/ -- I have Sangita and I set up as students that are listed as invited for Course 2, for testing purposes. It should create two repos with the prefix listed in ucsb-cs156.

Kills all mutations and has 100% line coverage. Merge after #21.