### PR TITLE
Fixing the OpenSSL Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 *.pem
 pkcs8.key
+*.key
 
 ## emacs ##
 *~

--- a/docs/github-app-setup-dokku.md
+++ b/docs/github-app-setup-dokku.md
@@ -68,7 +68,7 @@ This will download a private key to your computer.
 Next, we will switch the standard of the key we just downloaded so Java can understand it.
 To do so, open a terminal in the folder the key is in, and run the following command, replacing `<file-name>` with the name of the key.
 ```bash
-openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in <file-name> -out pkcs8.key
+./keyconvert.sh <file-name>
 ```
 
 Next, we're going to take the output of this newly created file and set it as an environmental variable on Dokku. To do so, output the file into your terminal with the following command:

--- a/docs/github-app-setup-localhost.md
+++ b/docs/github-app-setup-localhost.md
@@ -62,7 +62,7 @@ This will download a private key to your computer. Move this file into the repos
 Next, we will switch the standard of the key we just downloaded so Java can understand it.
 To do so, open a terminal in the repository folder, and run the following command, replacing `<file-name>` with the name of the key.
 ```bash
-openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in <file-name> -out pkcs8.key
+./keyconvert.sh <file-name>
 ```
 
 Next, create a copy of `secrets.yaml.EXAMPLE` with the following command:

--- a/keyconvert.sh
+++ b/keyconvert.sh
@@ -1,0 +1,5 @@
+if [ -f "$1" ]; then
+openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in $1 -out pkcs8.key
+else
+echo "$1 does not exist"
+fi

--- a/keyconvert.sh
+++ b/keyconvert.sh
@@ -1,5 +1,10 @@
 if [ -f "$1" ]; then
+if openssl rsa -in $1 --noout -check > /dev/null 2>&1; then
 openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in $1 -out pkcs8.key
+echo "successfully converted key"
+else
+echo "not a valid rsa key"
+fi
 else
 echo "$1 does not exist"
 fi


### PR DESCRIPTION
In this PR, I add the `./keyconvert.sh` script which ensures that the key the script is run on exists, as the `openssl` command will output a key whether or not there is an input.

I add all `.pem` and `.key` files to gitignore, and update the directions to match the new script.