### PR TITLE
Appropriately Marking Students as Invited in MembershipAuditJob

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
@@ -63,6 +63,14 @@ public class OrganizationMemberService {
         return getOrganizationMembersWithRole(course, ENDPOINT);
     }
 
+    /**
+    * This endpoint returns the list of users who have been **invited** to the organization but have not yet accepted.
+    */
+    public Iterable<OrgMember> getOrganizationInvitees(Course course) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+        String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/invitations";
+        return getOrganizationMembersWithRole(course, ENDPOINT);
+    }
+
     private Iterable<OrgMember> getOrganizationMembersWithRole(Course course, String ENDPOINT) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
         //happily stolen directly from GitHub: https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28
         Pattern pattern = Pattern.compile("(?<=<)([\\S]*)(?=>; rel=\"next\")");

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
@@ -69,14 +69,12 @@ public class OrganizationMemberServiceTests {
 
     @Test
     void testGetOrganizationMembers_SinglePage() throws Exception {
-        // Prepare test data
         List<OrgMember> expectedMembers = List.of(
             OrgMember.builder().githubId(1).githubLogin("user1").build(),
             OrgMember.builder().githubId(2).githubLogin("user2").build()
         );
         String jsonResponse = objectMapper.writeValueAsString(expectedMembers);
 
-        // Setup mock server
         mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?role=member"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
@@ -86,17 +84,14 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body(jsonResponse));
 
-        // Execute test
         Iterable<OrgMember> result = organizationMemberService.getOrganizationMembers(testCourse);
 
-        // Verify results
         mockServer.verify();
         assertIterableEquals(expectedMembers, result);
     }
 
     @Test
     void testGetOrganizationMembers_MultiplePages() throws Exception {
-        // Prepare test data for two pages
         OrgMember orgMember1 = OrgMember.builder().githubId(1).githubLogin("user1").build();
         OrgMember orgMember2 = OrgMember.builder().githubId(2).githubLogin("user2").build();
 
@@ -111,14 +106,12 @@ public class OrganizationMemberServiceTests {
         String secondPageJson = objectMapper.writeValueAsString(secondPageMembers);
 
         List<OrgMember> expectedResults = List.of(orgMember1, orgMember2);
-        // Setup headers for pagination
         HttpHeaders firstPageHeaders = new HttpHeaders();
         firstPageHeaders.add("link", 
             "<https://api.github.com/orgs/" + TEST_ORG + "/members?page=2&role=member>; rel=\"next\"");
 
         HttpHeaders secondPageHeaders = new HttpHeaders();
         secondPageHeaders.add("link", "<https://api.github.com/orgs/" + TEST_ORG + "/members?page=1>; rel=\"previous\"");
-        // Setup mock server for first page
         mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?role=member"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
@@ -127,7 +120,6 @@ public class OrganizationMemberServiceTests {
                         .headers(firstPageHeaders)
                         .body(firstPageJson));
 
-        // Setup mock server for second page
         mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?page=2&role=member"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
@@ -136,17 +128,14 @@ public class OrganizationMemberServiceTests {
                         .headers(secondPageHeaders)
                         .body(secondPageJson));
 
-        // Execute test
         List<OrgMember> result = (List<OrgMember>) organizationMemberService.getOrganizationMembers(testCourse);
 
-        // Verify results
         mockServer.verify();
         assertEquals(expectedResults, result);
     }
 
     @Test
     void testGetOrganizationMembers_EmptyResponse() throws Exception {
-        // Setup mock server with empty response
         mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?role=member"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
@@ -154,10 +143,8 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("[]"));
 
-        // Execute test
         Iterable<OrgMember> result = organizationMemberService.getOrganizationMembers(testCourse);
 
-        // Verify results
         mockServer.verify();
         assertEquals(result, List.of());
     }
