### PR TITLE
Adding Azure Active Directory as a Sign-On

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,7 @@
             <exclude>**/${app.packagePath}/services/GithubSignInServiceImpl.*</exclude>
             <exclude>**/${app.packagePath}/services/GoogleSignInServiceImpl.*</exclude>
             <exclude>**/${app.packagePath}/errors/NotAuthenticatedWithGoogleException.*</exclude>
+            <exclude>**/${app.packagePath}/startup/AzureProfileEnabler.*</exclude>
           </excludes>
         </configuration>
         <executions>
@@ -336,6 +337,7 @@
             <param>${app.package}.config.SpaCsrfTokenRequestHandler</param>
             <param>${app.package}.config.CsrfCookieFilter</param>
             <param>${app.package}.config.JpaAuditingConfig</param>
+            <param>${app.package}.startup.AzureProfileEnabler</param>
             <param>edu.ucsb.cs156.frontiers.services.wiremock.WiremockService</param>
             <param>edu.ucsb.cs156.frontiers.services.wiremock.WiremockServiceDummy</param>
             <param>edu.ucsb.cs156.frontiers.services.wiremock.WiremockServiceImpl</param>

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,7 @@
             <param>${app.package}.services.CurrentUserServiceImpl</param>
             <param>${app.package}.FrontiersMain</param>
             <param>${app.package}.config.SecurityConfig</param>
+            <param>${app.package}.config.SecurityConfig$CustomIssuerValidator</param>
             <param>${app.package}.config.SpaCsrfTokenRequestHandler</param>
             <param>${app.package}.config.CsrfCookieFilter</param>
             <param>${app.package}.config.JpaAuditingConfig</param>

