### PR TITLE
Separating the Integration and E2E Test Configuration from Unit Tests 

### DIFF
--- a/src/test/java/edu/ucsb/cs156/frontiers/testconfig/IntegrationConfig.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/testconfig/IntegrationConfig.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.frontiers.testconfig;
+
+import edu.ucsb.cs156.frontiers.services.GithubSignInService;
+import edu.ucsb.cs156.frontiers.services.GoogleSignInService;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import edu.ucsb.cs156.frontiers.config.SecurityConfig;
+import edu.ucsb.cs156.frontiers.services.CurrentUserService;
+import edu.ucsb.cs156.frontiers.services.GrantedAuthoritiesService;
+
+@TestConfiguration
+@Import(SecurityConfig.class)
+public class IntegrationConfig {
+
+    @Bean
+    public CurrentUserService currentUserService() {
+        return new MockCurrentUserServiceImpl();
+    }
+
+    @Bean
+    public GrantedAuthoritiesService grantedAuthoritiesService() {
+        return new GrantedAuthoritiesService();
+    }
+
+    @Bean
+    public GithubSignInService githubSignInService() {return new MockGithubSignInService();}
+
+    @Bean
+    public GoogleSignInService googleSignInService() {return new MockGoogleSignInService();}
+
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/web/HomePageWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/web/HomePageWebIT.java
@@ -1,10 +1,12 @@
 package edu.ucsb.cs156.frontiers.web;
 
+import edu.ucsb.cs156.frontiers.testconfig.IntegrationConfig;
 import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -23,7 +25,8 @@ import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertTha
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@Import(TestConfig.class)
+@ResourceLock("port-8080")
+@Import(IntegrationConfig.class)
 @ActiveProfiles("integration")
 public class HomePageWebIT {
     @Value("${app.playwright.headless:true}")

--- a/src/test/java/edu/ucsb/cs156/frontiers/web/OauthWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/web/OauthWebIT.java
@@ -1,8 +1,10 @@
 package edu.ucsb.cs156.frontiers.web;
 
+import edu.ucsb.cs156.frontiers.testconfig.IntegrationConfig;
 import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
@@ -19,7 +21,8 @@ import static com.microsoft.playwright.assertions.PlaywrightAssertions.setDefaul
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("integration")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-@Import(TestConfig.class)
+@ResourceLock("port-8080")
+@Import(IntegrationConfig.class)
 public class OauthWebIT extends WebTestCase {
     @Test
     public void regular_user_can_login_logout() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/frontiers/web/SwaggerWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/web/SwaggerWebIT.java
@@ -1,10 +1,12 @@
 package edu.ucsb.cs156.frontiers.web;
 
+import edu.ucsb.cs156.frontiers.testconfig.IntegrationConfig;
 import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -24,7 +26,8 @@ import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertTha
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@Import(TestConfig.class)
+@ResourceLock("port-8080")
+@Import(IntegrationConfig.class)
 @ActiveProfiles("integration")
 public class SwaggerWebIT {
     @Value("${app.playwright.headless:true}")


### PR DESCRIPTION
In this PR, I separate the end-to-end and (in the future) integration tests into a separate test configuration.

This is to better implement #166 to more cleanly separate mocked security annotations, or any centralized mocks that any unit tests rely on (CurrentUserService, etc).

In addition, I enforce a ResourceLock on port 8080 to ensure that the tests all properly break down their Spring configuration upon completion and do not interfere with each other.