### PR TITLE
pc - Student/Staff facing course table

### DIFF
--- a/frontend/src/fixtures/coursesFixtures.js
+++ b/frontend/src/fixtures/coursesFixtures.js
@@ -25,6 +25,57 @@ const coursesFixtures = {
       school: "UCSB",
     },
   ],
+  oneCourseWithEachStatus: [
+    {
+      id: 1,
+      courseName: "CMPSC 156",
+      term: "Spring 2025",
+      school: "UCSB",
+      status: "Pending",
+    },
+    {
+      id: 2,
+      courseName: "CPTS 489",
+      term: "Fall 2020",
+      school: "WSU",
+      status: "Join Course",
+    },
+    {
+      id: 3,
+      courseName: "CMPSC 156",
+      term: "Fall 2025",
+      school: "UCSB",
+      status: "Invited",
+    },
+    {
+      id: 4,
+      courseName: "CMPSC 156",
+      term: "Spring 2026",
+      school: "UCSB",
+      status: "Member",
+    },
+    {
+      id: 5,
+      courseName: "CMPSC 148",
+      term: "Spring 2026",
+      school: "UCSB",
+      status: "Owner",
+    },
+    {
+      id: 6,
+      courseName: "CMPSC 156",
+      term: "Fall 2026",
+      school: "UCSB",
+      status: "Error",
+    },
+    {
+      id: 7,
+      courseName: "CMPSC 156",
+      term: "Fall 2026",
+      school: "UCSB",
+      status: "Unknown Status",
+    },
+  ],
 };
 
 export default coursesFixtures;

--- a/frontend/src/main/components/Courses/AdminCoursesTable.js
+++ b/frontend/src/main/components/Courses/AdminCoursesTable.js
@@ -47,7 +47,7 @@ export default function AdminCoursesTable({
       "Install Github App",
       "primary",
       installCallback,
-      "CoursesTable",
+      "AdminCoursesTable",
     ),
   ];
   const columnsToDisplay = showInstallButton ? buttonColumns : columns;
@@ -55,7 +55,7 @@ export default function AdminCoursesTable({
     <OurTable
       data={courses}
       columns={columnsToDisplay}
-      testid={"CoursesTable"}
+      testid={"AdminCoursesTable"}
     />
   );
 }

--- a/frontend/src/main/components/Courses/AdminCoursesTable.js
+++ b/frontend/src/main/components/Courses/AdminCoursesTable.js
@@ -27,7 +27,7 @@ const columns = [
   },
 ];
 
