### PR TITLE
pc - rewrite scripts and instructions for converting the private key for the Github app

### DIFF
--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -2,6 +2,6 @@ GOOGLE_CLIENT_ID=see-instructions-in-readme
 GOOGLE_CLIENT_SECRET=see-instructions-in-readme
 GITHUB_CLIENT_ID=see-instructions-in-readme
 GITHUB_CLIENT_SECRET=see-instructions-in-readme
+app_private_key=see-instructions-in-readme
 ADMIN_EMAILS=phtcon@ucsb.edu
-
 CHROMATIC_PROJECT_TOKEN=see-instructions-in-readme

--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,6 @@ build/
 ### Local Configuration ###
 .env
 secrets.yaml
+secrets.yaml.backup
 .DS_Store
 

--- a/docs/github-app-setup-dokku.md
+++ b/docs/github-app-setup-dokku.md
@@ -123,3 +123,8 @@ xxxxxxxxxxxxxxxxxxxxxxxxx
 
 If you haven't yet done so, do the other steps listed in [/docs/dokku.md](dokku.md).
 
+For example, you'll need to do this command in order for
+the new config variables to take effect:
+
+
+`dokku ps:rebuild frontiers`

--- a/docs/github-app-setup-dokku.md
+++ b/docs/github-app-setup-dokku.md
@@ -1,4 +1,6 @@
-Next, we'll set up the Github App. To do so, go to https://github.com/
+# Setting up the Github App for Frontiers running on Dokku
+
+Go to https://github.com/
 
 Then, click your profile icon. Click "Settings". Then, Click "Developer Settings", on the bottom of the toolbar on the left.
 
@@ -61,37 +63,10 @@ Then, scroll further and under "Where can this Github App be installed?" select 
 
 Click "Create".
 
