### PR TITLE
Create Courses Index Page and Tests

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
 import "react-toastify/dist/ReactToastify.css";
+import CoursesIndexPage from "main/pages/Courses/CoursesIndexPage";
 
 function App() {
   const { data: currentUser } = useCurrentUser();
@@ -18,6 +19,9 @@ function App() {
         <Route exact path="/profile" element={<ProfilePage />} />
         {hasRole(currentUser, "ROLE_ADMIN") && (
           <Route exact path="/admin/users" element={<AdminUsersPage />} />
+        )}
+        {hasRole(currentUser, "ROLE_ADMIN") && (
+          <Route exact path="/admin/courses" element={<CoursesIndexPage />} />
         )}
       </Routes>
     </BrowserRouter>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -57,7 +57,9 @@ export default function AppNavbar({
                   data-testid="appnavbar-admin-dropdown"
                 >
                   <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
-                  <NavDropdown.Item href="/admin/courses">Courses</NavDropdown.Item>
+                  <NavDropdown.Item href="/admin/courses">
+                    Courses
+                  </NavDropdown.Item>
                 </NavDropdown>
               )}
             </Nav>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -57,6 +57,7 @@ export default function AppNavbar({
                   data-testid="appnavbar-admin-dropdown"
                 >
                   <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
+                  <NavDropdown.Item href="/admin/courses">Courses</NavDropdown.Item>
                 </NavDropdown>
               )}
             </Nav>

--- a/frontend/src/main/pages/Courses/CoursesIndexPage.js
+++ b/frontend/src/main/pages/Courses/CoursesIndexPage.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import CoursesTable from "main/components/Courses/CoursesTable";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
+
+export default function CoursesIndexPage() {
+  const currentUser = useCurrentUser();
+
+  const {
+    data: courses,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/courses/all"],
+    { method: "GET", url: "/api/courses/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Courses</h1>
+        <CoursesTable courses={courses} showInstallButton={hasRole(currentUser, "ROLE_ADMIN")} />
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Courses/CoursesIndexPage.js
+++ b/frontend/src/main/pages/Courses/CoursesIndexPage.js
@@ -24,7 +24,10 @@ export default function CoursesIndexPage() {
     <BasicLayout>
       <div className="pt-2">
         <h1>Courses</h1>
-        <CoursesTable courses={courses} showInstallButton={hasRole(currentUser, "ROLE_ADMIN")} />
+        <CoursesTable
+          courses={courses}
+          showInstallButton={hasRole(currentUser, "ROLE_ADMIN")}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
@@ -1,0 +1,121 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import CoursesIndexPage from "main/pages/Courses/CoursesIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+import coursesFixtures from "fixtures/coursesFixtures";
+
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("CoursesIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "CoursesTable";
+
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+
+  test("Renders for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/courses/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CoursesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Courses/)).toBeInTheDocument();
+    });
+  });
+
+  test("renders three courses correctly for admin user", async () => {
+    setupAdminUser();
+    axiosMock
+      .onGet("/api/courses/all")
+      .reply(200, coursesFixtures.threeCourses);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CoursesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    const installationId = screen.getByText("654321");
+    expect(installationId).toBeInTheDocument();
+
+    const orgName = screen.getByText(
+      "wsu-cpts489-fa20",
+    );
+    expect(orgName).toBeInTheDocument();
+
+  });
+
+  test("renders empty table when backend unavailable, admin only", async () => {
+    setupAdminUser();
+
+    axiosMock.onGet("/api/courses/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CoursesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/courses/all",
+    );
+    restoreConsole();
+  });
+
+});

--- a/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
@@ -1,10 +1,9 @@
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import CoursesIndexPage from "main/pages/Courses/CoursesIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import mockConsole from "jest-mock-console";
 import coursesFixtures from "fixtures/coursesFixtures";
-
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
@@ -85,11 +84,8 @@ describe("CoursesIndexPage tests", () => {
     const installationId = screen.getByText("654321");
     expect(installationId).toBeInTheDocument();
 
-    const orgName = screen.getByText(
-      "wsu-cpts489-fa20",
-    );
+    const orgName = screen.getByText("wsu-cpts489-fa20");
     expect(orgName).toBeInTheDocument();
-
   });
 
   test("renders empty table when backend unavailable, admin only", async () => {
@@ -117,5 +113,4 @@ describe("CoursesIndexPage tests", () => {
     );
     restoreConsole();
   });
-
 });


### PR DESCRIPTION
This PR creates the courses index page and tests, at the route `admin/courses` under the admin tab in the navbar.

Screenshot from localhost test:
<img width="1512" alt="Screenshot 2025-05-12 at 6 59 07 PM" src="https://github.com/user-attachments/assets/7c781956-903b-430f-9043-ce52a64e42f7" />

Closes #60 