-export default function CoursesTable({
+export default function AdminCoursesTable({
   courses,
   showInstallButton = false,
   storybook = false,

--- a/frontend/src/main/components/Courses/CoursesTable.js
+++ b/frontend/src/main/components/Courses/CoursesTable.js
@@ -1,0 +1,72 @@
+import OurTable from "main/components/OurTable";
+import { Button } from "react-bootstrap";
+
+const columns = [
+  {
+    Header: "id",
+    accessor: "id", // accessor is the "key" in the data
+  },
+  {
+    Header: "Course Name",
+    accessor: "courseName",
+  },
+  {
+    Header: "Term",
+    accessor: "term",
+  },
+  {
+    Header: "School",
+    accessor: "school",
+  },
+];
+
+export default function CoursesTable({ courses, storybook = false }) {
+  const joinCallback = (cell) => {
+    // TODO: Implement the join functionality here
+    if (storybook) {
+      window.alert(
+        `Join callback invoked for course with id: ${cell.row.values.id}`,
+      );
+      return;
+    }
+  };
+
+  const columnsWithStatus = [
+    ...columns,
+    {
+      Header: "Status",
+      accessor: "status",
+      Cell: ({ cell }) => {
+        if (cell.value === "Pending") {
+          return <span style={{ color: "orange" }}>{cell.value}</span>;
+        } else if (cell.value === "Join Course") {
+          return (
+            <Button
+              variant={"primary"}
+              onClick={() => joinCallback(cell)}
+              data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
+            >
+              Join Course
+            </Button>
+          );
+        } else if (cell.value === "Invited") {
+          return <span style={{ color: "green" }}>{cell.value}</span>;
+        } else if (cell.value === "Member") {
+          return <span style={{ color: "blue" }}>{cell.value}</span>;
+        } else if (cell.value === "Owner") {
+          return <span style={{ color: "purple" }}>{cell.value}</span>;
+        } else if (cell.value === "Error") {
+          return <span style={{ color: "red" }}>{cell.value}</span>;
+        }
+        return <span>{cell.value}</span>;
+      },
+    },
+  ];
+  return (
+    <OurTable
+      data={courses}
+      columns={columnsWithStatus}
+      testid={"CoursesTable"}
+    />
+  );
+}

--- a/frontend/src/main/pages/Courses/CoursesIndexPage.js
+++ b/frontend/src/main/pages/Courses/CoursesIndexPage.js
@@ -2,7 +2,7 @@ import React from "react";
 import { useBackend } from "main/utils/useBackend";
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import CoursesTable from "main/components/Courses/CoursesTable";
+import AdminCoursesTable from "main/components/Courses/AdminCoursesTable";
 import { useCurrentUser, hasRole } from "main/utils/currentUser";
 
 export default function CoursesIndexPage() {
@@ -24,7 +24,7 @@ export default function CoursesIndexPage() {
     <BasicLayout>
       <div className="pt-2">
         <h1>Courses</h1>
-        <CoursesTable
+        <AdminCoursesTable
           courses={courses}
           showInstallButton={hasRole(currentUser, "ROLE_ADMIN")}
         />

--- a/frontend/src/stories/components/Courses/AdminCoursesTable.stories.js
+++ b/frontend/src/stories/components/Courses/AdminCoursesTable.stories.js
@@ -1,15 +1,15 @@
 import React from "react";
 
-import CoursesTable from "main/components/Courses/CoursesTable";
+import AdminCoursesTable from "main/components/Courses/AdminCoursesTable";
 import coursesFixtures from "fixtures/coursesFixtures";
 
 export default {
-  title: "components/Courses/CoursesTable",
-  component: CoursesTable,
+  title: "components/Courses/AdminCoursesTable",
+  component: AdminCoursesTable,
 };
 
 const Template = (args) => {
-  return <CoursesTable {...args} />;
+  return <AdminCoursesTable {...args} />;
 };
 
 export const Empty = Template.bind({});

--- a/frontend/src/stories/components/Courses/CoursesTable.stories.js
+++ b/frontend/src/stories/components/Courses/CoursesTable.stories.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+import CoursesTable from "main/components/Courses/CoursesTable";
+import coursesFixtures from "fixtures/coursesFixtures";
+
+export default {
+  title: "components/Courses/CoursesTable",
+  component: CoursesTable,
+};
+
+const Template = (args) => {
+  return <CoursesTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+export const ManyCourses = Template.bind({});
+
+Empty.args = {
+  courses: [],
+};
+Empty.parameters = {};
+
+ManyCourses.args = {
+  courses: coursesFixtures.oneCourseWithEachStatus,
+  storybook: true,
+};
+ManyCourses.parameters = {};

--- a/frontend/src/tests/components/Courses/AdminCoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/AdminCoursesTable.test.js
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import coursesFixtures from "fixtures/coursesFixtures";
-import CoursesTable from "main/components/Courses/CoursesTable";
+import AdminCoursesTable from "main/components/Courses/AdminCoursesTable";
 import { BrowserRouter } from "react-router-dom";
 
 window.alert = jest.fn();
@@ -9,7 +9,7 @@ describe("CoursesTable tests", () => {
   test("Has the expected column headers and content", () => {
     render(
       <BrowserRouter>
-        <CoursesTable courses={coursesFixtures.threeCourses} />
+        <AdminCoursesTable courses={coursesFixtures.threeCourses} />
       </BrowserRouter>,
     );
 
@@ -67,7 +67,7 @@ describe("CoursesTable tests", () => {
   test("Calls the navigate callback when the button is pressed", () => {
     render(
       <BrowserRouter>
-        <CoursesTable
+        <AdminCoursesTable
           courses={coursesFixtures.threeCourses}
           showInstallButton={true}
         />
@@ -88,7 +88,7 @@ describe("CoursesTable tests", () => {
   test("Calls window.alert when the button is pressed on storybook", async () => {
     render(
       <BrowserRouter>
-        <CoursesTable
+        <AdminCoursesTable
           courses={coursesFixtures.threeCourses}
           showInstallButton={true}
           storybook={true}
@@ -114,7 +114,7 @@ describe("CoursesTable tests", () => {
   test("Tests that the default is to NOT show the buttons for installation", () => {
     render(
       <BrowserRouter>
-        <CoursesTable courses={coursesFixtures.threeCourses} />
+        <AdminCoursesTable courses={coursesFixtures.threeCourses} />
       </BrowserRouter>,
     );
 
@@ -130,7 +130,7 @@ describe("CoursesTable tests", () => {
   test("Tests that we don't see the buttons when we specify false", () => {
     render(
       <BrowserRouter>
-        <CoursesTable
+        <AdminCoursesTable
           courses={coursesFixtures.threeCourses}
           showInstallButton={false}
         />
@@ -149,7 +149,7 @@ describe("CoursesTable tests", () => {
   test("Tests that storybook is explictly false all still works as expected", async () => {
     render(
       <BrowserRouter>
-        <CoursesTable
+        <AdminCoursesTable
           courses={coursesFixtures.threeCourses}
           showInstallButton={true}
           storybook={false}

--- a/frontend/src/tests/components/Courses/AdminCoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/AdminCoursesTable.test.js
@@ -5,7 +5,20 @@ import { BrowserRouter } from "react-router-dom";
 
 window.alert = jest.fn();
 
-describe("CoursesTable tests", () => {
+describe("AdminCoursesTable tests", () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // Remove window.location and mock it
+    delete window.location;
+    window.location = { href: "" }; // Minimal mock
+  });
+
+  afterEach(() => {
+    // Restore original window.location
+    window.location = originalLocation;
+  });
+
   test("Has the expected column headers and content", () => {
     render(
       <BrowserRouter>
@@ -29,7 +42,7 @@ describe("CoursesTable tests", () => {
       "term",
       "school",
     ];
-    const testId = "CoursesTable";
+    const testId = "AdminCoursesTable";
 
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);
@@ -75,7 +88,7 @@ describe("CoursesTable tests", () => {
     );
 
     const button = screen.getByTestId(
-      "CoursesTable-cell-row-0-col-Install Github App-button",
+      "AdminCoursesTable-cell-row-0-col-Install Github App-button",
     );
     expect(button).toBeInTheDocument();
     expect(button).toHaveTextContent("Install Github App");
@@ -97,7 +110,7 @@ describe("CoursesTable tests", () => {
     );
 
     const button = screen.getByTestId(
-      "CoursesTable-cell-row-0-col-Install Github App-button",
+      "AdminCoursesTable-cell-row-0-col-Install Github App-button",
     );
     expect(button).toBeInTheDocument();
     expect(button).toHaveTextContent("Install Github App");
@@ -120,7 +133,7 @@ describe("CoursesTable tests", () => {
 
     // Check that the button is NOT in the document
     const button = screen.queryByTestId(
-      "CoursesTable-cell-row-0-col-Install Github App-button",
+      "AdminCoursesTable-cell-row-0-col-Install Github App-button",
     );
     expect(button).not.toBeInTheDocument();
     // expect that the mocked window.alert function is not called
@@ -139,7 +152,7 @@ describe("CoursesTable tests", () => {
 
     // Check that the button is NOT in the document
     const button = screen.queryByTestId(
-      "CoursesTable-cell-row-0-col-Install Github App-button",
+      "AdminCoursesTable-cell-row-0-col-Install Github App-button",
     );
     expect(button).not.toBeInTheDocument();
     // expect that the mocked window.alert function is not called
@@ -159,7 +172,7 @@ describe("CoursesTable tests", () => {
 
     // Check that the button is NOT in the document
     const button = screen.getByTestId(
-      "CoursesTable-cell-row-0-col-Install Github App-button",
+      "AdminCoursesTable-cell-row-0-col-Install Github App-button",
     );
     expect(button).toBeInTheDocument();
     expect(button).toHaveTextContent("Install Github App");
@@ -169,5 +182,7 @@ describe("CoursesTable tests", () => {
     await waitFor(() => {
       expect(window.alert).not.toHaveBeenCalled();
     });
+
+    expect(window.location.href).toBe("/api/courses/redirect?courseId=1");
   });
 });

--- a/frontend/src/tests/components/Courses/CoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/CoursesTable.test.js
@@ -1,0 +1,141 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import coursesFixtures from "fixtures/coursesFixtures";
+import CoursesTable from "main/components/Courses/CoursesTable";
+import { BrowserRouter } from "react-router-dom";
+
+window.alert = jest.fn();
+
+describe("CoursesTable tests", () => {
+  test("Has the expected column headers and content", () => {
+    render(
+      <BrowserRouter>
+        <CoursesTable courses={coursesFixtures.oneCourseWithEachStatus} />
+      </BrowserRouter>,
+    );
+
+    const expectedHeaders = ["id", "Course Name", "Term", "School", "Status"];
+    const expectedFields = ["id", "courseName", "term", "school", "status"];
+    const testId = "CoursesTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-courseName`),
+    ).toHaveTextContent("CMPSC 156");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-term`),
+    ).toHaveTextContent("Spring 2025");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-school`),
+    ).toHaveTextContent("UCSB");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-status`),
+    ).toHaveTextContent("Pending");
+
+    const pending = screen.getByText("Pending");
+    expect(pending).toBeInTheDocument();
+    expect(pending).toHaveStyle("color: orange");
+
+    const joinCourse = screen.getByText("Join Course");
+    expect(joinCourse).toBeInTheDocument();
+    expect(joinCourse).toHaveAttribute("class", "btn btn-primary");
+
+    const invited = screen.getByText("Invited");
+    expect(invited).toBeInTheDocument();
+    expect(invited).toHaveStyle("color: green");
+
+    const member = screen.getByText("Member");
+    expect(member).toBeInTheDocument();
+    expect(member).toHaveStyle("color: blue");
+
+    const owner = screen.getByText("Owner");
+    expect(owner).toBeInTheDocument();
+    expect(owner).toHaveStyle("color: purple");
+
+    const error = screen.getByText("Error");
+    expect(error).toBeInTheDocument();
+    expect(error).toHaveStyle("color: red");
+
+    const unknownStatus = screen.getByText("Unknown Status");
+    expect(unknownStatus).toBeInTheDocument();
+    expect(unknownStatus).not.toHaveStyle("color: red");
+
+    // expect that the mocked window.alert function is not called
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  test("Does not call window.alert in default case", () => {
+    render(
+      <BrowserRouter>
+        <CoursesTable courses={coursesFixtures.oneCourseWithEachStatus} />
+      </BrowserRouter>,
+    );
+
+    const button = screen.getByTestId(
+      "CoursesTable-cell-row-1-col-status-button",
+    );
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent("Join Course");
+    expect(button).toHaveAttribute("class", "btn btn-primary");
+
+    fireEvent.click(button);
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  test("Calls window.alert when the button is pressed on storybook", async () => {
+    render(
+      <BrowserRouter>
+        <CoursesTable
+          courses={coursesFixtures.oneCourseWithEachStatus}
+          storybook={true}
+        />
+      </BrowserRouter>,
+    );
+
+    const button = screen.getByTestId(
+      "CoursesTable-cell-row-1-col-status-button",
+    );
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent("Join Course");
+    expect(button).toHaveAttribute("class", "btn btn-primary");
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledTimes(1);
+    });
+    expect(window.alert).toHaveBeenCalledWith(
+      "Join callback invoked for course with id: 2",
+    );
+  });
+
+  test("Does not call window.alert when storybook is explicitly false", () => {
+    render(
+      <BrowserRouter>
+        <CoursesTable
+          courses={coursesFixtures.oneCourseWithEachStatus}
+          storybook={false}
+        />
+      </BrowserRouter>,
+    );
+
+    const button = screen.getByTestId(
+      "CoursesTable-cell-row-1-col-status-button",
+    );
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent("Join Course");
+    expect(button).toHaveAttribute("class", "btn btn-primary");
+
+    fireEvent.click(button);
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
@@ -23,7 +23,7 @@ jest.mock("react-toastify", () => {
 describe("CoursesIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const testId = "CoursesTable";
+  const testId = "AdminCoursesTable";
 
   const setupAdminUser = () => {
     axiosMock.reset();
@@ -99,7 +99,7 @@ describe("CoursesIndexPage tests", () => {
 
     // expect that the button for "Install Github App" is present
     const button = screen.getByTestId(
-      "CoursesTable-cell-row-0-col-Install Github App-button",
+      "AdminCoursesTable-cell-row-0-col-Install Github App-button",
     );
     expect(button).toBeInTheDocument();
     expect(button).toHaveTextContent("Install Github App");
@@ -153,7 +153,7 @@ describe("CoursesIndexPage tests", () => {
 
     // expect that the button for "Install Github App" is not present
     const button = screen.queryByTestId(
-      "CoursesTable-cell-row-0-col-Install Github App-button",
+      "AdminCoursesTable-cell-row-0-col-Install Github App-button",
     );
     expect(button).not.toBeInTheDocument();
   });


### PR DESCRIPTION
Closes #70 

This PR supports the user stories:
* As a student, 
* I can see the courses for which I appear on the roster, and my status in each course
* So that I can click to join the github organization for courses where I haven't done that yet.

* As a staff member
* I can see the courses where I've been listed as a staff member, and my status in those github orgs, * So that I can click to join the github orgs.

The new React component in this PR will be useful in building that page, which will likely become the new default home page after logging in to the app.

In this PR we:
* rename the existing React component `CoursesTable` to `AdminCoursesTable`
  * This one is used only for pages that are Admin/Instructor facing
* create a new React component called `CoursesTable` that is used for student and staff facing features.

This is part of an epic that will enable students and staff to join a course (i.e. see which courses they appear on the roster of, and click to join the course organization if they are not already a member.)

## Storybook 

* Existing `CourseTable` component (renamed to `AdminCourseTable`): https://67da6ee1a47bfcdda4700814-vphmzytqfx.chromatic.com/?path=/story/components-courses-admincoursestable--three-courses-with-install-button
* New CourseTable component: https://67da6ee1a47bfcdda4700814-vphmzytqfx.chromatic.com/?path=/story/components-courses-coursestable--many-courses

Note that in the new CourseTable, the join button is only shown for courses that would have a status that is suitable to be joined.

The status names were adapted from the ones described in Issue #70.   It may be necessary to modify either the API endpoint that returns the statuses, and/or the table so that these match.   


