### PR TITLE
Pc - add courses table component (frontend component for storybook only)

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -7,14 +7,11 @@
 
 # testing
 /coverage
-<<<<<<< Updated upstream
 /reports
-=======
 /.nyc_output
 
 # Dont store storybook logs
 build-storybook.log
->>>>>>> Stashed changes
 
 # production
 /build

--- a/frontend/src/fixtures/coursesFixtures.js
+++ b/frontend/src/fixtures/coursesFixtures.js
@@ -1,0 +1,30 @@
+const coursesFixtures = {
+  threeCourses: [
+    {
+      id: 1,
+      installationId: "123456",
+      orgName: "ucsb-cs156-s25",
+      courseName: "CMPSC 156",
+      term: "Spring 2025",
+      school: "UCSB",
+    },
+    {
+      id: 2,
+      installationId: "654321",
+      orgName: "wsu-cpts489-fa20",
+      courseName: "CPTS 489",
+      term: "Fall 2020",
+      school: "WSU",
+    },
+    {
+      id: 3,
+      installationId: "789012",
+      orgName: "ucsb-cs156-f25",
+      courseName: "CMPSC 156",
+      term: "Fall 2025",
+      school: "UCSB",
+    },
+  ],
+};
+
+export default coursesFixtures;

--- a/frontend/src/main/components/Courses/CoursesTable.js
+++ b/frontend/src/main/components/Courses/CoursesTable.js
@@ -1,0 +1,63 @@
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useNavigate } from "react-router-dom";
+
+const columns = [
+  {
+    Header: "id",
+    accessor: "id", // accessor is the "key" in the data
+  },
+  {
+    Header: "Installation Id",
+    accessor: "installationId",
+  },
+  {
+    Header: "Org Name",
+    accessor: "orgName",
+  },
+  {
+    Header: "Course Name",
+    accessor: "courseName",
+  },
+  {
+    Header: "Term",
+    accessor: "term",
+  },
+  {
+    Header: "School",
+    accessor: "school",
+  },
+];
+
+export default function CoursesTable({
+  courses,
+  showInstallButton = false,
+  storybook = false,
+}) {
+  const navigate = useNavigate();
+  const installCallback = (cell) => {
+    const url = `/api/courses/redirect?courseId=${cell.row.values.id}`;
+    if (storybook) {
+      window.alert(`would have navigated to: ${url}`);
+      return;
+    }
+    navigate(url);
+  };
+
+  const buttonColumns = [
+    ...columns,
+    ButtonColumn(
+      "Install Github App",
+      "primary",
+      installCallback,
+      "CoursesTable",
+    ),
+  ];
+  const columnsToDisplay = showInstallButton ? buttonColumns : columns;
+  return (
+    <OurTable
+      data={courses}
+      columns={columnsToDisplay}
+      testid={"CoursesTable"}
+    />
+  );
+}

