### PR TITLE
Moving the Installation Check to JwtService

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentRepositoriesJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentRepositoriesJob.java
@@ -20,7 +20,7 @@ public class CreateStudentRepositoriesJob implements JobContextConsumer {
         ctx.log("Processing...");
         for(RosterStudent student : course.getRosterStudents()){
             if(student.getUser() != null && student.getUser().getGithubLogin() != null && student.getOrgStatus() == OrgStatus.MEMBER){
-                repositoryService.createStudentRepository(course.getInstallationId(), course.getOrgName(), student, repositoryPrefix, isPrivate);
+                repositoryService.createStudentRepository(course, student, repositoryPrefix, isPrivate);
             }
         }
         ctx.log("Done");

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
@@ -39,7 +39,7 @@ public class OrganizationMemberService {
         String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/members";
         //happily stolen directly from GitHub: https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28
         Pattern pattern = Pattern.compile("(?<=<)([\\S]*)(?=>; rel=\"next\")");
-        String token = jwtService.getInstallationToken(course.getInstallationId());
+        String token = jwtService.getInstallationToken(course);
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", "Bearer " + token);
         headers.add("Accept", "application/vnd.github+json");

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/RepositoryService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/RepositoryService.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.frontiers.services;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.*;
@@ -28,18 +29,17 @@ public class RepositoryService {
 
     /**
      * Creates a single student repository if it doesn't already exist, and provisions access to the repository by that student
-     * @param installationId ID of the installation to act as
-     * @param orgName Name of the organization attached to a particular installation
+     * @param course The Course in question
      * @param student RosterStudent of the student the repository should be created for
      * @param repoPrefix Name of the project or assignment. Used to title the repository, in the format repoPrefix-githubLogin
      * @param isPrivate Whether the repository is private or not
      */
-    public void createStudentRepository(String installationId, String orgName, RosterStudent student, String repoPrefix, Boolean isPrivate) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+    public void createStudentRepository(Course course, RosterStudent student, String repoPrefix, Boolean isPrivate) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
         String newRepoName = repoPrefix+"-"+student.getUser().getGithubLogin();
-        String token = jwtService.getInstallationToken(installationId);
-        String existenceEndpoint = "https://api.github.com/repos/"+orgName+"/"+newRepoName;
-        String createEndpoint = "https://api.github.com/orgs/"+orgName+"/repos";
-        String provisionEndpoint = "https://api.github.com/repos/"+orgName+"/"+newRepoName+"/collaborators/"+student.getUser().getGithubLogin();
+        String token = jwtService.getInstallationToken(course);
+        String existenceEndpoint = "https://api.github.com/repos/"+course.getOrgName()+"/"+newRepoName;
+        String createEndpoint = "https://api.github.com/orgs/"+course.getOrgName()+"/repos";
+        String provisionEndpoint = "https://api.github.com/repos/"+course.getOrgName()+"/"+newRepoName+"/collaborators/"+student.getUser().getGithubLogin();
 
         HttpHeaders existenceHeaders = new HttpHeaders();
         existenceHeaders.add("Authorization", "Bearer " + token);

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentRepositoriesJobTest.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentRepositoriesJobTest.java
@@ -43,7 +43,7 @@ public class CreateStudentRepositoriesJobTest {
         RosterStudent student = RosterStudent.builder().user(user).orgStatus(OrgStatus.MEMBER).build();
         course.setRosterStudents(List.of(student));
 
-        doNothing().when(service).createStudentRepository(contains("1234"), contains("ucsb-cs156"), eq(student), contains("repo-prefix"), eq(false));
+        doNothing().when(service).createStudentRepository(eq(course), eq(student), contains("repo-prefix"), eq(false));
 
         var repoJob = spy(CreateStudentRepositoriesJob.builder()
                 .repositoryService(service)
@@ -58,7 +58,7 @@ public class CreateStudentRepositoriesJobTest {
                 Done""";
         assertEquals(expected, jobStarted.getLog());
 
-        verify(service, times(1)).createStudentRepository(contains("1234"), contains("ucsb-cs156"), eq(student), contains("repo-prefix"), eq(false));
+        verify(service, times(1)).createStudentRepository(eq(course), eq(student), contains("repo-prefix"), eq(false));
     }
 
     @Test
@@ -68,7 +68,7 @@ public class CreateStudentRepositoriesJobTest {
         RosterStudent student = RosterStudent.builder().user(user).orgStatus(OrgStatus.MEMBER).build();
         course.setRosterStudents(List.of(student));
 
-        doNothing().when(service).createStudentRepository(contains("1234"), contains("ucsb-cs156"), eq(student), contains("repo-prefix"), eq(true));
+        doNothing().when(service).createStudentRepository(eq(course), eq(student), contains("repo-prefix"), eq(true));
 
         var repoJob = spy(CreateStudentRepositoriesJob.builder()
                 .repositoryService(service)
@@ -83,7 +83,7 @@ public class CreateStudentRepositoriesJobTest {
                 Done""";
         assertEquals(expected, jobStarted.getLog());
 
-        verify(service, times(1)).createStudentRepository(contains("1234"), contains("ucsb-cs156"), eq(student), contains("repo-prefix"), eq(true));
+        verify(service, times(1)).createStudentRepository(eq(course), eq(student), contains("repo-prefix"), eq(true));
     }
 
     @Test
@@ -104,7 +104,7 @@ public class CreateStudentRepositoriesJobTest {
                 Done""";
         assertEquals(expected, jobStarted.getLog());
 
-        verify(service, times(0)).createStudentRepository(any(),any(),any(),any(), any());
+        verify(service, times(0)).createStudentRepository(any(),any(),any(),any());
     }
 
     @Test
@@ -127,7 +127,7 @@ public class CreateStudentRepositoriesJobTest {
                 Done""";
         assertEquals(expected, jobStarted.getLog());
 
-        verify(service, times(0)).createStudentRepository(any(),any(),any(),any(), any());
+        verify(service, times(0)).createStudentRepository(any(),any(),any(),any());
     }
 
     @Test
@@ -149,6 +149,6 @@ public class CreateStudentRepositoriesJobTest {
                 Done""";
         assertEquals(expected, jobStarted.getLog());
 
-        verify(service, times(0)).createStudentRepository(any(),any(),any(),any(), any());
+        verify(service, times(0)).createStudentRepository(any(),any(),any(),any());
     }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.client.MockRestServiceServer;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
@@ -54,7 +55,7 @@ public class OrganizationMemberServiceTests {
                 .installationId("123")
                 .build();
 
-        when(jwtService.getInstallationToken(anyString())).thenReturn(TEST_TOKEN);
+        when(jwtService.getInstallationToken(any(Course.class))).thenReturn(TEST_TOKEN);
     }
 
     @Test

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/RepositoryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/RepositoryServiceTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.frontiers.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.entities.User;
 import edu.ucsb.cs156.frontiers.services.wiremock.WiremockService;
@@ -18,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
@@ -40,9 +42,11 @@ public class RepositoryServiceTests {
     @Autowired
     private ObjectMapper objectMapper;
 
+    Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+
     @BeforeEach
     public void setup() throws Exception{
-        doReturn("real.installation.token").when(jwtService).getInstallationToken(contains("1234"));
+        doReturn("real.installation.token").when(jwtService).getInstallationToken(eq(course));
     }
 
     @Test
@@ -58,7 +62,7 @@ public class RepositoryServiceTests {
         User user = User.builder().githubLogin("student1").build();
         RosterStudent student = RosterStudent.builder().user(user).build();
 
-        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1", false);
+        repositoryService.createStudentRepository(course, student, "repo1", false);
         mockRestServiceServer.verify();
     }
 
@@ -101,7 +105,7 @@ public class RepositoryServiceTests {
         User user = User.builder().githubLogin("student1").build();
         RosterStudent student = RosterStudent.builder().user(user).build();
 
-        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1", false);
+        repositoryService.createStudentRepository(course, student, "repo1", false);
 
         mockRestServiceServer.verify();
     }
@@ -145,7 +149,7 @@ public class RepositoryServiceTests {
         User user = User.builder().githubLogin("student1").build();
         RosterStudent student = RosterStudent.builder().user(user).build();
 
-        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1", true);
+        repositoryService.createStudentRepository(course, student, "repo1", true);
 
         mockRestServiceServer.verify();
     }
@@ -164,7 +168,7 @@ public class RepositoryServiceTests {
         User user = User.builder().githubLogin("student1").build();
         RosterStudent student = RosterStudent.builder().user(user).build();
 
-        repositoryService.createStudentRepository("1234", "ucsb-cs156", student, "repo1", false);
+        repositoryService.createStudentRepository(course, student, "repo1", false);
         mockRestServiceServer.verify();
     }
 }


### PR DESCRIPTION
In this PR, I move the responsibility to check for whether or not a course has a linked GitHub Organization to the `JwtService`. This ensures that before calling the actual GitHub API, regardless of the controller behavior, an exception will be thrown if `installationId` or `orgName` is null. This exception is handled by `ApiController`, to provide a centralized response to the application being thrown. Endpoints that create jobs that access the GitHub API should still check to see whether or not there is a linked organization prior to the job being ran, but this at least provides a backstop to ensure that faulty API calls will not be made.

Deployed to https://frontiers-qa.dokku-00.cs.ucsb.edu/