### PR TITLE
FEATURE: instructor course show page

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -8,6 +8,8 @@ const config = {
     "@storybook/addon-essentials",
     "@chromatic-com/storybook",
     "@storybook/addon-interactions",
+    "storybook-addon-remix-react-router",
+    "@storybook/addon-queryparams"
   ],
   framework: {
     name: "@storybook/react-webpack5",

--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -5,40 +5,53 @@ import 'react-toastify/dist/ReactToastify.css';
 import { initialize, mswLoader } from 'msw-storybook-addon'
 
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
-import { ToastContainer } from "react-toastify";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { ToastContainer, toast } from "react-toastify";
+import { useEffect } from "react";
 
 const queryClient = new QueryClient();
 
-const currentUrl = window.location.href;
-const isLocalhost = currentUrl.startsWith("http://localhost:6006/");
-const mockServiceWorkerUrl = isLocalhost ? "mockServiceWorker.js" : "https://" + window.location.hostname + "/mockServiceWorker.js";
-
 // Initialize MSW
+initialize()
 
-initialize(
-  {
-    serviceWorker: {
-      url: mockServiceWorkerUrl
-    }
-  }
-);
-
-
-// Per https://storybook.js.org/docs/react/writing-stories/decorators#context-for-mocking
-// Here, we provide the context needed for some of the components,
-// e.g. the ones that rely on currentUser
+// For conditional decorators trick, see: https://github.com/storybookjs/storybook/issues/23237#issuecomment-1611351405 
+// Decorators are applied in order; the innermost decorator is applied first.
+// Here, if suppressMemoryRouter is true, then the MemoryRouter decorator is not applied,
+// and we don't use the useLocation hook to show a toast message when navigate is called.
 
 export const decorators = [
+  (Story, Context) => {
+    if (Context.args?.suppressMemoryRouter) {
+      return <Story />;
+    } else {
+      const location = useLocation();
+      useEffect(() => {
+        if (location.pathname !== "/") {
+          toast("Would navigate to: " + location.pathname);
+        }
+      }, [location]);
+      return <Story />;
+    }
+  },
+  (Story) => {
+    return (<>
+      <ToastContainer />
+      <Story />
+    </>
+    );
+  },
+  (Story, Context) => (
+    Context.args?.suppressMemoryRouter ?
+      <Story /> :
+      <MemoryRouter><Story /></MemoryRouter>
+  ),
   (Story) => (
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
-        <ToastContainer />
-        <Story />
-      </MemoryRouter>
-    </QueryClientProvider>
-  )
+      <Story />
+    </QueryClientProvider >
+  ),
 ];
+
 
 /** @type { import('@storybook/react').Preview } */
 const preview = {
@@ -52,5 +65,6 @@ const preview = {
   },
   loaders: [mswLoader]
 };
+
 
 export default preview;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
         "@storybook/addon-interactions": "^8.2.9",
         "@storybook/addon-links": "^8.2.9",
         "@storybook/addon-onboarding": "^8.2.9",
+        "@storybook/addon-queryparams": "^7.0.1",
         "@storybook/blocks": "^8.2.9",
         "@storybook/preset-create-react-app": "^8.2.9",
         "@storybook/react": "^8.2.9",
@@ -54,6 +55,7 @@
         "prettier": "^3.3.3",
         "prop-types": "^15.8.1",
         "storybook": "^8.2.9",
+        "storybook-addon-remix-react-router": "^3.0.0",
         "typescript-eslint": "^8.2.0",
         "webpack": "^5.93.0"
       },
@@ -5373,6 +5375,17 @@
         "storybook": "^8.2.9"
       }
     },
