### PR TITLE
pc - add methods for roles to ApiController

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
@@ -1,11 +1,15 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
 import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
+
+import org.checkerframework.checker.units.qual.Current;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -13,6 +17,7 @@ import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import edu.ucsb.cs156.frontiers.models.CurrentUser;
 import edu.ucsb.cs156.frontiers.services.CurrentUserService;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -24,6 +29,8 @@ public abstract class ApiController {
   @Autowired
   private CurrentUserService currentUserService;
 
+  @Autowired RoleHierarchy roleHierarchy;
+
   /**
    * This method returns the current user.
    * @return the current user
@@ -31,6 +38,32 @@ public abstract class ApiController {
   protected CurrentUser getCurrentUser() {
     return currentUserService.getCurrentUser();
   }
+
+/**
+   * This method checks if the current user has the given role
+   * @return true if the current user has the role, false otherwise
+   * @param role the role to check
+   */
+  protected boolean doesCurrentUserHaveRole(
+      String roleToCheck
+    ) {  
+    CurrentUser currentUser = getCurrentUser();    
+    Collection<? extends GrantedAuthority> authorities = currentUser.getRoles();
+
+    Collection<? extends GrantedAuthority> extendedAuthorities = roleHierarchy.getReachableGrantedAuthorities(authorities);
+
+    return extendedAuthorities.stream()
+         .anyMatch(role -> role.getAuthority().equals(roleToCheck));
+  }
+
+  /**
+   * This method checks if the current user is an admin.
+   * @return true if the current user is an admin, false otherwise
+   */
+  protected boolean isCurrentUserAdmin() {  
+    return doesCurrentUserHaveRole("ROLE_ADMIN");
+  }
+
 
   /**
    * This method returns a generic message.

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/ApiControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/ApiControllerTests.java
@@ -3,12 +3,17 @@ package edu.ucsb.cs156.frontiers.controllers;
 import edu.ucsb.cs156.frontiers.ControllerTestCase;
 import edu.ucsb.cs156.frontiers.controllers.ApiController;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.services.CurrentUserService;
 import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
+import lombok.With;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -17,13 +22,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @WebMvcTest(controllers = DummyController.class)
-@Import(TestConfig.class)
 public class ApiControllerTests extends ControllerTestCase {
 
-        @MockBean
+        @MockitoBean
         UserRepository userRepository;
+
+        @Autowired DummyController dummyController;
+
 
         @Test
         public void generic_message_test() {
@@ -70,6 +79,21 @@ public class ApiControllerTests extends ControllerTestCase {
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("NoLinkedOrganizationException", json.get("type"));
                 assertEquals("No linked GitHub Organization to course. Please link a GitHub Organization first.", json.get("message"));
+        }
+
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void test_doesCurrentUserHaveRole_true() throws Exception {           
+                assertTrue( dummyController.doesCurrentUserHaveRole("ROLE_ADMIN"));
+                assertTrue( dummyController.isCurrentUserAdmin());
+
+        }
+
+         @Test
+        @WithMockUser(roles = { "USER" })
+        public void test_doesCurrentUserHaveRole_false() throws Exception {
+                assertFalse( dummyController.doesCurrentUserHaveRole("ROLE_ADMIN"));
+                assertFalse( dummyController.isCurrentUserAdmin());
         }
 
 }


### PR DESCRIPTION
In this PR, we add methods to the Api controller that allow us to check whether the current user has a specific role.   

These methods are aware of the role hierarchy.

These methods are useful for modifying endpoints to, for example, making the /api/courses endpoint:
* For ROLE_ADMIN, return all courses
* For ROLE_INSTRUCTOR, return only the courses that the instructor has access to.