### PR TITLE
pc - ensure that within a course, RosterStudent records have unique email and unique studentId values

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -267,7 +267,7 @@ public class CoursesController extends ApiController {
         return rosterStudents.stream()
                 .map(rs -> {
                     Course course = rs.getCourse();
-                    RosterStudentDTO rsDto = RosterStudentDTO.from(rs);
+                    RosterStudentDTO rsDto = new RosterStudentDTO(rs);
                     Map<String, Object> response = new LinkedHashMap<>();
                     response.put("id", course.getId());
                     response.put("installationId", course.getInstallationId());
@@ -275,7 +275,7 @@ public class CoursesController extends ApiController {
                     response.put("courseName", course.getCourseName());
                     response.put("term", course.getTerm());
                     response.put("school", course.getSchool());
-                    response.put("studentStatus", rsDto.getOrgStatus());
+                    response.put("studentStatus", rsDto.orgStatus());
                     return response;
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -10,43 +10,46 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import edu.ucsb.cs156.frontiers.entities.Job;
-import edu.ucsb.cs156.frontiers.entities.User;
-import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
-import edu.ucsb.cs156.frontiers.jobs.UpdateOrgMembershipJob;
-import edu.ucsb.cs156.frontiers.repositories.UserRepository;
-import edu.ucsb.cs156.frontiers.services.*;
-import edu.ucsb.cs156.frontiers.services.jobs.JobService;
-import edu.ucsb.cs156.frontiers.utilities.CanonicalFormConverter;
-
-import org.apache.coyote.BadRequestException;
-import org.checkerframework.checker.units.qual.C;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.http.HttpStatus;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvException;
 
 import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.Job;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.entities.User;
 import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.enums.RosterStatus;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
+import edu.ucsb.cs156.frontiers.jobs.UpdateOrgMembershipJob;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.services.CurrentUserService;
+import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
+import edu.ucsb.cs156.frontiers.services.UpdateUserService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobService;
+import edu.ucsb.cs156.frontiers.utilities.CanonicalFormConverter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
-
-import com.opencsv.CSVReader;
-import com.opencsv.exceptions.CsvException;
-import org.springframework.transaction.annotation.Transactional;
 
 @Tag(name = "RosterStudents")
 @RequestMapping("/api/rosterstudents")
@@ -86,7 +89,7 @@ public class RosterStudentsController extends ApiController {
     @Operation(summary = "Create a new roster student")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
-    public RosterStudent postRosterStudent(
+    public UpsertResponse postRosterStudent(
             @Parameter(name = "studentId") @RequestParam String studentId,
             @Parameter(name = "firstName") @RequestParam String firstName,
             @Parameter(name = "lastName") @RequestParam String lastName,
@@ -106,7 +109,7 @@ public class RosterStudentsController extends ApiController {
                 .build();
 
         UpsertResponse upsertResponse = upsertStudent(rosterStudent, course, RosterStatus.MANUAL); 
-        return upsertResponse.rosterStudent; 
+        return upsertResponse; 
     }
 
     /**

--- a/src/main/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTO.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTO.java
@@ -4,59 +4,38 @@ package edu.ucsb.cs156.frontiers.models;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.enums.RosterStatus;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 
 /**
  * This is a DTO class that represents a student in the roster.
  * It is used to transfer data between the server and the client.
  */
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class RosterStudentDTO {
- 
-    private Long id;
 
-    private Long courseId;
-    
-    private String studentId;
-    private String firstName;
-    private String lastName;
-    private String email;
+public record RosterStudentDTO(
+        Long id,
+        Long courseId,
+        String studentId,
+        String firstName,
+        String lastName,
+        String email,
+        long userId,
+        Integer userGithubId,
+        String userGithubLogin,
+        RosterStatus rosterStatus,
+        OrgStatus orgStatus) {
 
-    private long userId;
-    private Integer userGithubId;
-    private String userGithubLogin;
-
-    @Enumerated(EnumType.STRING)
-    private RosterStatus rosterStatus;
-
-    @Enumerated(EnumType.STRING)
-    private OrgStatus orgStatus;
-
-
-    public static RosterStudentDTO from(RosterStudent student) {
-        long userId = student.getUser() != null ? student.getUser().getId() : 0;
-        
-        return RosterStudentDTO.builder()
-                .id(student.getId())
-                .courseId(student.getCourse().getId())
-                .studentId(student.getStudentId())
-                .firstName(student.getFirstName())
-                .lastName(student.getLastName())
-                .email(student.getEmail())
-                .userId(userId)
-                .userGithubId(student.getGithubId())
-                .userGithubLogin(student.getGithubLogin())
-                .rosterStatus(student.getRosterStatus())
-                .orgStatus(student.getOrgStatus())
-                .build();
+    public RosterStudentDTO(RosterStudent rosterStudent)  {
+        this(
+                rosterStudent.getId(),
+                rosterStudent.getCourse().getId(),
+                rosterStudent.getStudentId(),
+                rosterStudent.getFirstName(),
+                rosterStudent.getLastName(),
+                rosterStudent.getEmail(),
+                rosterStudent.getUser() != null ? rosterStudent.getUser().getId() : 0,
+                rosterStudent.getGithubId(),
+                rosterStudent.getGithubLogin(),
+                rosterStudent.getRosterStatus(),
+                rosterStudent.getOrgStatus()
+        );
     }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/models/UserDataDTO.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/models/UserDataDTO.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 @Builder
 public class UserDataDTO {
     private long id;

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/RosterStudentRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/RosterStudentRepository.java
@@ -15,6 +15,7 @@ public interface RosterStudentRepository extends JpaRepository<RosterStudent, Lo
     List<RosterStudent> findAllByEmail(String email);
     public Iterable<RosterStudent> findByCourseId(Long courseId);
     public Optional<RosterStudent> findByCourseIdAndStudentId(Long courseId, String studentId);
+    public Optional<RosterStudent> findByCourseIdAndEmail(Long courseId, String email);
 
     Optional<RosterStudent> findByCourseAndGithubId(Course course, int githubId);
 

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOService.java
@@ -35,7 +35,7 @@ public class RosterStudentDTOService {
         Iterable<RosterStudent> matchedStudents = rosterStudentRepository.findByCourseId(courseId);
         
         return StreamSupport.stream(matchedStudents.spliterator(), false)
-            .map(RosterStudentDTO::from)
+            .map(RosterStudentDTO::new)
             .collect(Collectors.toList());
 
     }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CSVDownloadsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CSVDownloadsControllerTests.java
@@ -128,25 +128,23 @@ public class CSVDownloadsControllerTests extends ControllerTestCase {
             .school("UCSB")
             .build();
 
-    RosterStudentDTO rosterStudentDTO = RosterStudentDTO.builder()
-            .id(42L)
-            .courseId(course.getId())
-            .studentId("12345")
-            .firstName("Chris")
-            .lastName("Gaucho")
-            .email("cgaucho@ucsb.edu")
-            .userId(102L)
-            .userGithubId(12345)
-            .userGithubLogin("cgaucho")
-            .rosterStatus(RosterStatus.ROSTER)
-            .orgStatus(OrgStatus.PENDING)
-            .build();
-
+    RosterStudentDTO rosterStudentDTO = new RosterStudentDTO(
+            42L,
+            course.getId(),
+            "12345",
+            "Chris",
+            "Gaucho",
+            "cgaucho@ucsb.edu",
+            102L,
+            12345,
+            "cgaucho",
+            RosterStatus.ROSTER,
+            OrgStatus.PENDING
+    );
+              
     doReturn(Optional.of(course)).when(courseRepository).findById(eq(1L));
     doReturn(List.of(rosterStudentDTO)).when(rosterStudentDTOService).getRosterStudentDTOs(eq(1L));
     
-
-
     String expectedResponse =  """
                 "COURSEID","EMAIL","FIRSTNAME","ID","LASTNAME","ORGSTATUS","ROSTERSTATUS","STUDENTID","USERGITHUBID","USERGITHUBLOGIN","USERID"
                 "1","cgaucho@ucsb.edu","Chris","42","Gaucho","PENDING","ROSTER","12345","12345","cgaucho","102"

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
@@ -499,7 +499,7 @@ public class CoursesControllerTests extends ControllerTestCase {
                 expected.put("courseName", course.getCourseName());
                 expected.put("term", course.getTerm());
                 expected.put("school", course.getSchool());
-                expected.put("studentStatus", RosterStudentDTO.from(rs).getOrgStatus());
+                expected.put("studentStatus", new RosterStudentDTO(rs).orgStatus());
 
                 String expectedJson = mapper.writeValueAsString(List.of(expected));
                 assertEquals(expectedJson, result.getResponse().getContentAsString());

--- a/src/test/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTOTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTOTests.java
@@ -38,20 +38,20 @@ public class RosterStudentDTOTests {
 
         // Act
 
-        RosterStudentDTO dto = RosterStudentDTO.from(rosterStudent);
+        RosterStudentDTO dto = new RosterStudentDTO(rosterStudent);
         // Assert
 
-        assertEquals(3L, dto.getId());
-        assertEquals(1L, dto.getCourseId());
-        assertEquals("U123456", dto.getStudentId());
-        assertEquals("John", dto.getFirstName());
-        assertEquals("Doe", dto.getLastName());
-        assertEquals("johndoe@example.com", dto.getEmail());
-        assertEquals(2L, dto.getUserId());
-        assertEquals(12345, dto.getUserGithubId());
-        assertEquals("testuser", dto.getUserGithubLogin());
-        assertEquals(RosterStatus.ROSTER, dto.getRosterStatus());
-        assertEquals(OrgStatus.PENDING, dto.getOrgStatus());
+        assertEquals(3L, dto.id());
+        assertEquals(1L, dto.courseId());
+        assertEquals("U123456", dto.studentId());
+        assertEquals("John", dto.firstName());
+        assertEquals("Doe", dto.lastName());
+        assertEquals("johndoe@example.com", dto.email());
+        assertEquals(2L, dto.userId());
+        assertEquals(12345, dto.userGithubId());
+        assertEquals("testuser", dto.userGithubLogin());
+        assertEquals(RosterStatus.ROSTER, dto.rosterStatus());
+        assertEquals(OrgStatus.PENDING, dto.orgStatus());
     }
 
     @Test
@@ -74,38 +74,20 @@ public class RosterStudentDTOTests {
         rosterStudent.setOrgStatus(OrgStatus.PENDING);
 
         // Act
-        RosterStudentDTO dto = RosterStudentDTO.from(rosterStudent);
+        RosterStudentDTO dto = new RosterStudentDTO(rosterStudent);
 
         // Assert
-        assertEquals(3L, dto.getId());
-        assertEquals(1L, dto.getCourseId());
-        assertEquals("U123456", dto.getStudentId());
-        assertEquals("John", dto.getFirstName());
-        assertEquals("Doe", dto.getLastName());
-        assertEquals("johndoe@example.com", dto.getEmail());
-        assertEquals(0, dto.getUserId());
-        assertEquals(12345, dto.getUserGithubId());
-        assertEquals("testuser", dto.getUserGithubLogin());
-        assertEquals(RosterStatus.ROSTER, dto.getRosterStatus());
-        assertEquals(OrgStatus.PENDING, dto.getOrgStatus());
+        assertEquals(3L, dto.id());
+        assertEquals(1L, dto.courseId());
+        assertEquals("U123456", dto.studentId());
+        assertEquals("John", dto.firstName());
+        assertEquals("Doe", dto.lastName());
+        assertEquals("johndoe@example.com", dto.email());
+        assertEquals(0L, dto.userId());
+        assertEquals(12345, dto.userGithubId());
+        assertEquals("testuser", dto.userGithubLogin());
+        assertEquals(RosterStatus.ROSTER, dto.rosterStatus());
+        assertEquals(OrgStatus.PENDING, dto.orgStatus());
 
-    }
-
-    @Test
-    public void test_no_arg_constructor() {
-        // Arrange
-        RosterStudentDTO dto = new RosterStudentDTO();
-
-        // Act & Assert
-        assertEquals(null, dto.getId());
-        assertEquals(null, dto.getCourseId());
-        assertEquals(null, dto.getStudentId());
-        assertEquals(null, dto.getFirstName());
-        assertEquals(null, dto.getLastName());
-        assertEquals(null, dto.getEmail());
-        assertEquals(0L, dto.getUserId());
-        assertEquals(null, dto.getUserGithubId());
-        assertEquals(null, dto.getUserGithubLogin());
-        assertEquals(null, dto.getOrgStatus());
     }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/models/UserDataDTOTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/models/UserDataDTOTests.java
@@ -4,6 +4,7 @@ import edu.ucsb.cs156.frontiers.entities.User;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class UserDataDTOTests {
 
@@ -60,4 +61,10 @@ public class UserDataDTOTests {
 
         assertEquals(translated, UserDataDTO.from(user, true, true) );
     }
+
+    @Test
+    public void noArgsConstructorTest() {
+        UserDataDTO userDataDTO = new UserDataDTO();
+        assertEquals(0, userDataDTO.getId());
+    }   
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/models/UserDataDTOTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/models/UserDataDTOTests.java
@@ -61,10 +61,4 @@ public class UserDataDTOTests {
 
         assertEquals(translated, UserDataDTO.from(user, true, true) );
     }
-
-    @Test
-    public void noArgsConstructorTest() {
-        UserDataDTO userDataDTO = new UserDataDTO();
-        assertEquals(0, userDataDTO.getId());
-    }   
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOServiceTests.java
@@ -64,17 +64,17 @@ public class RosterStudentDTOServiceTests {
         // Assert
         assertEquals(1, dtos.size());
         RosterStudentDTO dto = dtos.get(0);
-        assertEquals(3L, dto.getId());
-        assertEquals(1L, dto.getCourseId());
-        assertEquals("U123456", dto.getStudentId());
-        assertEquals("John", dto.getFirstName());
-        assertEquals("Doe", dto.getLastName());
-        assertEquals("johndoe@example.com", dto.getEmail());
-        assertEquals(2L, dto.getUserId());
-        assertEquals(12345, dto.getUserGithubId());
-        assertEquals("testuser", dto.getUserGithubLogin());
-        assertEquals(RosterStatus.ROSTER, dto.getRosterStatus());
-        assertEquals(OrgStatus.PENDING, dto.getOrgStatus());
+        assertEquals(3L, dto.id());
+        assertEquals(1L, dto.courseId());
+        assertEquals("U123456", dto.studentId());
+        assertEquals("John", dto.firstName());
+        assertEquals("Doe", dto.lastName());
+        assertEquals("johndoe@example.com", dto.email());
+        assertEquals(2L, dto.userId());
+        assertEquals(12345, dto.userGithubId());
+        assertEquals("testuser", dto.userGithubLogin());
+        assertEquals(RosterStatus.ROSTER, dto.rosterStatus());
+        assertEquals(OrgStatus.PENDING, dto.orgStatus());
     }
 
   


### PR DESCRIPTION
MERGE AFTER #184 (the refactor is needed for this PR to pass pitest mutation coverage)

Closes #180 and, when #179 also merged, also #46.

We do not want duplicate entries for the same student in a course.  Both email and studentId should be unique, but in the event of human error that results in entry of a duplicate value, we want to handle that gracefully.

The main way that duplicate might arise in practice are:
* Manually entering duplicates through the single add POST
* Having duplicate lines in a manually edited CSV file
* Entering someone manually by POST that was already entered via the CSV upload.

# Test Plan

Try all of the scenarios above, and ensure that in each one, the result is something reasonable.

Deployed to: https://frontiers-qa4.dokku-00.cs.ucsb.edu



