### PR TITLE
JOB - Async job that updates all student github org membership statuses

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/JobsController.java
@@ -5,9 +5,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.ucsb.cs156.frontiers.entities.Job;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.jobs.MembershipAuditJob;
 import edu.ucsb.cs156.frontiers.jobs.TestJob;
 import edu.ucsb.cs156.frontiers.jobs.UpdateAllJob;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.JobsRepository;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
 import edu.ucsb.cs156.frontiers.services.UpdateUserService;
 import edu.ucsb.cs156.frontiers.services.jobs.JobService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,6 +41,12 @@ public class JobsController extends ApiController {
   @Autowired private UpdateUserService updateUserService; 
   
   @Autowired ObjectMapper mapper;
+    @Autowired
+    private RosterStudentRepository rosterStudentRepository;
+    @Autowired
+    private CourseRepository courseRepository;
+    @Autowired
+    private OrganizationMemberService organizationMemberService;
 
   @Operation(summary = "List all jobs")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -106,6 +116,19 @@ public class JobsController extends ApiController {
     UpdateAllJob job = 
         UpdateAllJob.builder()
             .updateUserService(updateUserService) 
+            .build();
+    return jobService.runAsJob(job);
+  }
+
+  @Operation(summary = "Launch Audit All Courses Job")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/launch/auditAllCourses")
+  public Job launchAuditAllCoursesJob() {
+
+    MembershipAuditJob job = MembershipAuditJob.builder()
+            .rosterStudentRepository(rosterStudentRepository)
+            .courseRepository(courseRepository)
+            .organizationMemberService(organizationMemberService)
             .build();
     return jobService.runAsJob(job);
   }

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
@@ -31,6 +31,7 @@ public class MembershipAuditJob implements JobContextConsumer {
                 for (OrgMember member : members) {
                     RosterStudent student = rosterStudents.stream().filter(s -> s.getGithubId()!=null && s.getGithubId().equals(member.getGithubId())).findFirst().orElse(null);
                     if (student != null) {
+                        ctx.log("Student found: " + student.toString());
                         student.setOrgStatus(OrgStatus.MEMBER);
                         rosterStudentRepository.save(student);
                     }

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
@@ -28,7 +28,13 @@ public class MembershipAuditJob implements JobContextConsumer {
                 Iterable<OrgMember> members = organizationMemberService.getOrganizationMembers(course);
                 List<RosterStudent> rosterStudents = course.getRosterStudents();
                 for (OrgMember member : members) {
-                    RosterStudent student = rosterStudents.stream().filter(s -> s.getGithubId().equals(member.getGithubId())).findFirst().orElse(null);
+                    RosterStudent student = rosterStudents.stream().filter(s -> {
+                        if(s.getGithubId() == null){
+                            return false;
+                        }else{
+                            return s.getGithubId().equals(member.getGithubId());
+                        }
+                    }).findFirst().orElse(null);
                     if (student != null) {
                         student.setOrgStatus(OrgStatus.MEMBER);
                         rosterStudentRepository.save(student);

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
@@ -28,13 +28,7 @@ public class MembershipAuditJob implements JobContextConsumer {
                 Iterable<OrgMember> members = organizationMemberService.getOrganizationMembers(course);
                 List<RosterStudent> rosterStudents = course.getRosterStudents();
                 for (OrgMember member : members) {
-                    RosterStudent student = rosterStudents.stream().filter(s -> {
-                        if(s.getGithubId() == null){
-                            return false;
-                        }else{
-                            return s.getGithubId().equals(member.getGithubId());
-                        }
-                    }).findFirst().orElse(null);
+                    RosterStudent student = rosterStudents.stream().filter(s -> s.getGithubId()!=null && s.getGithubId().equals(member.getGithubId())).findFirst().orElse(null);
                     if (student != null) {
                         student.setOrgStatus(OrgStatus.MEMBER);
                         rosterStudentRepository.save(student);

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
@@ -24,13 +24,15 @@ public class MembershipAuditJob implements JobContextConsumer {
         ctx.log("Auditing membership for each course with an attached GitHub Organization...");
         Iterable<Course> courses = courseRepository.findAll();
         for(Course course : courses){
-            Iterable<OrgMember> members = organizationMemberService.getOrganizationMembers(course);
-            List<RosterStudent> rosterStudents = course.getRosterStudents();
-            for (OrgMember member : members) {
-                RosterStudent student = rosterStudents.stream().filter(s -> s.getGithubId().equals(member.getGithubId())).findFirst().orElse(null);
-                if (student!=null) {
-                    student.setOrgStatus(OrgStatus.MEMBER);
-                    rosterStudentRepository.save(student);
+            if (course.getOrgName() != null && course.getInstallationId() != null) {
+                Iterable<OrgMember> members = organizationMemberService.getOrganizationMembers(course);
+                List<RosterStudent> rosterStudents = course.getRosterStudents();
+                for (OrgMember member : members) {
+                    RosterStudent student = rosterStudents.stream().filter(s -> s.getGithubId().equals(member.getGithubId())).findFirst().orElse(null);
+                    if (student != null) {
+                        student.setOrgStatus(OrgStatus.MEMBER);
+                        rosterStudentRepository.save(student);
+                    }
                 }
             }
         }

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
@@ -26,6 +26,7 @@ public class MembershipAuditJob implements JobContextConsumer {
         for(Course course : courses){
             if (course.getOrgName() != null && course.getInstallationId() != null) {
                 Iterable<OrgMember> members = organizationMemberService.getOrganizationMembers(course);
+                ctx.log(members.toString());
                 List<RosterStudent> rosterStudents = course.getRosterStudents();
                 for (OrgMember member : members) {
                     RosterStudent student = rosterStudents.stream().filter(s -> s.getGithubId()!=null && s.getGithubId().equals(member.getGithubId())).findFirst().orElse(null);

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
@@ -52,6 +52,18 @@ public class OrganizationMemberService {
     */
     public Iterable<OrgMember> getOrganizationMembers(Course course) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
         String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/members?role=member";
+        return getOrganizationMembersWithRole(course, ENDPOINT);
+    }
+
+    /**
+    * This endpoint returns the list of **admins** for the organization. This is so that the roles are known for the return values.
+    */
+    public Iterable<OrgMember> getOrganizationAdmins(Course course) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+        String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/members?role=admin";
+        return getOrganizationMembersWithRole(course, ENDPOINT);
+    }
+
+    private Iterable<OrgMember> getOrganizationMembersWithRole(Course course, String ENDPOINT) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
         //happily stolen directly from GitHub: https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28
         Pattern pattern = Pattern.compile("(?<=<)([\\S]*)(?=>; rel=\"next\")");
         String token = jwtService.getInstallationToken(course);

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
@@ -46,8 +46,12 @@ public class OrganizationMemberService {
         this.restTemplate = builder.build();
     }
 
+
+    /**
+    * This endpoint returns the list of **members**, not admins for the organization. This is so that the roles are known for the return values.
+    */
     public Iterable<OrgMember> getOrganizationMembers(Course course) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
-        String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/members";
+        String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/members?role=member";
         //happily stolen directly from GitHub: https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28
         Pattern pattern = Pattern.compile("(?<=<)([\\S]*)(?=>; rel=\"next\")");
         String token = jwtService.getInstallationToken(course);

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/JobsControllerDetailedTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/JobsControllerDetailedTests.java
@@ -21,6 +21,7 @@ import edu.ucsb.cs156.frontiers.entities.User;
 import edu.ucsb.cs156.frontiers.jobs.UpdateAllJob;
 import edu.ucsb.cs156.frontiers.repositories.JobsRepository;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
 import edu.ucsb.cs156.frontiers.services.UpdateUserService;
 import edu.ucsb.cs156.frontiers.services.jobs.JobService;
 
@@ -71,6 +72,9 @@ public class JobsControllerDetailedTests extends ControllerTestCase {
 
   @Autowired
   ObjectMapper objectMapper;
+
+  @MockitoBean
+  OrganizationMemberService organizationMemberService;
 
   @WithMockUser(roles = { "ADMIN" })
   @Test

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/JobsControllerJobsTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/JobsControllerJobsTests.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,6 +32,7 @@ import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
 import edu.ucsb.cs156.frontiers.services.UpdateUserService;
 import edu.ucsb.cs156.frontiers.services.jobs.JobService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.test.web.servlet.MvcResult;
 
 
 /**
@@ -119,19 +121,22 @@ public class JobsControllerJobsTests extends ControllerTestCase {
         .status("started")
         .build();
 
+    String expectedResponse = objectMapper.writeValueAsString(jobStarted);
+
     when(jobService.runAsJob (any(MembershipAuditJob.class))).thenReturn(jobStarted);
 
 
     // act
-    mockMvc
+    MvcResult result = mockMvc
         .perform(post("/api/jobs/launch/auditAllCourses").with(csrf()))
         .andExpect(status().isOk())
         .andReturn();
 
     // assert
 
+    String response = result.getResponse().getContentAsString();
     verify(jobService, times(1)).runAsJob(any(MembershipAuditJob.class));
-
+      assertEquals(expectedResponse, response);
   }
 
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJobTests.java
@@ -64,7 +64,7 @@ public class MembershipAuditJobTests {
         RosterStudent student3 = RosterStudent.builder().studentId("banana").githubLogin("division9").githubId(123455).course(course2).build();
         RosterStudent student4 = RosterStudent.builder().studentId("apple").githubLogin("division10").githubId(123454).course(course2).build();
         RosterStudent student5 = RosterStudent.builder().studentId("orange").githubLogin(null).githubId(null).course(course2).build();
-        course2.setRosterStudents(List.of(student3, student4));
+        course2.setRosterStudents(List.of(student3, student4, student5));
         RosterStudent student1Updated = RosterStudent.builder().studentId("banana").githubLogin("division7").githubId(123456).course(course).orgStatus(OrgStatus.MEMBER).build();
         RosterStudent student2Updated = RosterStudent.builder().studentId("apple").githubLogin("division8").githubId(123457).course(course).orgStatus(OrgStatus.MEMBER).build();
         RosterStudent student3Updated = RosterStudent.builder().studentId("banana").githubLogin("division9").githubId(123455).course(course2).orgStatus(OrgStatus.MEMBER).build();

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJobTests.java
@@ -56,6 +56,9 @@ public class MembershipAuditJobTests {
         OrgMember orgMember3 = OrgMember.builder().githubId(123455).githubLogin("division9").build();
         OrgMember orgMember4 = OrgMember.builder().githubId(772).githubLogin("unmatched").build();
         List<OrgMember> secondCourse = List.of(orgMember3, orgMember4);
+
+        List<OrgMember> emptyAdmins = List.of();
+
         Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
         Course course2 = Course.builder().orgName("ucsb-cs156-f25").installationId("1235").build();
         Course course3 = Course.builder().build();
@@ -71,9 +74,16 @@ public class MembershipAuditJobTests {
         RosterStudent student1Updated = RosterStudent.builder().studentId("banana").githubLogin("division7").githubId(123456).course(course).orgStatus(OrgStatus.MEMBER).build();
         RosterStudent student2Updated = RosterStudent.builder().studentId("apple").githubLogin("division8").githubId(123457).course(course).orgStatus(OrgStatus.MEMBER).build();
         RosterStudent student3Updated = RosterStudent.builder().studentId("banana").githubLogin("division9").githubId(123455).course(course2).orgStatus(OrgStatus.MEMBER).build();
+        RosterStudent student4Updated = RosterStudent.builder().studentId("apple").githubLogin("division10").githubId(123454).course(course2).orgStatus(OrgStatus.NONE).build();
+        RosterStudent student5Updated = RosterStudent.builder().studentId("orange").githubLogin(null).githubId(null).course(course2).build();
+        RosterStudent student6Updated = RosterStudent.builder().studentId("grape").githubLogin(null).githubId(123455).course(course3).build();
+
+
 
         doReturn(orgMembers).when(organizationMemberService).getOrganizationMembers(eq(course));
         doReturn(secondCourse).when(organizationMemberService).getOrganizationMembers(eq(course2));
+        doReturn(emptyAdmins).when(organizationMemberService).getOrganizationAdmins(eq(course));
+        doReturn(emptyAdmins).when(organizationMemberService).getOrganizationAdmins(eq(course2));
         doReturn(List.of(course, course2, course3, course4)).when(courseRepository).findAll();
 
         var matchJob = spy(MembershipAuditJob.builder()
@@ -88,9 +98,10 @@ public class MembershipAuditJobTests {
                 Done""";
         assertEquals(expected, jobStarted.getLog());
 
-        verify(rosterStudentRepository, times(1)).save(eq(student1Updated));
-        verify(rosterStudentRepository, times(1)).save(eq(student2Updated));
-        verify(rosterStudentRepository, times(1)).save(eq(student3Updated));
+        // Verify that saveAll was called twice (once for each course with an org)
+        verify(rosterStudentRepository, atLeastOnce()).saveAll(eq(List.of(student1Updated, student2Updated)));
+        verify(rosterStudentRepository, atLeastOnce()).saveAll(eq(List.of(student3Updated, student4Updated, student5Updated, student6Updated)));
+        verify(rosterStudentRepository, times(2)).saveAll(any());
     }
 
 
@@ -99,10 +110,13 @@ public class MembershipAuditJobTests {
         OrgMember orgMember1 = OrgMember.builder().githubId(123455).githubLogin("unmatched-a").build();
         OrgMember orgMember2 = OrgMember.builder().githubId(772).githubLogin("unmatched-b").build();
         List<OrgMember> orgMembers = List.of(orgMember1, orgMember2);
+        List<OrgMember> emptyAdmins = List.of();
         Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
         RosterStudent student1 = RosterStudent.builder().studentId("banana").githubLogin("division7").githubId(123456).course(course).build();
         course.setRosterStudents(List.of(student1));
+        RosterStudent student1Updated = RosterStudent.builder().studentId("banana").githubLogin("division7").githubId(123456).course(course).orgStatus(OrgStatus.NONE).build();
         when(organizationMemberService.getOrganizationMembers(course)).thenReturn(orgMembers);
+        when(organizationMemberService.getOrganizationAdmins(course)).thenReturn(emptyAdmins);
         when(courseRepository.findAll()).thenReturn(List.of(course));
 
         var matchJob = spy(MembershipAuditJob.builder()
@@ -117,6 +131,41 @@ public class MembershipAuditJobTests {
                 Done""";
         assertEquals(expected, jobStarted.getLog());
 
-        verify(rosterStudentRepository, times(0)).save(any());
+        verify(rosterStudentRepository, times(1)).saveAll(eq(List.of(student1Updated)));
+    }
+
+    @Test
+    public void match_admin_students_correctly() throws Exception {
+        OrgMember orgMember2 = OrgMember.builder().githubId(123457).githubLogin("division8").build();
+        List<OrgMember> orgMembers = List.of(orgMember2);
+
+        OrgMember orgAdmin2 = OrgMember.builder().githubId(123455).githubLogin("division9").build();
+        List<OrgMember> orgAdmins = List.of(orgAdmin2);
+
+        Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+        RosterStudent student2 = RosterStudent.builder().studentId("apple").githubLogin("division8").githubId(123457).course(course).build();
+        RosterStudent student3 = RosterStudent.builder().studentId("orange").githubLogin("division9").githubId(123455).course(course).build();
+        course.setRosterStudents(List.of(student2, student3));
+
+        RosterStudent student2Updated = RosterStudent.builder().studentId("apple").githubLogin("division8").githubId(123457).course(course).orgStatus(OrgStatus.MEMBER).build();
+        RosterStudent student3Updated = RosterStudent.builder().studentId("orange").githubLogin("division9").githubId(123455).course(course).orgStatus(OrgStatus.OWNER).build();
+
+        doReturn(orgMembers).when(organizationMemberService).getOrganizationMembers(eq(course));
+        doReturn(orgAdmins).when(organizationMemberService).getOrganizationAdmins(eq(course));
+        doReturn(List.of(course)).when(courseRepository).findAll();
+
+        var matchJob = spy(MembershipAuditJob.builder()
+                .rosterStudentRepository(rosterStudentRepository)
+                .organizationMemberService(organizationMemberService)
+                .courseRepository(courseRepository)
+                .build());
+
+        matchJob.accept(ctx);
+        String expected = """
+                Auditing membership for each course with an attached GitHub Organization...
+                Done""";
+        assertEquals(expected, jobStarted.getLog());
+
+        verify(rosterStudentRepository, times(1)).saveAll(eq(List.of(student2Updated, student3Updated)));
     }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJobTests.java
@@ -1,0 +1,115 @@
+package edu.ucsb.cs156.frontiers.jobs;
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.Job;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.models.OrgMember;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class MembershipAuditJobTests {
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RosterStudentRepository rosterStudentRepository;
+
+    @Mock
+    private OrganizationMemberService organizationMemberService;
+
+    @Mock
+    private CourseRepository courseRepository;
+
+
+    Job jobStarted = Job.builder().build();
+    JobContext ctx = new JobContext(null, jobStarted);
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void match_students_correctly() throws Exception {
+        OrgMember orgMember1 = OrgMember.builder().githubId(123456).githubLogin("division7").build();
+        OrgMember orgMember2 = OrgMember.builder().githubId(123457).githubLogin("division8").build();
+        List<OrgMember> orgMembers = List.of(orgMember1, orgMember2);
+        OrgMember orgMember3 = OrgMember.builder().githubId(123455).githubLogin("division9").build();
+        OrgMember orgMember4 = OrgMember.builder().githubId(772).githubLogin("unmatched").build();
+        List<OrgMember> secondCourse = List.of(orgMember3, orgMember4);
+        Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+        Course course2 = Course.builder().orgName("ucsb-cs156-f25").installationId("1235").build();
+        RosterStudent student1 = RosterStudent.builder().studentId("banana").githubLogin("division7").githubId(123456).course(course).build();
+        RosterStudent student2 = RosterStudent.builder().studentId("apple").githubLogin("division8").githubId(123457).course(course).build();
+        course.setRosterStudents(List.of(student1, student2));
+        RosterStudent student3 = RosterStudent.builder().studentId("banana").githubLogin("division9").githubId(123455).course(course2).build();
+        RosterStudent student4 = RosterStudent.builder().studentId("apple").githubLogin("division10").githubId(123454).course(course2).build();
+        course2.setRosterStudents(List.of(student3, student4));
+        RosterStudent student1Updated = RosterStudent.builder().studentId("banana").githubLogin("division7").githubId(123456).course(course).orgStatus(OrgStatus.MEMBER).build();
+        RosterStudent student2Updated = RosterStudent.builder().studentId("apple").githubLogin("division8").githubId(123457).course(course).orgStatus(OrgStatus.MEMBER).build();
+        RosterStudent student3Updated = RosterStudent.builder().studentId("banana").githubLogin("division9").githubId(123455).course(course2).orgStatus(OrgStatus.MEMBER).build();
+
+        doReturn(orgMembers).when(organizationMemberService).getOrganizationMembers(eq(course));
+        doReturn(secondCourse).when(organizationMemberService).getOrganizationMembers(eq(course2));
+        doReturn(List.of(course, course2)).when(courseRepository).findAll();
+
+        var matchJob = spy(MembershipAuditJob.builder()
+                .rosterStudentRepository(rosterStudentRepository)
+                .organizationMemberService(organizationMemberService)
+                .courseRepository(courseRepository)
+                .build());
+
+        matchJob.accept(ctx);
+        String expected = """
+                Auditing membership for each course with an attached GitHub Organization...
+                Done""";
+        assertEquals(expected, jobStarted.getLog());
+
+        verify(rosterStudentRepository, times(1)).save(eq(student1Updated));
+        verify(rosterStudentRepository, times(1)).save(eq(student2Updated));
+        verify(rosterStudentRepository, times(1)).save(eq(student3Updated));
+    }
+
+    @Test
+    public void no_roster_student() throws Exception {
+        OrgMember orgMember1 = OrgMember.builder().githubId(123456).githubLogin("division7").build();
+        List<OrgMember> orgMembers = List.of(orgMember1);
+        Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+
+        doReturn(orgMembers).when(organizationMemberService).getOrganizationMembers(eq(course));
+        doReturn(Optional.empty()).when(rosterStudentRepository).findByCourseAndGithubId(eq(course), eq(123456));
+
+        var matchJob = spy(UpdateOrgMembershipJob.builder()
+                .rosterStudentRepository(rosterStudentRepository)
+                .organizationMemberService(organizationMemberService)
+                .course(course)
+                .build());
+
+        matchJob.accept(ctx);
+        String expected = """
+                Processing...
+                Done""";
+        assertEquals(expected, jobStarted.getLog());
+
+        verify(rosterStudentRepository, times(0)).save(any());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJobTests.java
@@ -63,6 +63,7 @@ public class MembershipAuditJobTests {
         course.setRosterStudents(List.of(student1, student2));
         RosterStudent student3 = RosterStudent.builder().studentId("banana").githubLogin("division9").githubId(123455).course(course2).build();
         RosterStudent student4 = RosterStudent.builder().studentId("apple").githubLogin("division10").githubId(123454).course(course2).build();
+        RosterStudent student5 = RosterStudent.builder().studentId("orange").githubLogin(null).githubId(null).course(course2).build();
         course2.setRosterStudents(List.of(student3, student4));
         RosterStudent student1Updated = RosterStudent.builder().studentId("banana").githubLogin("division7").githubId(123456).course(course).orgStatus(OrgStatus.MEMBER).build();
         RosterStudent student2Updated = RosterStudent.builder().studentId("apple").githubLogin("division8").githubId(123457).course(course).orgStatus(OrgStatus.MEMBER).build();

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
@@ -77,7 +77,7 @@ public class OrganizationMemberServiceTests {
         String jsonResponse = objectMapper.writeValueAsString(expectedMembers);
 
         // Setup mock server
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members"))
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?role=member"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
                 .andExpect(header("Accept", "application/vnd.github+json"))
@@ -114,12 +114,12 @@ public class OrganizationMemberServiceTests {
         // Setup headers for pagination
         HttpHeaders firstPageHeaders = new HttpHeaders();
         firstPageHeaders.add("link", 
-            "<https://api.github.com/orgs/" + TEST_ORG + "/members?page=2>; rel=\"next\"");
+            "<https://api.github.com/orgs/" + TEST_ORG + "/members?page=2&role=member>; rel=\"next\"");
 
         HttpHeaders secondPageHeaders = new HttpHeaders();
         secondPageHeaders.add("link", "<https://api.github.com/orgs/" + TEST_ORG + "/members?page=1>; rel=\"previous\"");
         // Setup mock server for first page
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members"))
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?role=member"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
                 .andRespond(withStatus(HttpStatus.OK)
@@ -128,7 +128,7 @@ public class OrganizationMemberServiceTests {
                         .body(firstPageJson));
 
         // Setup mock server for second page
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?page=2"))
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?page=2&role=member"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
                 .andRespond(withStatus(HttpStatus.OK)
@@ -147,7 +147,7 @@ public class OrganizationMemberServiceTests {
     @Test
     void testGetOrganizationMembers_EmptyResponse() throws Exception {
         // Setup mock server with empty response
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members"))
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?role=member"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
                 .andRespond(withStatus(HttpStatus.OK)

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
@@ -162,6 +162,104 @@ public class OrganizationMemberServiceTests {
         assertEquals(result, List.of());
     }
 
+
+
+    @Test
+    void testGetOrganizationAdmins_SinglePage() throws Exception {
+        // Prepare test data
+        List<OrgMember> expectedAdmins = List.of(
+            OrgMember.builder().githubId(1).githubLogin("admin1").build(),
+            OrgMember.builder().githubId(2).githubLogin("admin2").build()
+        );
+        String jsonResponse = objectMapper.writeValueAsString(expectedAdmins);
+
+        // Setup mock server
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?role=admin"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(jsonResponse));
+
+        // Execute test
+        Iterable<OrgMember> result = organizationMemberService.getOrganizationAdmins(testCourse);
+
+        // Verify results
+        mockServer.verify();
+        assertIterableEquals(expectedAdmins, result);
+    }
+
+    @Test
+    void testGetOrganizationAdmins_MultiplePages() throws Exception {
+        // Prepare test data for two pages
+        OrgMember orgAdmin1 = OrgMember.builder().githubId(1).githubLogin("admin1").build();
+        OrgMember orgAdmin2 = OrgMember.builder().githubId(2).githubLogin("admin2").build();
+
+        List<OrgMember> firstPageAdmins = List.of(
+            orgAdmin1
+        );
+        List<OrgMember> secondPageAdmins = List.of(
+            orgAdmin2
+        );
+
+        String firstPageJson = objectMapper.writeValueAsString(firstPageAdmins);
+        String secondPageJson = objectMapper.writeValueAsString(secondPageAdmins);
+
+        List<OrgMember> expectedResults = List.of(orgAdmin1, orgAdmin2);
+        // Setup headers for pagination
+        HttpHeaders firstPageHeaders = new HttpHeaders();
+        firstPageHeaders.add("link",
+            "<https://api.github.com/orgs/" + TEST_ORG + "/members?page=2&role=admin>; rel=\"next\"");
+
+        HttpHeaders secondPageHeaders = new HttpHeaders();
+        secondPageHeaders.add("link", "<https://api.github.com/orgs/" + TEST_ORG + "/members?page=1>; rel=\"previous\"");
+        // Setup mock server for first page
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?role=admin"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .headers(firstPageHeaders)
+                        .body(firstPageJson));
+
+        // Setup mock server for second page
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?page=2&role=admin"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .headers(secondPageHeaders)
+                        .body(secondPageJson));
+
+        // Execute test
+        List<OrgMember> result = (List<OrgMember>) organizationMemberService.getOrganizationAdmins(testCourse);
+
+        // Verify results
+        mockServer.verify();
+        assertEquals(expectedResults, result);
+    }
+
+    @Test
+    void testGetOrganizationAdmins_EmptyResponse() throws Exception {
+        // Setup mock server with empty response
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?role=admin"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("[]"));
+
+        // Execute test
+        Iterable<OrgMember> result = organizationMemberService.getOrganizationAdmins(testCourse);
+
+        // Verify results
+        mockServer.verify();
+        assertEquals(result, List.of());
+    }
+
+
     @Test
     void testInviteOrganizationMember_Success() throws Exception {
         // Create test roster student


### PR DESCRIPTION
In this PR, I implement a job that audits the status of each course, and ensures that students who have joined the course on GitHub are marked as MEMBER.

This runs on every course with an installation id and organization name.

Currently deployed to https://frontiers-daniel.dokku-00.cs.ucsb.edu/

Closes #157 

Merge after #154 