### PR TITLE
REFACTOR: add a utility to isolate the hacks for email addresses

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/utilities/CanonicalFormConverter.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/utilities/CanonicalFormConverter.java
@@ -21,4 +21,13 @@ public class CanonicalFormConverter {
                                     .toLowerCase();
        return canonicalEmail;
     }
+
+    /** Check whether two emails are equivalent in their canonical form
+     * @param email1
+     * @param email2
+     * @return true if the canonical forms of the two emails are equal, false otherwise
+     */
+    public static boolean areEquivalentEmails(String email1, String email2) {
+        return convertToValidEmail(email1).equals(convertToValidEmail(email2));
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/utiltiies/CanonicalFormConverterTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/utiltiies/CanonicalFormConverterTests.java
@@ -1,6 +1,8 @@
 package edu.ucsb.cs156.frontiers.utiltiies;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.junit.jupiter.api.Test;
@@ -21,9 +23,19 @@ public class CanonicalFormConverterTests {
      * constructor of CanonicalFormConverter is called, even though
      * it does not have any logic in it.
      */
-     @Test
+    @Test
     public void test_coverage_for_constructor() {
         CanonicalFormConverter converter = new CanonicalFormConverter();
         assertInstanceOf(CanonicalFormConverter.class, converter);
     }
+
+    /**
+     * Test the areEquivalentEmails method
+     */
+    @Test
+    public void testAreEquivalentEmails() {
+        assertTrue(CanonicalFormConverter.areEquivalentEmails("foo@umail.ucsb.edu", "foo@ucsb.edu"));
+        assertFalse(CanonicalFormConverter.areEquivalentEmails("bar@ucsb.edu", "foo@ucsb.edu"));
+    }
+
 }


### PR DESCRIPTION
Closes #179 

In this PR, we introduce a utility to the backend called CanonicalFormConverter.

This is for isolating code for various hacks such as converting @umail.ucsb.edu to @ucsb.edu

We may not be able to avoid including special case code for various universities completely.  But we can at least isolate it in one part of the code so that it doesn't spread all over the place.

# Test Plan

Deployed to https://frontiers-qa.dokku-00.cs.ucsb.edu

This is mostly a refactor, but there is one user facing change to test:

* As an admin, try enter email addresses containing `@umail.ucsb.edu` as admins or instructors (note that this would be unlikely to ever occur in practice, but it is not impossible.). They should automatically convert to @ucsb.edu addresses.