-Now, Select "Generate Client Secret". Copy this client secret to a safe location, you will use it in a few minutes. Copy the Client ID as well.
+Now, Select "Generate Client Secret". 
 
 ![image](https://github.com/user-attachments/assets/856cf882-b6f3-44a5-b70b-115531bb8cae)
 
-
-Scroll down to "Private Keys" and select "Generate a Private Key"
-
-![image](https://github.com/user-attachments/assets/7c2b958a-f912-4972-af63-9ff2c30339cd)
-
-
-Though we will now start using other applications, keep this Github window open. You'll need it later.
-
-This will download a private key to your computer.
-
-Next, we will switch the standard of the key we just downloaded so Java can understand it.
-
-Copy the key from wherever it downloaded to the root of the frontiers project.
-To do so, open a terminal in the folder the key is in, and run the following command, replacing `<file-name>` with the name of the key.
-```bash
-./keyconvert.sh <file-name>
-```
-
-Next, we're going to take the output of this newly created file and set it as an environmental variable on Dokku. To do so, output the file into your terminal with the following command:
-```bash
-cat pkcs8.key
-```
-
-Copy the output from this command and connect to your Dokku installation. As this is a multiline variable, it will need to be between a set of quotes. Make sure that you paste it between the quotes, otherwise the variable will only be set to the first line of the key. Use the following command, replacing <appname> with your app name and <file-output> with the copied output from the previous step:
-```bash
-dokku config:set --no-restart <appname> app_private_key="<file-output>"
-```
 
 Then, set your Github Client ID and Github Client Secret with the following commands respectively:
 ```bash
@@ -99,20 +74,52 @@ dokku config:set --no-restart <appname> GITHUB_CLIENT_ID=<client-id>
 dokku config:set --no-restart <appname> GITHUB_CLIENT_SECRET=<client-secret>
 ```
 
-Then, set your Google Cloud Credentials from earlier with the following commands:
-```bash
-dokku config:set --no-restart <appname> GOOGLE_CLIENT_ID=<client-id>
-dokku config:set --no-restart <appname> GOOGLE_CLIENT_SECRET=<client-secret>
+## Generating a value for `app_private_key`
+
+Scroll down to "Private Keys" and select "Generate a Private Key"
+
+![image](https://github.com/user-attachments/assets/7c2b958a-f912-4972-af63-9ff2c30339cd)
+
+
+This will download a private key file (with file name ending `.private-key.pem` to your computer, probably into your default `Downloads` directory.  We'll need this file in the next step.
+
+Note that the file has the current date in the filename; this will help you be sure you have the correct file.  We'll use this file in the next step.
+
+## Converting the private key file.
+
+Next, we will run a script that converts this private key 
+into a `dokku config:set ...` command.
+
+Copy the key from wherever it downloaded to the *root of the frontiers project*, i.e. the directory where you cloned the repo.
+
+For example, if `~/Downloads` is the directory where files are downloaded, then this command will copy all files ending in `.private-key.pem` to your current directory.
+
+```
+cp ~/Downloads/*.private-key.pem .
 ```
 
-Next, set up a Postgres database for your app. A separate set of directions for this step are listed [here](https://ucsb-cs156.github.io/topics/dokku/postgres_database.html#postgres-database---how-to-deploy-a-postgres-database).
+Note that you *must not commit* this private key to the Github Repo! The `.gitignore` should handle this, but be careful in any case.
 
-Next, sync the app with the repository.
-```bash
-dokku git:sync <appname> https://github.com/ucsb-cs156/proj-frontiers main
+Now run this script: 
+```
+./keyconvert.sh
 ```
 
-Next, start your app.
+* If there is only one file ending in `private-key.pem` in the current directory, it will be selected automatically. Otherwise, you'll be asked to choose one.
+* The script will then prompt you for the name of your dokku app (e.g. `frontiers`, `frontiers-qa`, etc.)
+
+The script will then output the command that you should copy to the dokku command line
+
+As this is a multiline variable, it will need to be between a set of quotes. Make sure that you paste it between the quotes, otherwise the variable will only be set to the first line of the key. Use the following command, replacing <appname> with your app name and <file-output> with the copied output from the previous step:
 ```bash
-dokku ps:rebuild <appname>
+dokku config:set frontiers --no-restart app_private_key="-----BEGIN PRIVATE KEY-----
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxx
+-----END PRIVATE KEY-----"
 ```
+
+## Other steps you may need to do
+
+If you haven't yet done so, do the other steps listed in [/docs/dokku.md](dokku.md).
+

--- a/docs/github-app-setup-localhost.md
+++ b/docs/github-app-setup-localhost.md
@@ -1,16 +1,26 @@
-# Installing on Localhost
-First, clone the repository. This can be done with the following command:
-```bash
-git clone git@github.com:ucsb-cs156/proj-frontiers.git
-```
-Then, obtain a set of Google Cloud Credentials. Directions for obtaining these can be found [here](https://ucsb-cs156.github.io/topics/oauth/oauth_google_setup.html).
-Next, we'll set up the Github App. To do so, go to https://github.com/
+# Setting up frontiers as a Github App on Localhost
+
+You should already have a `.env` file that you created by copying from `.env.SAMPLE`.
+
+Start by following the instructions in [`docs/oauth.md`] to obtain values for these
+variables and setting them in `.env`
+* `GOOGLE_CLIENT_ID`
+* `GOOGLE_CLIENT_SECRET`
+
+These instructions will explain how to fill in the values for:
+* `GITHUB_CLIENT_ID`
+* `GITHUB_CLIENT_SECRET`
+* `app_private_key`
+
+## Obtaining `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`
+
+Go to <https://github.com/>
 
 Then, click your profile icon. Click "Settings". Then, Click "Developer Settings", on the bottom of the toolbar on the left.
 
 Select "New Github App". Fill in an appropriate name, and write it down. You will need it later.
-![image](https://github.com/user-attachments/assets/3d0fe501-318c-4907-a267-eff44f06f17a)
 
+![image](https://github.com/user-attachments/assets/3d0fe501-318c-4907-a267-eff44f06f17a)
 
 For the homepage url, fill in `http://localhost:8080`.
 
@@ -48,33 +58,39 @@ Now, Select "Generate Client Secret". Copy this client secret to a safe location
 
 ![image](https://github.com/user-attachments/assets/856cf882-b6f3-44a5-b70b-115531bb8cae)
 
+* Copy the value for the client id into `GITHUB_CLIENT_ID` in `.env`
+* Copy the value for the client secret into `GITHUB_CLIENT_SECRET` in `.env`
+
+## Generating a value for `app_private_key`
 
 Scroll down to "Private Keys" and select "Generate a Private Key"
 
 ![image](https://github.com/user-attachments/assets/7c2b958a-f912-4972-af63-9ff2c30339cd)
 
 
-Though we will now start using other applications, keep this Github window open. You'll need it later.
+Next, we will run a script that converts this private key 
+into a `dokku config:set ...` command.
 
-This will download a private key to your computer. Move this file into the repository directory. Importantly, **Do not commit this file**.
+Copy the key from wherever it downloaded to the *root of the frontiers project*, i.e. the directory where you cloned the repo.
 
-Next, we will switch the standard of the key we just downloaded so Java can understand it.
-To do so, open a terminal in the repository folder, and run the following command, replacing `<file-name>` with the name of the key.
-```bash
-./keyconvert.sh <file-name>
+For example, if `~/Downloads` is the directory where files are downloaded, then this command will copy all files ending in `.private-key.pem` to your current directory.
+
+```
+cp ~/Downloads/*.private-key.pem .
 ```
 
-Next, create a copy of `secrets.yaml.EXAMPLE` with the following command:
-```bash
-cp secrets.yaml.EXAMPLE secrets.yaml
+Note that you *must not commit* this private key to the Github Repo! The `.gitignore` should handle this, but be careful in any case.
+
+Now run this script: 
+```
+./keyconvert-localhost.sh
 ```
 
-Now, we're going to take the key we generated and place it into secrets.yaml. Output the key into the terminal with the following command:
-```bash
-cat pkcs8.key
-```
+* If there is only one file ending in `private-key.pem` in the current directory, it will be selected automatically. Otherwise, you'll be asked to choose one.
 
-Copy the output from this command, and paste it into secrets.yaml, replacing add your key here with the output. The file should now look like this:
+The script will then output a file called `secrets.yaml`
+
+
 ```yaml
 app:
   private:
@@ -84,15 +100,8 @@ app:
 "
 ```
 
-Next, we'll fill in `.env`. Create a copy of it from `.env.SAMPLE` with:
-```bash
-cp .env.SAMPLE .env
-```
+You should now be able to run the app using:
 
-Fill in your Google secrets, from the article at the beginning. Additionally, fill in your Github Client ID and Client Secret, named `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_ID`, and `GITHUB_CLIENT_SECRET` respectively.
-Additionally, make sure your email is on the list of admin emails.
-
-Next, start your project:
 ```bash
 mvn spring-boot:run
 ```

--- a/keyconvert-localhost.sh
+++ b/keyconvert-localhost.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# If there is more than one .pem file in the current directory, prompt the user to select one
+pem_files=($(find . -maxdepth 1 -type f -name "*.private-key.pem"))
+if [ ${#pem_files[@]} -gt 1 ]; then
+  echo "Multiple PEM files found. Please select one:"
+  select pem_file in "${pem_files[@]}"; do
+    if [[ -n "$pem_file" ]]; then
+      break
+    else
+      echo "Invalid selection. Please try again."
+    fi
+  done
+elif [ ${#pem_files[@]} -eq 0 ]; then
+  echo "No PEM files found. Please provide a valid PEM file"
+  exit 1
+else 
+  pem_file=$(find . -maxdepth 1 -type f -name "*.pem" | head -n 1)
+fi
+
+if [ -z "$pem_file" ]; then
+    echo "No PEM file found. Please provide a valid PEM file."
+    exit 1 
+fi
+
+if openssl rsa -in $pem_file --noout -check > /dev/null 2>&1; then
+  openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in $pem_file -out pkcs8.key
+  echo "successfully converted key"
+else
+  echo "File $1 not a valid rsa key"
+fi
+
+# Read the contents of pkcs8.key and escape for YAML (indent each line by two spaces)
+key_content=$(awk '{print "  " $0}' pkcs8.key)
+
+# If secrets.yaml already exists, prompt the user to confirm overwriting
+# and back it up if they choose to overwrite
+if [ -f secrets.yaml ]; then
+  echo "secrets.yaml already exists. Do you want to overwrite it? (y/n)"
+  read -r confirm
+  if [[ "$confirm" != "y" ]]; then
+    echo "Exiting without overwriting secrets.yaml."
+    exit 0
+  fi
+  mv secrets.yaml secrets.yaml.backup
+  echo "Existing secrets.yaml backed up as secrets.yaml.backup"
+fi
+
+# Write the contents to secrets.yaml
+cat <<EOF > secrets.yaml
+app:
+  private:
+    key: "-----BEGIN PRIVATE KEY-----
+$key_content
+-----END PRIVATE KEY-----"
+EOF
+
+echo "secrets.yaml has been created with the converted key."

--- a/keyconvert.sh
+++ b/keyconvert.sh
@@ -1,10 +1,77 @@
-if [ -f "$1" ]; then
-if openssl rsa -in $1 --noout -check > /dev/null 2>&1; then
-openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in $1 -out pkcs8.key
-echo "successfully converted key"
-else
-echo "not a valid rsa key"
+#!/bin/bash
+
+# Function to validate valid dokku app name
+validate_app_name() {
+  local app_name="$1"
+  if [[ -z "$app_name" || ! "$app_name" =~ ^[a-z0-9-]+$ ]]; then
+    echo "Invalid app name. Please enter a valid Dokku app name (lowercase letters, numbers, and hyphens only)."
+    return 1
+  fi
+  return 0
+}
+
+# Function to valid if the provided PEM file is a valid RSA key
+validate_pem_file() {
+  local pem_file="$1"
+  if [[ ! -f "$pem_file" ]]; then
+    echo "File $pem_file does not exist."
+    return 1
+  fi
+  if [[ ! "$1" =~ "\.private-key\.pem$" ]]; then
+    echo "File $pem_file is not a valid PEM file. Filename should end with .private-key.pem."
+    return 1
+  fi
+  if ! openssl rsa -in "$pem_file" -noout -check > /dev/null 2>&1; then
+    echo "File $pem_file is not a valid RSA key."
+    return 1
+  fi
+  return 0 
+}
+
+# If there is more than one .pem file in the current directory, prompt the user to select one
+pem_files=($(find . -maxdepth 1 -type f -name "*.private-key.pem"))
+if [ ${#pem_files[@]} -gt 1 ]; then
+  echo "Multiple PEM files found. Please select one:"
+  select pem_file in "${pem_files[@]}"; do
+    if [[ -n "$pem_file" ]]; then
+    break
+    else
+    echo "Invalid selection. Please try again."
+    fi
+  done
+elif [ ${#pem_files[@]} -eq 0 ]; then
+  echo "No PEM files found. Please provide a valid PEM file"
+  exit 1
+else  
+  pem_file=$(find . -maxdepth 1 -type f -name "*.pem" | head -n 1)
 fi
-else
-echo "$1 does not exist"
+
+if [ -z "$pem_file" ]; then
+    echo "No PEM file found in the current directory."
+    echo "Please download a private key from the GitHub app settings page,"
+    echo "and save it in the current directory."
+    exit 1 
 fi
+
+if openssl rsa -in $pem_file --noout -check > /dev/null 2>&1; then
+  openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in $pem_file -out pkcs8.key
+  echo "successfully converted key"
+else
+  echo "File $1 not a valid rsa key"
+fi
+
+echo "Please provide the Dokku app name to set the private key for:"
+echo "For example, frontiers, frontiers-qa, frontiers-cgaucho, etc"
+echo ""
+read -p "Enter the Dokku app name: " app_name
+# Validate the app name with a loop until a valid name is provided
+while ! validate_app_name "$app_name"; do
+echo "Invalid app name. Please enter a valid Dokku app name (lowercase letters, numbers, and hyphens only):"
+read -p "Enter the Dokku app name: " app_name
+done
+
+
+echo "Copy/paste the following command to set the private key for your Dokku app:"
+echo ""
+echo "dokku config:set --no-restart $app_name app_private_key=\"$(cat pkcs8.key)\""
+


### PR DESCRIPTION
In this PR, we rewrite the scripts and the instructions
for installing the Github App.   Instead of passing the name of
the private key file, we just find it automatically; if there is
more than one, we prompt the user to select one.

We have separate scripts for localhost and dokku.

The localhost version just creates the secrets.yaml file directly (warning the user if it is overwriting another one).

The dokku version gives the exact command to copy/paste to the dokku command line.

The instructions have been modified to match these changes t to the scripts, and have been streamlined to avoid duplicating instructions that already appear elsewhere.

# Test plan

1. Try setting up a new installation of frontiers on localhost, following the instructions and using the script.
2. Try setting up a new installation of frontiers on dokku, following the instructions and using the script.
3. Try both scripts with three cases:
    - No .pem files in the current directory
    - Exactly one .pem file in the current directory
    - Multiple .pem files in the current directory
    Ensure that each of these cases behaves in a way that the user will understand what is happening.