### PR TITLE
Fixing JwtService

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/services/JwtService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/JwtService.java
@@ -85,7 +85,7 @@ public class JwtService {
             throw new NoLinkedOrganizationException(course.getCourseName());
         }else {
             String token = getJwt();
-            String ENDPOINT = "https://api.github.com/app/installations/" + course.getOrgName() + "/access_tokens";
+            String ENDPOINT = "https://api.github.com/app/installations/" + course.getInstallationId() + "/access_tokens";
             HttpHeaders headers = new HttpHeaders();
             headers.add("Authorization", "Bearer " + token);
             headers.add("Accept", "application/vnd.github+json");

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/JwtServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/JwtServiceTests.java
@@ -100,7 +100,7 @@ public class JwtServiceTests {
                 }
                 """, expectedToken);
         Course course = Course.builder().installationId("03112004").orgName("ucsb-cs156").build();
-        String expectedURL = "https://api.github.com/app/installations/"+course.getOrgName()+"/access_tokens";
+        String expectedURL = "https://api.github.com/app/installations/"+course.getInstallationId()+"/access_tokens";
         mockRestServiceServer.expect(requestTo(expectedURL))
                 .andExpect(header("Accept", "application/vnd.github+json"))
                 .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))


### PR DESCRIPTION
At some point, GitHub transitioned to using installation IDs rather than org names for generating tokens.

This updates JWTService to match the new standard.