--- a/frontend/src/stories/components/Courses/CoursesTable.stories.js
+++ b/frontend/src/stories/components/Courses/CoursesTable.stories.js
@@ -1,0 +1,35 @@
+import React from "react";
+
+import CoursesTable from "main/components/Courses/CoursesTable";
+import coursesFixtures from "fixtures/coursesFixtures";
+
+export default {
+  title: "components/Courses/CoursesTable",
+  component: CoursesTable,
+};
+
+const Template = (args) => {
+  return <CoursesTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+export const ThreeCourses = Template.bind({});
+export const ThreeCoursesWithInstallButton = Template.bind({});
+
+Empty.args = {
+  courses: [],
+};
+Empty.parameters = {};
+
+ThreeCourses.args = {
+  courses: coursesFixtures.threeCourses,
+};
+ThreeCourses.parameters = {};
+
+// This story is for testing the install button
+ThreeCoursesWithInstallButton.args = {
+  courses: coursesFixtures.threeCourses,
+  showInstallButton: true,
+  storybook: true,
+};
+ThreeCoursesWithInstallButton.parameters = {};

--- a/frontend/src/tests/components/Courses/CoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/CoursesTable.test.js
@@ -1,0 +1,192 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import coursesFixtures from "fixtures/coursesFixtures";
+import CoursesTable from "main/components/Courses/CoursesTable";
+import { BrowserRouter } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+window.alert = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("CoursesTable tests", () => {
+  test("Has the expected column headers and content", () => {
+    render(
+      <BrowserRouter>
+        <CoursesTable courses={coursesFixtures.threeCourses} />
+      </BrowserRouter>,
+    );
+
+    const expectedHeaders = [
+      "id",
+      "Installation Id",
+      "Org Name",
+      "Course Name",
+      "Term",
+      "School",
+    ];
+    const expectedFields = [
+      "id",
+      "installationId",
+      "orgName",
+      "courseName",
+      "term",
+      "school",
+    ];
+    const testId = "CoursesTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-installationId`),
+    ).toHaveTextContent("123456");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-orgName`),
+    ).toHaveTextContent("ucsb-cs156-s25");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-courseName`),
+    ).toHaveTextContent("CMPSC 156");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-term`),
+    ).toHaveTextContent("Spring 2025");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-school`),
+    ).toHaveTextContent("UCSB");
+
+    // expect that the mocked navigate function is not called
+    expect(mockedNavigate).not.toHaveBeenCalled();
+    // expect that the mocked window.alert function is not called
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  test("Calls the navigate callback when the button is pressed", () => {
+    render(
+      <BrowserRouter>
+        <CoursesTable
+          courses={coursesFixtures.threeCourses}
+          showInstallButton={true}
+        />
+      </BrowserRouter>,
+    );
+
+    const button = screen.getByTestId(
+      "CoursesTable-cell-row-0-col-Install Github App-button",
+    );
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent("Install Github App");
+    expect(button).toHaveAttribute("class", "btn btn-primary");
+
+    fireEvent.click(button);
+    expect(mockedNavigate).toHaveBeenCalledTimes(1);
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      "/api/courses/redirect?courseId=1",
+    );
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  test("Calls window.alert when the button is pressed on storybook", async () => {
+    render(
+      <BrowserRouter>
+        <CoursesTable
+          courses={coursesFixtures.threeCourses}
+          showInstallButton={true}
+          storybook={true}
+        />
+      </BrowserRouter>,
+    );
+
+    const button = screen.getByTestId(
+      "CoursesTable-cell-row-0-col-Install Github App-button",
+    );
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent("Install Github App");
+    expect(button).toHaveAttribute("class", "btn btn-primary");
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledTimes(1);
+    });
+    expect(window.alert).toHaveBeenCalledWith(
+      "would have navigated to: /api/courses/redirect?courseId=1",
+    );
+    expect(mockedNavigate).not.toHaveBeenCalled();
+  });
+
+  test("Tests that the default is to NOT show the buttons for installation", () => {
+    render(
+      <BrowserRouter>
+        <CoursesTable courses={coursesFixtures.threeCourses} />
+      </BrowserRouter>,
+    );
+
+    // Check that the button is NOT in the document
+    const button = screen.queryByTestId(
+      "CoursesTable-cell-row-0-col-Install Github App-button",
+    );
+    expect(button).not.toBeInTheDocument();
+    expect(mockedNavigate).not.toHaveBeenCalled();
+    // expect that the mocked window.alert function is not called
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  test("Tests that we don't see the buttons when we specify false", () => {
+    render(
+      <BrowserRouter>
+        <CoursesTable
+          courses={coursesFixtures.threeCourses}
+          showInstallButton={false}
+        />
+      </BrowserRouter>,
+    );
+
+    // Check that the button is NOT in the document
+    const button = screen.queryByTestId(
+      "CoursesTable-cell-row-0-col-Install Github App-button",
+    );
+    expect(button).not.toBeInTheDocument();
+    expect(mockedNavigate).not.toHaveBeenCalled();
+    // expect that the mocked window.alert function is not called
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  test("Tests that storybook is explictly false all still works as expected", async () => {
+    render(
+      <BrowserRouter>
+        <CoursesTable
+          courses={coursesFixtures.threeCourses}
+          showInstallButton={true}
+          storybook={false}
+        />
+      </BrowserRouter>,
+    );
+
+    // Check that the button is NOT in the document
+    const button = screen.getByTestId(
+      "CoursesTable-cell-row-0-col-Install Github App-button",
+    );
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent("Install Github App");
+    expect(button).toHaveAttribute("class", "btn btn-primary");
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockedNavigate).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      "/api/courses/redirect?courseId=1",
+    );
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #57 

In this PR we add a CoursesTable component, plus tests and storybook.

This PR changes nothing in the active app; this is a component for future use in creating a Courses Index Page.

Link to Storybook: <https://67da6ee1a47bfcdda4700814-zzasiwkikr.chromatic.com/?path=/story/components-courses-coursestable--three-courses-with-install-button>

Screenshot: 

<img width="1089" alt="image" src="https://github.com/user-attachments/assets/1d451e3d-2c4a-4d77-a236-80439056c2b4" />
