### PR TITLE
Killing The Flaky Job Test

### DIFF
--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/JobsControllerDetailedTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/JobsControllerDetailedTests.java
@@ -372,6 +372,6 @@ public class JobsControllerDetailedTests extends ControllerTestCase {
     // assert
     String responseString = response.getResponse().getContentAsString();
     Job jobReturned = objectMapper.readValue(responseString, Job.class);
-    MatcherAssert.assertThat(jobReturned.getStatus(), Matchers.anyOf(Matchers.is("completed"), Matchers.is("running")));
+    MatcherAssert.assertThat(jobReturned.getStatus(), Matchers.anyOf(Matchers.is("complete"), Matchers.is("running")));
   }
 }


### PR DESCRIPTION
In this PR, I finally kill the flaky job test once and for all by appropriately attributing the status to "complete" rather than "completed"
Merge before #149.