### PR TITLE
Removing Org Name from the Course POST Endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -79,7 +79,6 @@ public class CoursesController extends ApiController {
     /**
      * This method creates a new Course.
      * 
-     * @param orgName    the name of the organization
      * @param courseName the name of the course
      * @param term       the term of the course
      * @param school     the school of the course
@@ -90,14 +89,12 @@ public class CoursesController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public Course postCourse(
-            @Parameter(name = "orgName") @RequestParam String orgName,
             @Parameter(name = "courseName") @RequestParam String courseName,
             @Parameter(name = "term") @RequestParam String term,
             @Parameter(name = "school") @RequestParam String school) {
         // get current date right now and set status to pending
         CurrentUser currentUser = getCurrentUser();
         Course course = Course.builder()
-                .orgName(orgName)
                 .courseName(courseName)
                 .term(term)
                 .school(school)

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
@@ -84,7 +84,6 @@ public class CoursesControllerTests extends ControllerTestCase {
                 // arrange
                 Course course = Course.builder()
                                 .courseName("CS156")
-                                .orgName("ucsb-cs156-s25")
                                 .term("S25")
                                 .school("UCSB")
                                 .creator(user)
@@ -96,7 +95,6 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 MvcResult response = mockMvc.perform(post("/api/courses/post")
                                 .with(csrf())
-                                .param("orgName", "ucsb-cs156-s25")
                                 .param("courseName", "CS156")
                                 .param("term", "S25")
                                 .param("school", "UCSB"))
@@ -124,14 +122,12 @@ public class CoursesControllerTests extends ControllerTestCase {
                 // arrange
                 Course course1 = Course.builder()
                                 .courseName("CS156")
-                                .orgName("ucsb-cs156-s25")
                                 .term("S25")
                                 .school("UCSB")
                                 .build();
 
                 Course course2 = Course.builder()
                                 .courseName("CS148")
-                                .orgName("ucsb-cs148-s25")
                                 .term("S25")
                                 .school("UCSB")
                                 .build();


### PR DESCRIPTION
The Organization Name on GitHub is autofilled when the course is linked to a GitHub organization. As a result, it is not necessary to input the organization name on creation.