+    "node_modules/@storybook/addon-queryparams": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-queryparams/-/addon-queryparams-7.0.1.tgz",
+      "integrity": "sha512-hlOrjCbUdkg/f/7HaIBMvEp2oyNkBYaxifDdGNyUhdBzfuWUeWDTUwYDxUubbhuqNcSMbw5Cje34dE+hJaGR9A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@storybook/manager-api": "^7.0.0 || ^8.0.0 || ^8.0.0-rc.0",
+        "@storybook/preview-api": "^7.0.0 || ^8.0.0 || ^8.0.0-rc.0"
+      }
+    },
     "node_modules/@storybook/addon-toolbars": {
       "version": "8.2.9",
       "dev": true,
@@ -5682,6 +5695,21 @@
         }
       }
     },
+    "node_modules/@storybook/channels": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.6.14.tgz",
+      "integrity": "sha512-vIpR+Yii1urfL+aVAIj4Wbfv/dbO8yfGd70LaIQSgHiFQqN2/BCrst65UfeQxLUVlFiKY70ll6ll3/2JFj3Cag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
     "node_modules/@storybook/codemod": {
       "version": "8.2.9",
       "dev": true,
@@ -5790,6 +5818,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-events": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.6.14.tgz",
+      "integrity": "sha512-RrJ95u3HuIE4Nk8VmZP0tc/u0vYoE2v9fYlMw6K2GUSExzKDITs3voy6WMIY7Q3qbQun8XUXVlmqkuFzTEy/pA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
       }
     },
     "node_modules/@storybook/core-webpack": {
@@ -11006,6 +11049,13 @@
     },
     "node_modules/commondir": {
       "version": "1.0.1",
+      "license": "MIT"
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/compressible": {
@@ -24248,6 +24298,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/storybook-addon-remix-react-router": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-remix-react-router/-/storybook-addon-remix-react-router-3.1.0.tgz",
+      "integrity": "sha512-h6cOD+afyAddNrDz5ezoJGV6GBSeH7uh92VAPDz+HLuay74Cr9Ozz+aFmlzMEyVJ1hhNIMOIWDsmK56CueZjsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compare-versions": "^6.0.0",
+        "react-inspector": "6.0.2"
+      },
+      "peerDependencies": {
+        "@storybook/blocks": "^8.0.0",
+        "@storybook/channels": "^8.0.0",
+        "@storybook/components": "^8.0.0",
+        "@storybook/core-events": "^8.0.0",
+        "@storybook/manager-api": "^8.0.0",
+        "@storybook/preview-api": "^8.0.0",
+        "@storybook/theming": "^8.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-router-dom": "^6.4.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/storybook/node_modules/@sindresorhus/merge-streams": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "@storybook/addon-interactions": "^8.2.9",
     "@storybook/addon-links": "^8.2.9",
     "@storybook/addon-onboarding": "^8.2.9",
+    "@storybook/addon-queryparams": "^7.0.1",
     "@storybook/blocks": "^8.2.9",
     "@storybook/preset-create-react-app": "^8.2.9",
     "@storybook/react": "^8.2.9",
@@ -75,6 +76,7 @@
     "prettier": "^3.3.3",
     "prop-types": "^15.8.1",
     "storybook": "^8.2.9",
+    "storybook-addon-remix-react-router": "^3.0.0",
     "typescript-eslint": "^8.2.0",
     "webpack": "^5.93.0"
   },

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,7 @@ import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import "bootstrap/dist/css/bootstrap.css";
 import "react-toastify/dist/ReactToastify.css";
 import CoursesIndexPage from "main/pages/Courses/CoursesIndexPage";
+import InstructorCourseShowPage from "main/pages/Instructor/InstructorCourseShowPage";
 
 function App() {
   const { data: currentUser } = useCurrentUser();
@@ -22,11 +23,18 @@ function App() {
         )}
         {(hasRole(currentUser, "ROLE_ADMIN") ||
           hasRole(currentUser, "ROLE_INSTRUCTOR")) && (
-          <Route
-            exact
-            path="/instructor/courses"
-            element={<CoursesIndexPage />}
-          />
+          <>
+            <Route
+              exact
+              path="/instructor/courses"
+              element={<CoursesIndexPage />}
+            />
+            <Route
+              exact
+              path="/instructor/courses/:id"
+              element={<InstructorCourseShowPage />}
+            />
+          </>
         )}
       </Routes>
     </BrowserRouter>

