### PR TITLE
Adding a Job to Mark Linked Users as Members

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/UpdateOrgMembershipJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/UpdateOrgMembershipJob.java
@@ -1,0 +1,42 @@
+package edu.ucsb.cs156.frontiers.jobs;
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.models.OrgMember;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.services.OrganizationLinkerService;
+import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobContext;
+import edu.ucsb.cs156.frontiers.services.jobs.JobContextConsumer;
+import lombok.Builder;
+
+import java.util.Optional;
+@Builder
+public class UpdateOrgMembershipJob implements JobContextConsumer {
+    Course course;
+    OrganizationMemberService organizationMemberService;
+    UserRepository userRepository;
+    RosterStudentRepository rosterStudentRepository;
+
+
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+        ctx.log("Processing...");
+        Iterable<OrgMember> members = organizationMemberService.getOrganizationMembers(course);
+        for(OrgMember member : members){
+            Optional<User> user = userRepository.findByGithubId(member.getGithubId());
+            if(user.isPresent()){
+                Optional<RosterStudent> student = rosterStudentRepository.findByCourseAndUser(course, user.get());
+                if(student.isPresent()){
+                    RosterStudent foundStudent = student.get();
+                    foundStudent.setOrgStatus(OrgStatus.MEMBER);
+                    rosterStudentRepository.save(foundStudent);
+                }
+            }
+        }
+        ctx.log("Done");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/models/OrgMember.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/models/OrgMember.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.frontiers.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrgMember {
+
+    @JsonProperty("id")
+    private int githubId;
+
+    @JsonProperty("login")
+    private String githubLogin;
+
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/UserRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/UserRepository.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository;
 
 import edu.ucsb.cs156.frontiers.entities.User;
 
+import javax.swing.text.html.Option;
 import java.util.Optional;
 
 /**
@@ -22,4 +23,6 @@ public interface UserRepository extends CrudRepository<User, Long> {
   Optional<User> findByGoogleSub(String googleSub);
 
   Optional<User> findByGithubLogin(String githubLogin);
+
+  Optional<User> findByGithubId(int githubId);
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
@@ -1,0 +1,63 @@
+package edu.ucsb.cs156.frontiers.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.models.OrgMember;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+public class OrganizationMemberService {
+
+    private final JwtService jwtService;
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+
+    public OrganizationMemberService(JwtService jwtService, ObjectMapper objectMapper, RestTemplateBuilder builder) {
+        this.jwtService = jwtService;
+        this.objectMapper = objectMapper;
+        this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        this.restTemplate = builder.build();
+    }
+
+    public Iterable<OrgMember> getOrganizationMembers(Course course) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+        String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/members";
+        //happily stolen directly from GitHub: https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28
+        Pattern pattern = Pattern.compile("(?<=<)([\\S]*)(?=>; rel=\"next\")");
+        String token = jwtService.getInstallationToken(course.getInstallationId());
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + token);
+        headers.add("Accept", "application/vnd.github+json");
+        headers.add("X-GitHub-Api-Version", "2022-11-28");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<String> response = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class);
+        List<String> responseLinks = response.getHeaders().getOrEmpty("link");
+        List<OrgMember> orgMembers = new ArrayList<>();
+        while (!responseLinks.isEmpty()&&responseLinks.getFirst().contains("next")) {
+            orgMembers.addAll(objectMapper.convertValue(objectMapper.readTree(response.getBody()), new TypeReference<List<OrgMember>>() {
+            }));
+            Matcher matcher = pattern.matcher(responseLinks.getFirst());
+            matcher.find();
+            response = restTemplate.exchange(matcher.group(0), HttpMethod.GET, entity, String.class);
+            responseLinks = response.getHeaders().getOrEmpty("link");
+        }
+        orgMembers.addAll(objectMapper.convertValue(objectMapper.readTree(response.getBody()), new TypeReference<List<OrgMember>>() {
+        }));
+        return orgMembers;
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/UpdateOrgMembershipJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/UpdateOrgMembershipJobTests.java
@@ -1,0 +1,141 @@
+package edu.ucsb.cs156.frontiers.jobs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.Job;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.models.OrgMember;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.services.OrganizationLinkerService;
+import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateOrgMembershipJobTests {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RosterStudentRepository rosterStudentRepository;
+
+    @Mock
+    private OrganizationMemberService organizationMemberService;
+
+    Job jobStarted = Job.builder().build();
+    JobContext ctx = new JobContext(null, jobStarted);
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void match_students_correctly() throws Exception {
+        OrgMember orgMember1 = OrgMember.builder().githubId(123456).githubLogin("division7").build();
+        OrgMember orgMember2 = OrgMember.builder().githubId(123457).githubLogin("division8").build();
+        User user1 = User.builder().githubLogin("division7").githubId(123456).id(1L).build();
+        User user2 = User.builder().githubLogin("division8").githubId(123457).id(2L).build();
+        List<OrgMember> orgMembers = List.of(orgMember1, orgMember2);
+        Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+        RosterStudent student1 = RosterStudent.builder().studentId("banana").course(course).user(user1).build();
+        RosterStudent student2 = RosterStudent.builder().studentId("apple").course(course).user(user2).build();
+        RosterStudent student1Updated = RosterStudent.builder().studentId("banana").course(course).user(user1).orgStatus(OrgStatus.MEMBER).build();
+        RosterStudent student2Updated = RosterStudent.builder().studentId("apple").course(course).user(user2).orgStatus(OrgStatus.MEMBER).build();
+
+        doReturn(orgMembers).when(organizationMemberService).getOrganizationMembers(eq(course));
+        doReturn(Optional.of(user1)).when(userRepository).findByGithubId(eq(123456));
+        doReturn(Optional.of(user2)).when(userRepository).findByGithubId(eq(123457));
+        doReturn(Optional.of(student1)).when(rosterStudentRepository).findByCourseAndUser(eq(course), eq(user1));
+        doReturn(Optional.of(student2)).when(rosterStudentRepository).findByCourseAndUser(eq(course), eq(user2));
+
+        var matchJob = spy(UpdateOrgMembershipJob.builder()
+                .rosterStudentRepository(rosterStudentRepository)
+                .userRepository(userRepository)
+                .organizationMemberService(organizationMemberService)
+                .course(course)
+                .build());
+
+        matchJob.accept(ctx);
+        String expected = """
+                Processing...
+                Done""";
+        assertEquals(expected, jobStarted.getLog());
+
+        verify(rosterStudentRepository, times(1)).save(eq(student1Updated));
+        verify(rosterStudentRepository, times(1)).save(eq(student2Updated));
+    }
+
+    @Test
+    public void no_user() throws Exception {
+        OrgMember orgMember1 = OrgMember.builder().githubId(123456).githubLogin("division7").build();
+        List<OrgMember> orgMembers = List.of(orgMember1);
+        Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+
+        doReturn(orgMembers).when(organizationMemberService).getOrganizationMembers(eq(course));
+        doReturn(Optional.empty()).when(userRepository).findByGithubId(eq(123456));
+
+        var matchJob = spy(UpdateOrgMembershipJob.builder()
+                .rosterStudentRepository(rosterStudentRepository)
+                .userRepository(userRepository)
+                .organizationMemberService(organizationMemberService)
+                .course(course)
+                .build());
+
+        matchJob.accept(ctx);
+        String expected = """
+                Processing...
+                Done""";
+        assertEquals(expected, jobStarted.getLog());
+
+        verify(rosterStudentRepository, times(0)).save(any());
+    }
+
+    @Test
+    public void no_roster_student() throws Exception {
+        OrgMember orgMember1 = OrgMember.builder().githubId(123456).githubLogin("division7").build();
+        User user1 = User.builder().githubLogin("division7").githubId(123456).id(1L).build();
+        List<OrgMember> orgMembers = List.of(orgMember1);
+        Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+
+        doReturn(orgMembers).when(organizationMemberService).getOrganizationMembers(eq(course));
+        doReturn(Optional.of(user1)).when(userRepository).findByGithubId(eq(123456));
+        doReturn(Optional.empty()).when(rosterStudentRepository).findByCourseAndUser(eq(course), eq(user1));
+
+        var matchJob = spy(UpdateOrgMembershipJob.builder()
+                .rosterStudentRepository(rosterStudentRepository)
+                .userRepository(userRepository)
+                .organizationMemberService(organizationMemberService)
+                .course(course)
+                .build());
+
+        matchJob.accept(ctx);
+        String expected = """
+                Processing...
+                Done""";
+        assertEquals(expected, jobStarted.getLog());
+
+        verify(rosterStudentRepository, times(0)).save(any());
+    }
+
+
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
@@ -87,16 +87,20 @@ public class OrganizationMemberServiceTests {
     @Test
     void testGetOrganizationMembers_MultiplePages() throws Exception {
         // Prepare test data for two pages
+        OrgMember orgMember1 = OrgMember.builder().githubId(1).githubLogin("user1").build();
+        OrgMember orgMember2 = OrgMember.builder().githubId(2).githubLogin("user2").build();
+
         List<OrgMember> firstPageMembers = List.of(
-            OrgMember.builder().githubId(1).githubLogin("user1").build()
+            orgMember1
         );
         List<OrgMember> secondPageMembers = List.of(
-            OrgMember.builder().githubId(2).githubLogin("user2").build()
+            orgMember2
         );
 
         String firstPageJson = objectMapper.writeValueAsString(firstPageMembers);
         String secondPageJson = objectMapper.writeValueAsString(secondPageMembers);
 
+        List<OrgMember> expectedResults = List.of(orgMember1, orgMember2);
         // Setup headers for pagination
         HttpHeaders firstPageHeaders = new HttpHeaders();
         firstPageHeaders.add("link", 
@@ -127,11 +131,7 @@ public class OrganizationMemberServiceTests {
 
         // Verify results
         mockServer.verify();
-        assertEquals(2, result.size());
-        assertEquals(1, result.get(0).getGithubId());
-        assertEquals(2, result.get(1).getGithubId());
-        assertEquals("user1", result.get(0).getGithubLogin());
-        assertEquals("user2", result.get(1).getGithubLogin());
+        assertEquals(expectedResults, result);
     }
 
     @Test

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
@@ -1,0 +1,155 @@
+package edu.ucsb.cs156.frontiers.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.models.OrgMember;
+import edu.ucsb.cs156.frontiers.services.wiremock.WiremockService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+@RestClientTest(OrganizationMemberService.class)
+@AutoConfigureDataJpa
+public class OrganizationMemberServiceTests {
+
+    @Autowired
+    private OrganizationMemberService organizationMemberService;
+
+    @Autowired
+    private MockRestServiceServer mockServer;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @MockitoBean
+    private WiremockService wiremockService;
+
+    private Course testCourse;
+    private static final String TEST_TOKEN = "test-token";
+    private static final String TEST_ORG = "test-org";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        testCourse = Course.builder()
+                .orgName(TEST_ORG)
+                .installationId("123")
+                .build();
+
+        when(jwtService.getInstallationToken(anyString())).thenReturn(TEST_TOKEN);
+    }
+
+    @Test
+    void testGetOrganizationMembers_SinglePage() throws Exception {
+        // Prepare test data
+        List<OrgMember> expectedMembers = List.of(
+            OrgMember.builder().githubId(1).githubLogin("user1").build(),
+            OrgMember.builder().githubId(2).githubLogin("user2").build()
+        );
+        String jsonResponse = objectMapper.writeValueAsString(expectedMembers);
+
+        // Setup mock server
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(jsonResponse));
+
+        // Execute test
+        Iterable<OrgMember> result = organizationMemberService.getOrganizationMembers(testCourse);
+
+        // Verify results
+        mockServer.verify();
+        assertIterableEquals(expectedMembers, result);
+    }
+
+    @Test
+    void testGetOrganizationMembers_MultiplePages() throws Exception {
+        // Prepare test data for two pages
+        List<OrgMember> firstPageMembers = List.of(
+            OrgMember.builder().githubId(1).githubLogin("user1").build()
+        );
+        List<OrgMember> secondPageMembers = List.of(
+            OrgMember.builder().githubId(2).githubLogin("user2").build()
+        );
+
+        String firstPageJson = objectMapper.writeValueAsString(firstPageMembers);
+        String secondPageJson = objectMapper.writeValueAsString(secondPageMembers);
+
+        // Setup headers for pagination
+        HttpHeaders firstPageHeaders = new HttpHeaders();
+        firstPageHeaders.add("link", 
+            "<https://api.github.com/orgs/" + TEST_ORG + "/members?page=2>; rel=\"next\"");
+
+        HttpHeaders secondPageHeaders = new HttpHeaders();
+        secondPageHeaders.add("link", "<https://api.github.com/orgs/" + TEST_ORG + "/members?page=1>; rel=\"previous\"");
+        // Setup mock server for first page
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .headers(firstPageHeaders)
+                        .body(firstPageJson));
+
+        // Setup mock server for second page
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?page=2"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .headers(secondPageHeaders)
+                        .body(secondPageJson));
+
+        // Execute test
+        List<OrgMember> result = (List<OrgMember>) organizationMemberService.getOrganizationMembers(testCourse);
+
+        // Verify results
+        mockServer.verify();
+        assertEquals(2, result.size());
+        assertEquals(1, result.get(0).getGithubId());
+        assertEquals(2, result.get(1).getGithubId());
+        assertEquals("user1", result.get(0).getGithubLogin());
+        assertEquals("user2", result.get(1).getGithubLogin());
+    }
+
+    @Test
+    void testGetOrganizationMembers_EmptyResponse() throws Exception {
+        // Setup mock server with empty response
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("[]"));
+
+        // Execute test
+        Iterable<OrgMember> result = organizationMemberService.getOrganizationMembers(testCourse);
+
+        // Verify results
+        mockServer.verify();
+        assertEquals(result, List.of());
+    }
+
+}


### PR DESCRIPTION
In this PR, I create a job under `RosterStudentsController` that will take students with a linked user and github login, and if they are present in the organization, marks the Roster Student as `OrgStatus.MEMBER`


Currently deployed to https://frontiers-qa.dokku-00.cs.ucsb.edu/

I successfully ran the job against Course 1, and each student is marked as member, other than the two students who linked a separate account on Frontiers than using the membership script.

Notable issue:
If two accounts have the same GitHub account linked, the job will throw an error. I'm unsure if I should simply account for this here or prevent two accounts from linking the same GitHub account.