### PR TITLE
pc - eslint should ignore build directory

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -103,6 +103,9 @@
     ]
   },
   "eslintConfig": {
+    "ignorePatterns": [
+      "build/"
+    ],
     "extends": [
       "react-app",
       "react-app/jest",


### PR DESCRIPTION
In this PR, we fix a problem that can crop up if you have a `build` directory under `frontend`, which can happen if you've been running end2end tests recently.

Suddenly, eslint has a cow, and there are thousands of errors!  

This is because eslint is trying to do linting on all kinds of code that you didn't write, that happens to live the `build` directory.

This small change to `package.json` tells eslint to ignore the `build` directory,