### PR TITLE
pc - don't store .pem files in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+## Don't store .pem files
+
+*.pem
+
 ## emacs ##
 *~
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-## Don't store .pem files
+## Don't store .pem files, or pkcs8.key
 
 *.pem
+pkcs8.key
 
 ## emacs ##
 *~
@@ -56,3 +57,4 @@ build/
 .env
 secrets.yaml
 .DS_Store
+


### PR DESCRIPTION
In this PR, we add `*.pem` files and `pkcs8.key` to the `.gitignore`

.pem files are private keys downloaded from Github as part of the installation process for a Github App.

It is important that they not get committed to the repo accidentally.