@@ -166,14 +153,12 @@ public class OrganizationMemberServiceTests {
 
     @Test
     void testGetOrganizationAdmins_SinglePage() throws Exception {
-        // Prepare test data
         List<OrgMember> expectedAdmins = List.of(
             OrgMember.builder().githubId(1).githubLogin("admin1").build(),
             OrgMember.builder().githubId(2).githubLogin("admin2").build()
         );
         String jsonResponse = objectMapper.writeValueAsString(expectedAdmins);
 
-        // Setup mock server
         mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?role=admin"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
@@ -183,17 +168,14 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body(jsonResponse));
 
-        // Execute test
         Iterable<OrgMember> result = organizationMemberService.getOrganizationAdmins(testCourse);
 
-        // Verify results
         mockServer.verify();
         assertIterableEquals(expectedAdmins, result);
     }
 
     @Test
     void testGetOrganizationAdmins_MultiplePages() throws Exception {
-        // Prepare test data for two pages
         OrgMember orgAdmin1 = OrgMember.builder().githubId(1).githubLogin("admin1").build();
         OrgMember orgAdmin2 = OrgMember.builder().githubId(2).githubLogin("admin2").build();
 
@@ -208,14 +190,12 @@ public class OrganizationMemberServiceTests {
         String secondPageJson = objectMapper.writeValueAsString(secondPageAdmins);
 
         List<OrgMember> expectedResults = List.of(orgAdmin1, orgAdmin2);
-        // Setup headers for pagination
         HttpHeaders firstPageHeaders = new HttpHeaders();
         firstPageHeaders.add("link",
             "<https://api.github.com/orgs/" + TEST_ORG + "/members?page=2&role=admin>; rel=\"next\"");
 
         HttpHeaders secondPageHeaders = new HttpHeaders();
         secondPageHeaders.add("link", "<https://api.github.com/orgs/" + TEST_ORG + "/members?page=1>; rel=\"previous\"");
-        // Setup mock server for first page
         mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?role=admin"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
@@ -224,7 +204,6 @@ public class OrganizationMemberServiceTests {
                         .headers(firstPageHeaders)
                         .body(firstPageJson));
 
-        // Setup mock server for second page
         mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?page=2&role=admin"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
@@ -233,17 +212,14 @@ public class OrganizationMemberServiceTests {
                         .headers(secondPageHeaders)
                         .body(secondPageJson));
 
-        // Execute test
         List<OrgMember> result = (List<OrgMember>) organizationMemberService.getOrganizationAdmins(testCourse);
 
-        // Verify results
         mockServer.verify();
         assertEquals(expectedResults, result);
     }
 
     @Test
     void testGetOrganizationAdmins_EmptyResponse() throws Exception {
-        // Setup mock server with empty response
         mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members?role=admin"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
@@ -251,10 +227,8 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("[]"));
 
-        // Execute test
         Iterable<OrgMember> result = organizationMemberService.getOrganizationAdmins(testCourse);
 
-        // Verify results
         mockServer.verify();
         assertEquals(result, List.of());
     }
@@ -262,19 +236,16 @@ public class OrganizationMemberServiceTests {
 
     @Test
     void testInviteOrganizationMember_Success() throws Exception {
-        // Create test roster student
         RosterStudent testStudent = RosterStudent.builder()
                 .githubId(12345)
                 .course(testCourse)
                 .build();
 
-        // Expected request body
         Map<String, Object> expectedRequestBody = new HashMap<>();
         expectedRequestBody.put("invitee_id", 12345);
         expectedRequestBody.put("role", "direct_member");
         String expectedRequestBodyJson = objectMapper.writeValueAsString(expectedRequestBody);
 
-        // Setup mock server for successful response
         mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/invitations"))
                 .andExpect(method(HttpMethod.POST))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
@@ -285,29 +256,24 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{}"));
 
-        // Execute test
         OrgStatus result = organizationMemberService.inviteOrganizationMember(testStudent);
 
-        // Verify results
         mockServer.verify();
         assertEquals(OrgStatus.INVITED, result);
     }
 
     @Test
     void testInviteOrganizationMember_Failure() throws Exception {
-        // Create test roster student
         RosterStudent testStudent = RosterStudent.builder()
                 .githubId(12345)
                 .course(testCourse)
                 .build();
 
-        // Expected request body
         Map<String, Object> expectedRequestBody = new HashMap<>();
         expectedRequestBody.put("invitee_id", 12345);
         expectedRequestBody.put("role", "direct_member");
         String expectedRequestBodyJson = objectMapper.writeValueAsString(expectedRequestBody);
 
-        // Setup mock server for failed response
         mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/invitations"))
                 .andExpect(method(HttpMethod.POST))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
@@ -318,11 +284,91 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"message\": \"Error inviting member\"}"));
 