--- a/src/main/java/edu/ucsb/cs156/frontiers/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/models/SystemInfo.java
@@ -24,4 +24,5 @@ public class SystemInfo {
   private String commitMessage;
   private String commitId;
   private String githubUrl; // URL to the commit in the source repository
+  private String activeDirectoryUrl;
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/GoogleSignInServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/GoogleSignInServiceImpl.java
@@ -39,7 +39,7 @@ public class GoogleSignInServiceImpl extends OidcUserService implements GoogleSi
     }
 
     private OidcUser managePrimarySignIn(OidcUser oidcUser) {
-        Optional<User> currentUser = userRepository.findByGoogleSub(oidcUser.getSubject());
+        Optional<User> currentUser = userRepository.findByEmail(oidcUser.getEmail());
         Set<GrantedAuthority> authorities = new HashSet<>();
         boolean changed = false;
         if (currentUser.isPresent()) {

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/SystemInfoServiceImpl.java
@@ -26,6 +26,9 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
+  @Value("${spring.security.oauth2.client.registration.azure-dev.provider:#{null}}")
+  private String microsoftEnabled;
+
   @Value("${app.oauth.login:/oauth2/authorization/google}")
   private String oauthLogin;
 
@@ -58,6 +61,10 @@ public class SystemInfoServiceImpl extends SystemInfoService {
         .commitId(this.commitId)
         .githubUrl(githubUrl(this.sourceRepo, this.commitId))
         .build();
+
+    if (this.microsoftEnabled != null) {
+      si.setActiveDirectoryUrl("/oauth2/authorization/azure-dev");
+    }
     log.info("getSystemInfo returns {}", si);
     return si;
   }

--- a/src/main/java/edu/ucsb/cs156/frontiers/startup/AzureProfileEnabler.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/startup/AzureProfileEnabler.java
@@ -1,0 +1,35 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePropertySource;
+
+import java.io.IOException;
+
+@Order(Ordered.LOWEST_PRECEDENCE)
+@Slf4j
+public class AzureProfileEnabler implements EnvironmentPostProcessor {
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        if (System.getenv("MICROSOFT") != null && System.getenv("MICROSOFT").equals("true")) {
+            environment.addActiveProfile("microsoft");
+            try {
+                Resource resource = new ClassPathResource("application-microsoft.properties");
+                if (resource.exists()) {
+                    ResourcePropertySource propertySource = new ResourcePropertySource("application-microsoft", resource);
+                    environment.getPropertySources().addLast(propertySource);
+                }
+            } catch (IOException e) {
+                // Handle exception appropriately
+                log.error("Azure Oauth2 data file is missing. Please check that application-microsoft exists.");
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.env.EnvironmentPostProcessor=edu.ucsb.cs156.frontiers.startup.AzureProfileEnabler

--- a/src/main/resources/application-microsoft.properties
+++ b/src/main/resources/application-microsoft.properties
@@ -1,0 +1,11 @@
+spring.security.oauth2.client.provider.azure.issuer-uri=https://login.microsoftonline.com/${MICROSOFT_TENANT_ID:${env.MICROSOFT_TENANT_ID}}/v2.0
+spring.security.oauth2.client.registration.azure-dev.client-secret=${MICROSOFT_CLIENT_SECRET:${env.MICROSOFT_CLIENT_SECRET}}
+spring.security.oauth2.client.registration.azure-dev.client-id=${MICROSOFT_CLIENT_ID:${env.MICROSOFT_CLIENT_ID}}
+spring.security.oauth2.client.registration.azure-dev.scope=openid,email,profile
+spring.security.oauth2.client.registration.azure-dev.provider=azure
+spring.security.oauth2.client.registration.azure-dev.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.azure-dev.redirect-uri={baseUrl}/login/oauth2/code/azure-dev
+spring.security.oauth2.client.provider.azure.authorization-uri=https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize
+spring.security.oauth2.client.provider.azure.token-uri=https://login.microsoftonline.com/organizations/oauth2/v2.0/token
+spring.security.oauth2.client.provider.azure.jwk-set-uri=https://login.microsoftonline.com/organizations/discovery/v2.0/keys
+spring.security.oauth2.client.provider.azure.user-info-uri=https://graph.microsoft.com/oidc/userinfo

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/SystemInfoServiceImplTests.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.test.context.NestedTestConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -20,6 +22,7 @@ import edu.ucsb.cs156.frontiers.services.SystemInfoServiceImpl;
 
 @ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties(value = SystemInfoServiceImpl.class)
+@NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.INHERIT)
 @TestPropertySource("classpath:application-development.properties")
 class SystemInfoServiceImplTests {
 
@@ -45,5 +48,19 @@ class SystemInfoServiceImplTests {
     assertNull(SystemInfoServiceImpl.githubUrl(null, null));
     assertNull(SystemInfoServiceImpl.githubUrl("x", null));
     assertNull(SystemInfoServiceImpl.githubUrl(null, "x"));
+  }
+
+  @Nested
+  @TestPropertySource(properties = "spring.security.oauth2.client.registration.azure-dev.provider=azure")
+  class MicrosoftEnabledInfoServiceTests{
+
+    @Autowired
+    private SystemInfoService secondaryLoadedService;
+
+    @Test
+    public void displaysMicrosoftProvider() {
+      SystemInfo si = secondaryLoadedService.getSystemInfo();
+      assertEquals("/oauth2/authorization/azure-dev", si.getActiveDirectoryUrl());
+    }
   }
 }


### PR DESCRIPTION
In this PR, I add access to Azure Active Directory.

This is achieved by creating a custom issuer validator, as Microsoft will give different issuers depending on who the tenant is.

To prevent students from requiring an Azure account and a working setup, this is configured to remain gated behind the Spring Profile "microsoft" -- it is programatically enabled when the environment variable MICROSOFT is set to true.

The code for doing so (`AzureProfileEnabler`) is exempted from line coverage and unit testing since I'm not exactly sure how to test it.

Included also is a change to `GoogleSignInServiceImpl` to prevent duplicate accounts from being created if a user signs in with both Google & AD with the same email.

Deployed to https://frontiers-daniel.dokku-00.cs.ucsb.edu/

Changes to the frontend (including a sign-in button) will be implemented in a separate PR.

It reports to the frontend that azure is enabled via activeDirectoryUrl in /api/systemInfo.

This can be tested by going to the url https://frontiers-daniel.dokku-00.cs.ucsb.edu/oauth2/authorization/azure-dev