### PR TITLE
Hotfix to Update OrgStatus from NONE to PENDING in the Prod/QA databases

### DIFF
--- a/src/main/resources/db/migration/changes/011-Update-None-To-Pending.json
+++ b/src/main/resources/db/migration/changes/011-Update-None-To-Pending.json
@@ -1,0 +1,27 @@
+{ "databaseChangeLog": [
+  {
+    "changeSet": {
+      "id": "011-Update-None-To-Pending",
+      "author": "Division7",
+      "preConditions": [
+        {
+          "onFail": "MARK_RAN"
+        }
+      ],
+      "changes": [
+        {
+          "update": {
+            "columns": [{
+              "column": {
+                "name": "ORG_STATUS",
+                "value": "PENDING"
+              }
+            }],
+            "tableName": "ROSTER_STUDENT",
+            "where": "ORG_STATUS='NONE'"
+          }
+        }
+      ]
+    }
+  }
+]}


### PR DESCRIPTION
In this PR, I add a liquibase migration file to update all instances of RosterStudents at NONE to PENDING.

Currently, this prevents users with attached Roster Students at the status NONE from signing in.


## Test Plan
1. Inspect the database frontiers-qa-test-db2 with `dokku postgres:connect frontiers-qa-test-db2`.
2.  With the following command, observe that there are Roster Students with the status NONE:
`SELECT * FROM ROSTER_STUDENT`
3. Unlink frontiers-qa-test-db1 from frontiers-qa (`dokku postgres:unlink frontiers-qa-test-db-1 frontiers-qa --no-restart`)
4. Link frontiers-qa-test-db2 to frontiers-qa. (`dokku postgres:link frontiers-qa-test-db2 frontiers-qa`)
5. Then, sign into frontiers-qa, and using swagger, look to make sure there are no errors with any roster students.

Deployed to https://frontiers-qa.dokku-00.cs.ucsb.edu/