### PR TITLE
Flattening the Role Hierarchy on the Frontend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/services/CurrentUserServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/CurrentUserServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -33,6 +34,8 @@ public class CurrentUserServiceImpl extends CurrentUserService {
 
   @Autowired
   GrantedAuthoritiesService grantedAuthoritiesService;
+  @Autowired
+  private RoleHierarchy roleHierarchy;
 
   /**
    * This method returns the current user as a User object.
@@ -82,6 +85,6 @@ public class CurrentUserServiceImpl extends CurrentUserService {
    * @return a collection of roles
    */
   public Collection<? extends GrantedAuthority> getRoles() {
-   return grantedAuthoritiesService.getGrantedAuthorities();
+    return roleHierarchy.getReachableGrantedAuthorities(grantedAuthoritiesService.getGrantedAuthorities());
   }
 }


### PR DESCRIPTION
In this PR, I flatten the role hierarchy on the frontend so that we don't have to transmit or update the hierarchy on the frontend.

Merge after #150.

Currently deployed to https://proj-frontiers-division7.dokku-00.cs.ucsb.edu/

Despite solely being tagged with the admin role, the following roles now appear on the frontend:
![image](https://github.com/user-attachments/assets/4d408cdd-7944-4b3b-b451-270b7669502e)