### PR TITLE
Enabling Admin Role by Email

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/AdminRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/AdminRepository.java
@@ -15,4 +15,6 @@ public interface AdminRepository extends CrudRepository<Admin, String> {
    * @return Optional of Admin (empty if not found)
    */
   Optional<Admin> findByEmail(String email);
-} 
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/GoogleSignInServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/GoogleSignInServiceImpl.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.frontiers.services;
 
 import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,12 +21,12 @@ public class GoogleSignInServiceImpl extends OidcUserService implements GoogleSi
 
     private final UserRepository userRepository;
 
-    @Value("${app.admin.emails}")
-    private final List<String> adminEmails = new ArrayList<>();
+    private final AdminRepository adminEmails;
 
     @Autowired
-    public GoogleSignInServiceImpl(UserRepository userRepository) {
+    public GoogleSignInServiceImpl(UserRepository userRepository, AdminRepository adminRepository) {
         this.userRepository = userRepository;
+        this.adminEmails = adminRepository;
     }
 
     @Override
@@ -42,7 +43,7 @@ public class GoogleSignInServiceImpl extends OidcUserService implements GoogleSi
             User user = currentUser.get();
             if (user.getAdmin()) {
                 authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
-            } else if (adminEmails.contains(user.getEmail())) {
+            } else if (adminEmails.existsByEmail(user.getEmail())) {
                 authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
                 user.setAdmin(true);
                 changed = true;
@@ -82,7 +83,7 @@ public class GoogleSignInServiceImpl extends OidcUserService implements GoogleSi
                     .givenName(oidcUser.getGivenName())
                     .pictureUrl(oidcUser.getPicture())
                     .build();
-            if (adminEmails.contains(oidcUser.getEmail())) {
+            if (adminEmails.existsByEmail(oidcUser.getEmail())) {
                 newUser.setAdmin(true);
                 authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
             } else {


### PR DESCRIPTION
In this PR, I enable adding admins by email, building off of team 7's work on managing admin emails.

I achieve this by replacing the static `ADMIN_EMAILS` variable in the GoogleSignInServiceImpl with the AdminRepository, which has existsByEmail added as a method.

Currently deployed to https://proj-frontiers-division7.dokku-00.cs.ucsb.edu/