-        // Execute test
         OrgStatus result = organizationMemberService.inviteOrganizationMember(testStudent);
 
-        // Verify results
         mockServer.verify();
         assertEquals(OrgStatus.JOINCOURSE, result);
+    }
+
+    @Test
+    void testGetOrganizationInvitees_SinglePage() throws Exception {
+        List<OrgMember> expectedInvitees = List.of(
+            OrgMember.builder().githubId(1).githubLogin("invitee1").build(),
+            OrgMember.builder().githubId(2).githubLogin("invitee2").build()
+        );
+        String jsonResponse = objectMapper.writeValueAsString(expectedInvitees);
+
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/invitations"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(jsonResponse));
+
+        Iterable<OrgMember> result = organizationMemberService.getOrganizationInvitees(testCourse);
+
+        mockServer.verify();
+        assertIterableEquals(expectedInvitees, result);
+    }
+
+    @Test
+    void testGetOrganizationInvitees_MultiplePages() throws Exception {
+        OrgMember orgInvitee1 = OrgMember.builder().githubId(1).githubLogin("invitee1").build();
+        OrgMember orgInvitee2 = OrgMember.builder().githubId(2).githubLogin("invitee2").build();
+
+        List<OrgMember> firstPageInvitees = List.of(
+            orgInvitee1
+        );
+        List<OrgMember> secondPageInvitees = List.of(
+            orgInvitee2
+        );
+
+        String firstPageJson = objectMapper.writeValueAsString(firstPageInvitees);
+        String secondPageJson = objectMapper.writeValueAsString(secondPageInvitees);
+
+        List<OrgMember> expectedResults = List.of(orgInvitee1, orgInvitee2);
+        HttpHeaders firstPageHeaders = new HttpHeaders();
+        firstPageHeaders.add("link", 
+            "<https://api.github.com/orgs/" + TEST_ORG + "/invitations?page=2>; rel=\"next\"");
+
+        HttpHeaders secondPageHeaders = new HttpHeaders();
+        secondPageHeaders.add("link", "<https://api.github.com/orgs/" + TEST_ORG + "/invitations?page=1>; rel=\"previous\"");
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/invitations"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .headers(firstPageHeaders)
+                        .body(firstPageJson));
+
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/invitations?page=2"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .headers(secondPageHeaders)
+                        .body(secondPageJson));
+
+        List<OrgMember> result = (List<OrgMember>) organizationMemberService.getOrganizationInvitees(testCourse);
+
+        mockServer.verify();
+        assertEquals(expectedResults, result);
+    }
+
+    @Test
+    void testGetOrganizationInvitees_EmptyResponse() throws Exception {
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/invitations"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("[]"));
+
+        Iterable<OrgMember> result = organizationMemberService.getOrganizationInvitees(testCourse);
+
+        mockServer.verify();
+        assertEquals(result, List.of());
     }
 }


### PR DESCRIPTION
In this PR, I make the MembershipAuditJob appropriately check for students that are currently invited to the organization, and mark them as such. Closes #170 

In addition to adding the necessary unit tests, I remove comments for test code that is self-defining.

Test Plan:
1. Make a course with a linked github org
2. Add a roster student that corresponds to a real github user
3. Invite that github user (whether using the app or simply GitHub, it shouldn't matter)
4. Run MembershipAuditJob and ensure they continue to be marked as INVITED.

Deployed to https://frontiers-qa2.dokku-00.cs.ucsb.edu