### PR TITLE
Fixing the Maven Artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <!-- (3) <artifactId/> -->
 
-  <artifactId>team01</artifactId>
+  <artifactId>frontiers</artifactId>
 
   <!-- (4) <version/> -->
   <version>1.0.0</version>


### PR DESCRIPTION
In this PR, we correct the artifact name to `frontiers` from `team01`, which I missed in #50.

Merge before #64, #65