--- a/frontend/src/main/components/Courses/InstructorCoursesTable.js
+++ b/frontend/src/main/components/Courses/InstructorCoursesTable.js
@@ -10,6 +10,16 @@ const columns = [
   {
     Header: "Course Name",
     accessor: "courseName",
+    Cell: ({ cell }) => {
+      return (
+        <a
+          href={`/instructor/courses/${cell.row.values.id}`}
+          data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-link`}
+        >
+          {cell.value}
+        </a>
+      );
+    },
   },
   {
     Header: "Term",
@@ -25,6 +35,7 @@ export default function InstructorCoursesTable({
   courses,
   storybook = false,
   currentUser,
+  testId = "InstructorCoursesTable",
 }) {
   const installCallback = (cell) => {
     const url = `/api/courses/redirect?courseId=${cell.row.values.id}`;
@@ -64,7 +75,7 @@ export default function InstructorCoursesTable({
             <Button
               variant={"primary"}
               onClick={() => installCallback(cell)}
-              data-testid={`InstructorCoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
+              data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
               data-reason={result.reason}
             >
               Install Github App
@@ -73,7 +84,7 @@ export default function InstructorCoursesTable({
         } else {
           return (
             <span
-              data-testid={`InstructorCoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-cannot-install-${result.reason}`}
+              data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-cannot-install-${result.reason}`}
             >
               {cell.value}
             </span>
@@ -88,10 +99,6 @@ export default function InstructorCoursesTable({
   ];
 
   return (
-    <OurTable
-      data={courses}
-      columns={columnsWithInstall}
-      testid={"InstructorCoursesTable"}
-    />
+    <OurTable data={courses} columns={columnsWithInstall} testid={testId} />
   );
 }

--- a/frontend/src/main/pages/Instructor/InstructorCourseShowPage.js
+++ b/frontend/src/main/pages/Instructor/InstructorCourseShowPage.js
@@ -1,0 +1,41 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import InstructorCoursesTable from "main/components/Courses/InstructorCoursesTable";
+import { useCurrentUser } from "main/utils/currentUser";
+import { useParams } from "react-router-dom";
+
+export default function InstructorCourseShowPage() {
+  const { data: currentUser } = useCurrentUser();
+  const courseId = useParams().id;
+
+  const {
+    data: course,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/courses/all"],
+    // Stryker disable next-line StringLiteral : GET and empty string are equivalent
+    { method: "GET", url: `/api/courses/${courseId}` },
+    // Stryker disable next-line all : don't test default value of empty list
+    null,
+  );
+
+  const testId = "InstructorCourseShowPage";
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Course</h1>
+        <InstructorCoursesTable
+          courses={course ? [course] : []}
+          currentUser={currentUser}
+          testId={testId}
+        />
+        <h2>Roster Students</h2>
+        <p>Coming soon: Roster Students for this course will appear here.</p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/stories/pages/Instructor/InstructorCourseShowPage.stories.js
+++ b/frontend/src/stories/pages/Instructor/InstructorCourseShowPage.stories.js
@@ -1,0 +1,58 @@
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import {
+  withRouter,
+  reactRouterParameters,
+} from "storybook-addon-remix-react-router";
+
+import InstructorCourseShowPage from "main/pages/Instructor/InstructorCourseShowPage";
+import coursesFixtures from "fixtures/coursesFixtures";
+
+export default {
+  title: "pages/Instructor/InstructorCourseShowPage",
+  component: InstructorCourseShowPage,
+  decorators: [withRouter],
+  parameters: {
+    reactRouter: reactRouterParameters({
+      location: {
+        pathParams: { id: "7" },
+      },
+      routing: { path: "/instructor/courses/:id" },
+    }),
+  },
+};
+
+const Template = () => <InstructorCourseShowPage />;
+
+const exampleCourse = {
+  ...coursesFixtures.oneCourseWithEachStatus[0],
+  id: 7,
+  createdByEmail: "phtcon@ucsb.edu",
+};
+
+export const ExampleCourse = Template.bind({});
+ExampleCourse.args = {
+  suppressMemoryRouter: true,
+};
+ExampleCourse.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+      }),
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+      http.get("/api/courses/7", () => {
+        return HttpResponse.json(exampleCourse, {
+          status: 200,
+        });
+      }),
+    ],
+  },
+};

--- a/frontend/src/tests/components/Courses/InstructorCoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/InstructorCoursesTable.test.js
@@ -102,6 +102,11 @@ describe("InstructorCoursesTable tests", () => {
     // This span should be empty since the course has no orgName
     expect(span4).toBeEmptyDOMElement();
 
+    const firstCourseLink = screen.getByTestId(
+      "CoursesTable-cell-row-0-col-courseName-link",
+    );
+    expect(firstCourseLink).toHaveAttribute("href", "/instructor/courses/1");
+
     // Make sure that the callback is called when the button is clicked
     fireEvent.click(button3);
     await waitFor(() => {

--- a/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
+++ b/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from "@testing-library/react";
 import InstructorCourseShowPage from "main/pages/Instructor/InstructorCourseShowPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import mockConsole from "jest-mock-console";
 import coursesFixtures from "fixtures/coursesFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
+++ b/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import InstructorCourseShowPage from "main/pages/Instructor/InstructorCourseShowPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+import coursesFixtures from "fixtures/coursesFixtures";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("InstructorCourseShowPage tests", () => {
+  const testId = "InstructorCourseShowPage";
+
+  let axiosMock;
+
+  beforeEach(() => {
+    axiosMock = new AxiosMockAdapter(axios);
+  });
+
+  afterEach(() => {
+    axiosMock.restore();
+  });
+
+  const setupInstructorUser = () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.instructorUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  test("renders correctly for instructor user", async () => {
+    setupInstructorUser();
+    const queryClient = new QueryClient();
+    const theCourse = {
+      ...coursesFixtures.oneCourseWithEachStatus[0],
+      id: 1,
+      createdByEmail: "phtcon@ucsb.edu",
+    };
+    axiosMock.onGet("/api/courses/1").reply(200, theCourse);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/instructor/courses/1"]}>
+          <Routes>
+            <Route
+              path="/instructor/courses/:id"
+              element={<InstructorCourseShowPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+
+    const orgName = screen.getByText("ucsb-cs156-s25");
+    expect(orgName).toBeInTheDocument();
+  });
+
+  test("renders correctly for default empty list", async () => {
+    setupInstructorUser();
+    const queryClient = new QueryClient();
+
+    axiosMock.onGet("/api/courses/7").reply(200, "");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/instructor/courses/7"]}>
+          <Routes>
+            <Route
+              path="/instructor/courses/:id"
+              element={<InstructorCourseShowPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Course Name")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-id`),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Deployed to: https://frontiers-qa5.dokku-00.cs.ucsb.edu

In this PR, we add a show page for the course.

For now, this page just repeats information already available on the InstructorCoursesTable, but in the future, it will be a basis for adding more instructor facing features, such as:
* maintaining the list of roster students
* creating repos for individual and team assignments
* anything else an instructor needs to do that pertains to a specific course.

# Screenshots

Modified InstructorCoursesTable, where course title is a link:

<img width="1241" height="315" alt="image" src="https://github.com/user-attachments/assets/ce459fe1-4ae9-42f8-a465-78d861302643" />

When you click on the link, you go to pages such as these:

<img width="1196" height="423" alt="image" src="https://github.com/user-attachments/assets/150c97de-c8cc-4a93-9dfd-6dbcd94cdbc2" />


# Storybook entries

