### PR TITLE
Factoring Out Course Permissions Management

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/config/CourseSecurity.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/config/CourseSecurity.java
@@ -1,0 +1,43 @@
+package edu.ucsb.cs156.frontiers.config;
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.models.CurrentUser;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.services.CurrentUserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Optional;
+
+@Slf4j
+@Component("CourseSecurity")
+public class CourseSecurity {
+    private final CurrentUserService currentUserService;
+    private final RoleHierarchy roleHierarchy;
+    private final CourseRepository courseRepository;
+    public CourseSecurity(CurrentUserService currentUserService, RoleHierarchy roleHierarchy, CourseRepository courseRepository){
+        this.currentUserService = currentUserService;
+        this.roleHierarchy = roleHierarchy;
+        this.courseRepository = courseRepository;
+    }
+
+    @PreAuthorize("hasRole('ROLE_INSTRUCTOR')")
+    public Boolean hasManagePermissions(MethodSecurityExpressionOperations operations, Long courseId){
+        CurrentUser currentUser = currentUserService.getCurrentUser();
+        Collection<? extends GrantedAuthority> authorities = roleHierarchy.getReachableGrantedAuthorities(currentUser.getRoles());
+        if(authorities.stream().anyMatch(role -> role.getAuthority().equals("ROLE_ADMIN"))){
+            return true;
+        }else {
+            Optional<Course> course = courseRepository.findById(courseId);
+            if(course.isEmpty()){
+                return true;
+            }
+            return currentUser.getUser().getId() == course.get().getCreator().getId();
+        }
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/config/SecurityConfig.java
@@ -89,7 +89,7 @@ public class SecurityConfig {
   }
 
   @Bean
-  static RoleHierarchy roleHierarchy() {
+  public static RoleHierarchy roleHierarchy() {
     return RoleHierarchyImpl.withDefaultRolePrefix()
             .role("ADMIN").implies("INSTRUCTOR")
             .role("INSTRUCTOR").implies("USER")

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RepositoryController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RepositoryController.java
@@ -45,7 +45,7 @@ public class RepositoryController extends ApiController {
     * @return the {@link edu.ucsb.cs156.frontiers.entities.Job Job} started to create the repos.
     */
     @PostMapping("/createRepos")
-    @PreAuthorize("hasRole('ROLE_INSTRUCTOR')")
+    @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
     public Job createRepos(@RequestParam Long courseId, @RequestParam String repoPrefix, @RequestParam Optional<Boolean> isPrivate) {
         Course course = courseRepository.findById(courseId).orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
         if (getCurrentUser().getUser().getId() == course.getCreator().getId()) {

--- a/src/test/java/edu/ucsb/cs156/frontiers/ControllerTestCase.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/ControllerTestCase.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.ucsb.cs156.frontiers.config.SecurityConfig;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.testconfig.TestCourseSecurity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -31,7 +32,7 @@ import java.util.Map;
  */
 
 @ActiveProfiles("test")
-@Import({TestConfig.class, SecurityConfig.class})
+@Import({TestConfig.class, SecurityConfig.class, TestCourseSecurity.class})
 public abstract class ControllerTestCase {
   @Autowired
   public CurrentUserService currentUserService;

--- a/src/test/java/edu/ucsb/cs156/frontiers/annotations/WithInstructorCoursePermissions.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/annotations/WithInstructorCoursePermissions.java
@@ -12,6 +12,6 @@ import java.lang.annotation.RetentionPolicy;
  * It cannot be combined with <i>@WithMockUser</i>.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@WithMockUser(authorities = {"COURSE_PERMISSION","ROLE_ADMIN"})
+@WithMockUser(authorities = {"COURSE_PERMISSION","ROLE_INSTRUCTOR"})
 public @interface WithInstructorCoursePermissions {
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/annotations/WithInstructorCoursePermissions.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/annotations/WithInstructorCoursePermissions.java
@@ -9,7 +9,7 @@ import java.lang.annotation.RetentionPolicy;
  * This annotation interacts with the mock CourseSecurity annotation. It adds authorities that tell the CourseSecurity annotation
  * used in testing that the user has permission to manage the course being accessed. It should be used on methods that have the
  * <i>@PreAuthorize("@CourseSecurity.hasManagePermissions")</i> annotation.
- * It cannot be combined with <i>@WithMockUser</i>.
+ * This should not be combined with <i>@WithMockUser</i>, because this annotation implies <i>@WithMockUser("ROLE_INSTRUCTOR")</i>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @WithMockUser(authorities = {"COURSE_PERMISSION","ROLE_INSTRUCTOR"})

--- a/src/test/java/edu/ucsb/cs156/frontiers/annotations/WithInstructorCoursePermissions.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/annotations/WithInstructorCoursePermissions.java
@@ -12,6 +12,6 @@ import java.lang.annotation.RetentionPolicy;
  * This should not be combined with <i>@WithMockUser</i>, because this annotation implies <i>@WithMockUser("ROLE_INSTRUCTOR")</i>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@WithMockUser(authorities = {"COURSE_PERMISSION","ROLE_INSTRUCTOR"})
+@WithMockUser(authorities = {"COURSE_PERMISSIONS","ROLE_INSTRUCTOR"})
 public @interface WithInstructorCoursePermissions {
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/annotations/WithInstructorCoursePermissions.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/annotations/WithInstructorCoursePermissions.java
@@ -6,10 +6,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * This annotation interacts with the mock CourseSecurity annotation. It adds authorities that tells the CourseSecurity annotation
+ * This annotation interacts with the mock CourseSecurity annotation. It adds authorities that tell the CourseSecurity annotation
  * used in testing that the user has permission to manage the course being accessed. It should be used on methods that have the
- * <p>@PreAuthorize("@CourseSecurity.hasManagePermissions") annotation.</p>
- * It cannot be combined with <p>@WithMockUser</p>
+ * <i>@PreAuthorize("@CourseSecurity.hasManagePermissions")</i> annotation.
+ * It cannot be combined with <i>@WithMockUser</i>.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @WithMockUser(authorities = {"COURSE_PERMISSION","ROLE_ADMIN"})

--- a/src/test/java/edu/ucsb/cs156/frontiers/annotations/WithInstructorCoursePermissions.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/annotations/WithInstructorCoursePermissions.java
@@ -1,0 +1,17 @@
+package edu.ucsb.cs156.frontiers.annotations;
+
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * This annotation interacts with the mock CourseSecurity annotation. It adds authorities that tells the CourseSecurity annotation
+ * used in testing that the user has permission to manage the course being accessed. It should be used on methods that have the
+ * <p>@PreAuthorize("@CourseSecurity.hasManagePermissions") annotation.</p>
+ * It cannot be combined with <p>@WithMockUser</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@WithMockUser(authorities = {"COURSE_PERMISSION","ROLE_ADMIN"})
+public @interface WithInstructorCoursePermissions {
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/security/CourseSecurityTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/security/CourseSecurityTests.java
@@ -1,0 +1,124 @@
+package edu.ucsb.cs156.frontiers.security;
+
+import edu.ucsb.cs156.frontiers.config.CourseSecurity;
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.models.CurrentUser;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.services.CurrentUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.NestedTestConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+@NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.INHERIT)
+@Import({CourseSecurity.class, DummyCourseSecurity.class})
+@EnableMethodSecurity
+public class CourseSecurityTests {
+
+    @MockitoBean
+    private CourseRepository courseRepository;
+
+    @MockitoBean
+    CurrentUserService currentUserService;
+
+    @MockitoBean
+    UserRepository userRepository;
+
+    @Autowired
+    DummyCourseSecurity DummyCourseSecurity;
+
+
+    @Nested
+    public class SuccessfulAdmin {
+        @BeforeEach
+        public void setup(){
+            User user = User.builder().id(1L).build();
+            User user2 = User.builder().id(2L).build();
+            Course testCourse = Course.builder().id(1L).creator(user2).build();
+            when(currentUserService.getCurrentUser()).thenReturn(CurrentUser.builder().user(user).roles(Set.of(new SimpleGrantedAuthority("ROLE_ADMIN"))).build());
+            when(courseRepository.findById(1L)).thenReturn(java.util.Optional.of(testCourse));
+        }
+
+        @Test
+        @WithMockUser(setupBefore = TestExecutionEvent.TEST_EXECUTION, roles = {"ADMIN"})
+        public void instructor_can_load_owned_course() {
+            DummyCourseSecurity.loadCourse(1L);
+        }
+    }
+
+    @Nested
+    public class SuccessfulInstructor {
+        @BeforeEach
+        public void setup(){
+            User user = User.builder().id(1L).build();
+            Course testCourse = Course.builder().id(1L).creator(user).build();
+            when(currentUserService.getCurrentUser()).thenReturn(CurrentUser.builder().user(user).roles(Set.of(new SimpleGrantedAuthority("ROLE_INSTRUCTOR"))).build());
+            when(courseRepository.findById(1L)).thenReturn(java.util.Optional.of(testCourse));
+        }
+
+        @Test
+        @WithMockUser(setupBefore = TestExecutionEvent.TEST_EXECUTION, roles = {"INSTRUCTOR"})
+        public void instructor_can_load_owned_course() {
+            DummyCourseSecurity.loadCourse(1L);
+        }
+    }
+
+    @Nested
+    public class UnsuccessfulInstructor {
+        @BeforeEach
+        public void setup(){
+            User user = User.builder().id(1L).build();
+            User user2 = User.builder().id(2L).build();
+            Course testCourse = Course.builder().id(1L).creator(user2).build();
+            when(currentUserService.getCurrentUser()).thenReturn(CurrentUser.builder().user(user).roles(Set.of(new SimpleGrantedAuthority("ROLE_INSTRUCTOR"))).build());
+            when(courseRepository.findById(1L)).thenReturn(java.util.Optional.of(testCourse));
+        }
+
+        @Test
+        @WithMockUser(setupBefore = TestExecutionEvent.TEST_EXECUTION, roles = {"INSTRUCTOR"})
+        public void instructor_cant_load_non_owned_course() {
+            assertThrows(AccessDeniedException.class, () -> DummyCourseSecurity.loadCourse(1L));
+        }
+    }
+
+    @Nested
+    public class NotFound {
+        @BeforeEach
+        public void setup(){
+            User user = User.builder().id(1L).build();
+            when(currentUserService.getCurrentUser()).thenReturn(CurrentUser.builder().user(user).roles(Set.of(new SimpleGrantedAuthority("ROLE_INSTRUCTOR"))).build());
+            when(courseRepository.findById(1L)).thenReturn(Optional.empty());
+        }
+
+        @Test
+        @WithMockUser(setupBefore = TestExecutionEvent.TEST_EXECUTION, roles = {"INSTRUCTOR"})
+        public void null_on_null() {
+            assertTrue(DummyCourseSecurity.nullTest(1L));
+        }
+
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/security/DummyCourseSecurity.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/security/DummyCourseSecurity.java
@@ -1,0 +1,39 @@
+package edu.ucsb.cs156.frontiers.security;
+
+import edu.ucsb.cs156.frontiers.config.SecurityConfig;
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@TestComponent
+public class DummyCourseSecurity {
+
+    @Autowired
+    CourseRepository courseRepository;
+
+    @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
+    public Course loadCourse(Long courseId){
+        /*
+        This method simply exists to add the preauthorization annotation so that the method can be tested directly.
+         */
+        return courseRepository.findById(courseId).orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
+    }
+
+    @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
+    public boolean nullTest(Long courseId){
+        if (courseRepository.findById(courseId).isEmpty() ){
+            return true;
+        }else{
+            return false;
+        }
+    }
+    @Bean
+    public static RoleHierarchy loadedRoleHierarchy(){
+        return SecurityConfig.roleHierarchy();
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/testconfig/TestCourseSecurity.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/testconfig/TestCourseSecurity.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.frontiers.testconfig;
+
+import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent("CourseSecurity")
+public class TestCourseSecurity {
+    @PreAuthorize("(hasRole('ROLE_INSTRUCTOR') && hasAuthority('COURSE_PERMISSIONS'))|| hasRole('ROLE_ADMIN')")
+    public Boolean hasManagePermissions(MethodSecurityExpressionOperations operations, Long courseId) {
+        return true;
+    }
+}


### PR DESCRIPTION
In this PR, I create a Spring Security annotation designed to factor out Spring Security annotations. It is designed to be used on methods that require a Course Id.

However, this method is inefficient because it has to call the database for the Current User, and the Course objects again.

In the future, this can be mitigated by using a Spring Boot converter, so that handling of returning a Course object is centrally handled.

As a proof of concept, this is applied to createStudentRepos.

Currently synced to https://proj-frontiers-division7.dokku-00.cs.ucsb.edu/

Closes #167 
