### PR TITLE
REFACTOR: refactor the RosterStudentDTO to make it a record instead of a Lombok Data Class

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -267,7 +267,7 @@ public class CoursesController extends ApiController {
         return rosterStudents.stream()
                 .map(rs -> {
                     Course course = rs.getCourse();
-                    RosterStudentDTO rsDto = RosterStudentDTO.from(rs);
+                    RosterStudentDTO rsDto = new RosterStudentDTO(rs);
                     Map<String, Object> response = new LinkedHashMap<>();
                     response.put("id", course.getId());
                     response.put("installationId", course.getInstallationId());
@@ -275,7 +275,7 @@ public class CoursesController extends ApiController {
                     response.put("courseName", course.getCourseName());
                     response.put("term", course.getTerm());
                     response.put("school", course.getSchool());
-                    response.put("studentStatus", rsDto.getOrgStatus());
+                    response.put("studentStatus", rsDto.orgStatus());
                     return response;
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTO.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTO.java
@@ -4,59 +4,38 @@ package edu.ucsb.cs156.frontiers.models;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.enums.RosterStatus;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 
 /**
  * This is a DTO class that represents a student in the roster.
  * It is used to transfer data between the server and the client.
  */
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class RosterStudentDTO {
- 
-    private Long id;
 
-    private Long courseId;
-    
-    private String studentId;
-    private String firstName;
-    private String lastName;
-    private String email;
+public record RosterStudentDTO(
+        Long id,
+        Long courseId,
+        String studentId,
+        String firstName,
+        String lastName,
+        String email,
+        long userId,
+        Integer userGithubId,
+        String userGithubLogin,
+        RosterStatus rosterStatus,
+        OrgStatus orgStatus) {
 
-    private long userId;
-    private Integer userGithubId;
-    private String userGithubLogin;
-
-    @Enumerated(EnumType.STRING)
-    private RosterStatus rosterStatus;
-
-    @Enumerated(EnumType.STRING)
-    private OrgStatus orgStatus;
-
-
-    public static RosterStudentDTO from(RosterStudent student) {
-        long userId = student.getUser() != null ? student.getUser().getId() : 0;
-        
-        return RosterStudentDTO.builder()
-                .id(student.getId())
-                .courseId(student.getCourse().getId())
-                .studentId(student.getStudentId())
-                .firstName(student.getFirstName())
-                .lastName(student.getLastName())
-                .email(student.getEmail())
-                .userId(userId)
-                .userGithubId(student.getGithubId())
-                .userGithubLogin(student.getGithubLogin())
-                .rosterStatus(student.getRosterStatus())
-                .orgStatus(student.getOrgStatus())
-                .build();
+    public RosterStudentDTO(RosterStudent rosterStudent)  {
+        this(
+                rosterStudent.getId(),
+                rosterStudent.getCourse().getId(),
+                rosterStudent.getStudentId(),
+                rosterStudent.getFirstName(),
+                rosterStudent.getLastName(),
+                rosterStudent.getEmail(),
+                rosterStudent.getUser() != null ? rosterStudent.getUser().getId() : 0,
+                rosterStudent.getGithubId(),
+                rosterStudent.getGithubLogin(),
+                rosterStudent.getRosterStatus(),
+                rosterStudent.getOrgStatus()
+        );
     }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOService.java
@@ -35,7 +35,7 @@ public class RosterStudentDTOService {
         Iterable<RosterStudent> matchedStudents = rosterStudentRepository.findByCourseId(courseId);
         
         return StreamSupport.stream(matchedStudents.spliterator(), false)
-            .map(RosterStudentDTO::from)
+            .map(RosterStudentDTO::new)
             .collect(Collectors.toList());
 
     }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CSVDownloadsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CSVDownloadsControllerTests.java
@@ -128,25 +128,23 @@ public class CSVDownloadsControllerTests extends ControllerTestCase {
             .school("UCSB")
             .build();
 
-    RosterStudentDTO rosterStudentDTO = RosterStudentDTO.builder()
-            .id(42L)
-            .courseId(course.getId())
-            .studentId("12345")
-            .firstName("Chris")
-            .lastName("Gaucho")
-            .email("cgaucho@ucsb.edu")
-            .userId(102L)
-            .userGithubId(12345)
-            .userGithubLogin("cgaucho")
-            .rosterStatus(RosterStatus.ROSTER)
-            .orgStatus(OrgStatus.PENDING)
-            .build();
-
+    RosterStudentDTO rosterStudentDTO = new RosterStudentDTO(
+            42L,
+            course.getId(),
+            "12345",
+            "Chris",
+            "Gaucho",
+            "cgaucho@ucsb.edu",
+            102L,
+            12345,
+            "cgaucho",
+            RosterStatus.ROSTER,
+            OrgStatus.PENDING
+    );
+              
     doReturn(Optional.of(course)).when(courseRepository).findById(eq(1L));
     doReturn(List.of(rosterStudentDTO)).when(rosterStudentDTOService).getRosterStudentDTOs(eq(1L));
     
-
-
     String expectedResponse =  """
                 "COURSEID","EMAIL","FIRSTNAME","ID","LASTNAME","ORGSTATUS","ROSTERSTATUS","STUDENTID","USERGITHUBID","USERGITHUBLOGIN","USERID"
                 "1","cgaucho@ucsb.edu","Chris","42","Gaucho","PENDING","ROSTER","12345","12345","cgaucho","102"

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
@@ -499,7 +499,7 @@ public class CoursesControllerTests extends ControllerTestCase {
                 expected.put("courseName", course.getCourseName());
                 expected.put("term", course.getTerm());
                 expected.put("school", course.getSchool());
-                expected.put("studentStatus", RosterStudentDTO.from(rs).getOrgStatus());
+                expected.put("studentStatus", new RosterStudentDTO(rs).orgStatus());
 
                 String expectedJson = mapper.writeValueAsString(List.of(expected));
                 assertEquals(expectedJson, result.getResponse().getContentAsString());

--- a/src/test/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTOTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/models/RosterStudentDTOTests.java
@@ -38,20 +38,20 @@ public class RosterStudentDTOTests {
 
         // Act
 
-        RosterStudentDTO dto = RosterStudentDTO.from(rosterStudent);
+        RosterStudentDTO dto = new RosterStudentDTO(rosterStudent);
         // Assert
 
-        assertEquals(3L, dto.getId());
-        assertEquals(1L, dto.getCourseId());
-        assertEquals("U123456", dto.getStudentId());
-        assertEquals("John", dto.getFirstName());
-        assertEquals("Doe", dto.getLastName());
-        assertEquals("johndoe@example.com", dto.getEmail());
-        assertEquals(2L, dto.getUserId());
-        assertEquals(12345, dto.getUserGithubId());
-        assertEquals("testuser", dto.getUserGithubLogin());
-        assertEquals(RosterStatus.ROSTER, dto.getRosterStatus());
-        assertEquals(OrgStatus.PENDING, dto.getOrgStatus());
+        assertEquals(3L, dto.id());
+        assertEquals(1L, dto.courseId());
+        assertEquals("U123456", dto.studentId());
+        assertEquals("John", dto.firstName());
+        assertEquals("Doe", dto.lastName());
+        assertEquals("johndoe@example.com", dto.email());
+        assertEquals(2L, dto.userId());
+        assertEquals(12345, dto.userGithubId());
+        assertEquals("testuser", dto.userGithubLogin());
+        assertEquals(RosterStatus.ROSTER, dto.rosterStatus());
+        assertEquals(OrgStatus.PENDING, dto.orgStatus());
     }
 
     @Test
@@ -74,38 +74,20 @@ public class RosterStudentDTOTests {
         rosterStudent.setOrgStatus(OrgStatus.PENDING);
 
         // Act
-        RosterStudentDTO dto = RosterStudentDTO.from(rosterStudent);
+        RosterStudentDTO dto = new RosterStudentDTO(rosterStudent);
 
         // Assert
-        assertEquals(3L, dto.getId());
-        assertEquals(1L, dto.getCourseId());
-        assertEquals("U123456", dto.getStudentId());
-        assertEquals("John", dto.getFirstName());
-        assertEquals("Doe", dto.getLastName());
-        assertEquals("johndoe@example.com", dto.getEmail());
-        assertEquals(0, dto.getUserId());
-        assertEquals(12345, dto.getUserGithubId());
-        assertEquals("testuser", dto.getUserGithubLogin());
-        assertEquals(RosterStatus.ROSTER, dto.getRosterStatus());
-        assertEquals(OrgStatus.PENDING, dto.getOrgStatus());
+        assertEquals(3L, dto.id());
+        assertEquals(1L, dto.courseId());
+        assertEquals("U123456", dto.studentId());
+        assertEquals("John", dto.firstName());
+        assertEquals("Doe", dto.lastName());
+        assertEquals("johndoe@example.com", dto.email());
+        assertEquals(0L, dto.userId());
+        assertEquals(12345, dto.userGithubId());
+        assertEquals("testuser", dto.userGithubLogin());
+        assertEquals(RosterStatus.ROSTER, dto.rosterStatus());
+        assertEquals(OrgStatus.PENDING, dto.orgStatus());
 
-    }
-
-    @Test
-    public void test_no_arg_constructor() {
-        // Arrange
-        RosterStudentDTO dto = new RosterStudentDTO();
-
-        // Act & Assert
-        assertEquals(null, dto.getId());
-        assertEquals(null, dto.getCourseId());
-        assertEquals(null, dto.getStudentId());
-        assertEquals(null, dto.getFirstName());
-        assertEquals(null, dto.getLastName());
-        assertEquals(null, dto.getEmail());
-        assertEquals(0L, dto.getUserId());
-        assertEquals(null, dto.getUserGithubId());
-        assertEquals(null, dto.getUserGithubLogin());
-        assertEquals(null, dto.getOrgStatus());
     }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/RosterStudentDTOServiceTests.java
@@ -64,17 +64,17 @@ public class RosterStudentDTOServiceTests {
         // Assert
         assertEquals(1, dtos.size());
         RosterStudentDTO dto = dtos.get(0);
-        assertEquals(3L, dto.getId());
-        assertEquals(1L, dto.getCourseId());
-        assertEquals("U123456", dto.getStudentId());
-        assertEquals("John", dto.getFirstName());
-        assertEquals("Doe", dto.getLastName());
-        assertEquals("johndoe@example.com", dto.getEmail());
-        assertEquals(2L, dto.getUserId());
-        assertEquals(12345, dto.getUserGithubId());
-        assertEquals("testuser", dto.getUserGithubLogin());
-        assertEquals(RosterStatus.ROSTER, dto.getRosterStatus());
-        assertEquals(OrgStatus.PENDING, dto.getOrgStatus());
+        assertEquals(3L, dto.id());
+        assertEquals(1L, dto.courseId());
+        assertEquals("U123456", dto.studentId());
+        assertEquals("John", dto.firstName());
+        assertEquals("Doe", dto.lastName());
+        assertEquals("johndoe@example.com", dto.email());
+        assertEquals(2L, dto.userId());
+        assertEquals(12345, dto.userGithubId());
+        assertEquals("testuser", dto.userGithubLogin());
+        assertEquals(RosterStatus.ROSTER, dto.rosterStatus());
+        assertEquals(OrgStatus.PENDING, dto.orgStatus());
     }
 
   


### PR DESCRIPTION
In this PR, we refactor the RosterStudentDTO to make it a record instead of a Lombok Data Class.

This simplifies mutation coverage and reduces boilerplate code.