### PR TITLE
Replacing RosterStudent & RosterStudentDTO int with Integer

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/RosterStudent.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/RosterStudent.java
@@ -37,7 +37,7 @@ public class RosterStudent {
     @Enumerated(EnumType.STRING)
     private OrgStatus orgStatus;
 
-    private int githubId;
+    private Integer githubId;
     private String githubLogin;
 
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTO.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTO.java
@@ -32,7 +32,7 @@ public class RosterStudentDTO {
     private String email;
 
     private long userId;
-    private int userGithubId;
+    private Integer userGithubId;
     private String userGithubLogin;
 
     @Enumerated(EnumType.STRING)
@@ -44,8 +44,6 @@ public class RosterStudentDTO {
 
     public static RosterStudentDTO from(RosterStudent student) {
         long userId = student.getUser() != null ? student.getUser().getId() : 0;
-        int userGithubId = student.getUser() != null ? student.getUser().getGithubId() : 0;
-        String userGithubLogin = student.getUser() != null ? student.getUser().getGithubLogin() : "";
         
         return RosterStudentDTO.builder()
                 .id(student.getId())
@@ -55,8 +53,8 @@ public class RosterStudentDTO {
                 .lastName(student.getLastName())
                 .email(student.getEmail())
                 .userId(userId)
-                .userGithubId(userGithubId)
-                .userGithubLogin(userGithubLogin)
+                .userGithubId(student.getGithubId())
+                .userGithubLogin(student.getGithubLogin())
                 .rosterStatus(student.getRosterStatus())
                 .orgStatus(student.getOrgStatus())
                 .build();

--- a/src/test/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTOTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTOTests.java
@@ -22,8 +22,6 @@ public class RosterStudentDTOTests {
 
         User user = User.builder().build();
         user.setId(2L);
-        user.setGithubId(12345);
-        user.setGithubLogin("testuser");
 
         RosterStudent rosterStudent = new RosterStudent();
         rosterStudent.setId(3L);
@@ -31,6 +29,8 @@ public class RosterStudentDTOTests {
         rosterStudent.setStudentId("U123456");
         rosterStudent.setFirstName("John");
         rosterStudent.setLastName("Doe");
+        rosterStudent.setGithubId(12345);
+        rosterStudent.setGithubLogin("testuser");
         rosterStudent.setEmail("johndoe@example.com");
         rosterStudent.setUser(user);
         rosterStudent.setRosterStatus(RosterStatus.ROSTER);
@@ -67,6 +67,8 @@ public class RosterStudentDTOTests {
         rosterStudent.setFirstName("John");
         rosterStudent.setLastName("Doe");
         rosterStudent.setEmail("johndoe@example.com");
+        rosterStudent.setGithubId(12345);
+        rosterStudent.setGithubLogin("testuser");
         rosterStudent.setUser(null);
         rosterStudent.setRosterStatus(RosterStatus.ROSTER);
         rosterStudent.setOrgStatus(OrgStatus.NONE);
@@ -82,8 +84,8 @@ public class RosterStudentDTOTests {
         assertEquals("Doe", dto.getLastName());
         assertEquals("johndoe@example.com", dto.getEmail());
         assertEquals(0, dto.getUserId());
-        assertEquals(0, dto.getUserGithubId());
-        assertEquals("", dto.getUserGithubLogin());
+        assertEquals(12345, dto.getUserGithubId());
+        assertEquals("testuser", dto.getUserGithubLogin());
         assertEquals(RosterStatus.ROSTER, dto.getRosterStatus());
         assertEquals(OrgStatus.NONE, dto.getOrgStatus());
 

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOServiceTests.java
@@ -43,8 +43,6 @@ public class RosterStudentDTOServiceTests {
 
         User user = User.builder().build();
         user.setId(2L);
-        user.setGithubId(12345);
-        user.setGithubLogin("testuser");
 
         RosterStudent rosterStudent = new RosterStudent();
         rosterStudent.setId(3L);
@@ -53,6 +51,8 @@ public class RosterStudentDTOServiceTests {
         rosterStudent.setFirstName("John");
         rosterStudent.setLastName("Doe");
         rosterStudent.setEmail("johndoe@example.com");
+        rosterStudent.setGithubId(12345);
+        rosterStudent.setGithubLogin("testuser");
         rosterStudent.setUser(user);
         rosterStudent.setRosterStatus(RosterStatus.ROSTER);
         rosterStudent.setOrgStatus(OrgStatus.NONE);


### PR DESCRIPTION
In this PR, I replace RosterStudent and RosterStudentDTO's primitive githubId int with Integer, in order to allow null values in the database.

I will add an issue to do the same for Users so that there is parity, as there is not enough time to do so right now.

Deployed to https://frontiers-daniel.dokku-00.cs.ucsb.edu/