### PR TITLE
Allowing Course Creation

### DIFF
--- a/frontend/src/main/components/Courses/CourseModal.js
+++ b/frontend/src/main/components/Courses/CourseModal.js
@@ -1,0 +1,99 @@
+import Modal from "react-bootstrap/Modal";
+import { Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+
+function CourseModal({
+  onSubmitAction,
+  showModal,
+  toggleShowModal,
+  initialContents,
+  buttonText = "Create",
+}) {
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+
+  const closeModal = () => {
+    toggleShowModal(false);
+  };
+
+  return (
+    <Modal
+      show={showModal}
+      onHide={closeModal}
+      centered={true}
+      data-testid={"CourseModal-base"}
+    >
+      <Modal.Header>
+        <Modal.Title>Create Course</Modal.Title>
+        <button
+          type="button"
+          className="btn-close"
+          aria-label="Close"
+          data-testid={"CourseModal-closeButton"}
+          onClick={closeModal}
+        ></button>
+      </Modal.Header>
+      <Form onSubmit={handleSubmit(onSubmitAction)}>
+        <Modal.Body>
+          <Form.Group>
+            <Form.Label htmlFor="courseName">Course Name</Form.Label>
+            <Form.Control
+              data-testid={"CourseModal-courseName"}
+              id="courseName"
+              type="text"
+              isInvalid={Boolean(errors.courseName)}
+              {...register("courseName", {
+                required: "Course Name is required.",
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.courseName?.message}
+            </Form.Control.Feedback>
+            <Form.Label htmlFor="term">Term</Form.Label>
+            <Form.Control
+              data-testid={"CourseModal-term"}
+              id="term"
+              type="text"
+              isInvalid={Boolean(errors.term)}
+              {...register("term", {
+                required: "Course Term is required.",
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.term?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+          <Form.Group>
+            <Form.Label htmlFor="school">School</Form.Label>
+            <Form.Control
+              data-testid={"CourseModal-school"}
+              id="school"
+              type="text"
+              isInvalid={Boolean(errors.school)}
+              {...register("school", {
+                required: "School is required.",
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.school?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <button
+            type="submit"
+            className="btn btn-primary"
+            data-testid="CourseModal-submit"
+          >
+            {buttonText}
+          </button>
+        </Modal.Footer>
+      </Form>
+    </Modal>
+  );
+}
+
+export default CourseModal;

--- a/frontend/src/main/pages/Instructors/CoursesIndexPage.js
+++ b/frontend/src/main/pages/Instructors/CoursesIndexPage.js
@@ -1,9 +1,12 @@
 import React from "react";
-import { useBackend } from "main/utils/useBackend";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import InstructorCoursesTable from "main/components/Courses/InstructorCoursesTable";
 import { useCurrentUser } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
+import { toast } from "react-toastify";
+import CourseModal from "main/components/Courses/CourseModal";
 
 export default function CoursesIndexPage() {
   const { data: currentUser } = useCurrentUser();
@@ -20,10 +23,52 @@ export default function CoursesIndexPage() {
     [],
   );
 
+  const [viewModal, setViewModal] = React.useState(false);
+
+  const objectToAxiosParams = (course) => ({
+    url: "/api/courses/post",
+    method: "POST",
+    params: {
+      courseName: course.courseName,
+      term: course.term,
+      school: course.school,
+    },
+  });
+
+  const onSuccess = (course) => {
+    toast(`Course ${course.courseName} created`);
+    setViewModal(false);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/courses/all"],
+  );
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  const createCourse = () => setViewModal(true);
+
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Courses</h1>
+        <Button
+          onClick={createCourse}
+          style={{ float: "right", marginBottom: 10 }}
+          variant="primary"
+        >
+          Create Course
+        </Button>
+        <CourseModal
+          showModal={viewModal}
+          toggleShowModal={setViewModal}
+          onSubmitAction={onSubmit}
+        />
         <InstructorCoursesTable courses={courses} currentUser={currentUser} />
       </div>
     </BasicLayout>

--- a/frontend/src/stories/components/Courses/CourseModal.stories.js
+++ b/frontend/src/stories/components/Courses/CourseModal.stories.js
@@ -1,0 +1,44 @@
+import React, { useState } from "react";
+import coursesFixtures from "fixtures/coursesFixtures";
+import CourseModal from "main/components/Courses/CourseModal";
+import { Button } from "react-bootstrap";
+
+export default {
+  title: "components/Courses/CourseModal",
+  component: CourseModal,
+};
+
+const Template = (args) => {
+  const [modal, setModalState] = useState(false);
+  return (
+    <div>
+      <Button onClick={() => setModalState(true)}>Open Modal</Button>
+      <CourseModal
+        showModal={modal}
+        toggleShowModal={setModalState}
+        {...args}
+      />
+    </div>
+  );
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonText: "Create",
+  onSubmitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: coursesFixtures.severalCourses[0],
+  buttonText: "Update",
+  onSubmitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/tests/components/Courses/CourseModal.test.js
+++ b/frontend/src/tests/components/Courses/CourseModal.test.js
@@ -1,0 +1,108 @@
+import CourseModal from "main/components/Courses/CourseModal";
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import coursesFixtures from "fixtures/coursesFixtures";
+
+const mockSubmit = jest.fn();
+const showModal = jest.fn();
+const toggleShowModal = jest.fn();
+
+describe("CourseModal Tests", () => {
+  test("Validation works correctly", async () => {
+    render(
+      <div
+        className="modal show"
+        style={{ display: "block", position: "initial" }}
+      >
+        <CourseModal
+          showModal={showModal}
+          toggleShowModal={toggleShowModal}
+          onSubmitAction={mockSubmit}
+        />
+      </div>,
+    );
+
+    const submitButton = screen.getByTestId(/CourseModal-submit/);
+    fireEvent.click(submitButton);
+
+    expect(mockSubmit).toHaveBeenCalledTimes(0);
+
+    await screen.findByText(/Course Name is required./);
+    expect(screen.getByText(/Course Term is required./)).toBeInTheDocument();
+    expect(screen.getByText(/School is required./)).toBeInTheDocument();
+  });
+
+  test("Can see initialContents", async () => {
+    render(
+      <div
+        className="modal show"
+        style={{ display: "block", position: "initial" }}
+      >
+        <CourseModal
+          showModal={showModal}
+          toggleShowModal={toggleShowModal}
+          onSubmitAction={mockSubmit}
+          initialContents={coursesFixtures.severalCourses[0]}
+          buttonText={"Edit"}
+        />
+      </div>,
+    );
+
+    expect(screen.getByDisplayValue("CMPSC 156")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Spring 2025")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("UCSB")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+
+  test("Can submit successfully", async () => {
+    render(
+      <div
+        className="modal show"
+        style={{ display: "block", position: "initial" }}
+      >
+        <CourseModal
+          showModal={showModal}
+          toggleShowModal={toggleShowModal}
+          onSubmitAction={mockSubmit}
+        />
+      </div>,
+    );
+
+    const courseName = screen.getByLabelText("Course Name");
+    const courseTerm = screen.getByLabelText("Term");
+    const school = screen.getByLabelText("School");
+    fireEvent.change(courseName, { target: { value: "CMPSC 156" } });
+    fireEvent.change(courseTerm, { target: { value: "Spring 2025" } });
+    fireEvent.change(school, { target: { value: "UCSB" } });
+    expect(screen.getByTestId("CourseModal-courseName")).toBeInTheDocument();
+    expect(screen.getByTestId("CourseModal-term")).toBeInTheDocument();
+    expect(screen.getByTestId("CourseModal-school")).toBeInTheDocument();
+    expect(screen.getByTestId("CourseModal-base")).toHaveClass(
+      "modal-dialog-centered",
+    );
+    const submitButton = screen.getByText("Create");
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(mockSubmit).toHaveBeenCalledTimes(1));
+  });
+
+  test("Can click close", async () => {
+    render(
+      <div
+        className="modal show"
+        style={{ display: "block", position: "initial" }}
+      >
+        <CourseModal
+          showModal={showModal}
+          toggleShowModal={toggleShowModal}
+          onSubmitAction={mockSubmit}
+        />
+      </div>,
+    );
+
+    const closeButton = screen.getByTestId("CourseModal-closeButton");
+    fireEvent.click(closeButton);
+    await waitFor(() => expect(toggleShowModal).toHaveBeenCalledTimes(1));
+    expect(toggleShowModal).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -75,7 +75,7 @@ public class CoursesController extends ApiController {
     @Operation(summary = "Create a new course")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_INSTRUCTOR')")
     @PostMapping("/post")
-    public Course postCourse(
+    public InstructorCourseView postCourse(
             @Parameter(name = "courseName") @RequestParam String courseName,
             @Parameter(name = "term") @RequestParam String term,
             @Parameter(name = "school") @RequestParam String school) {
@@ -89,7 +89,7 @@ public class CoursesController extends ApiController {
                 .build();
         Course savedCourse = courseRepository.save(course);
 
-        return savedCourse;
+        return new InstructorCourseView(savedCourse);
     }
 
 

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
@@ -109,7 +109,7 @@ public class CoursesControllerTests extends ControllerTestCase {
                 verify(courseRepository, times(1)).save(eq(course));
 
                 String responseString = response.getResponse().getContentAsString();
-                String expectedJson = mapper.writeValueAsString(course);
+                String expectedJson = mapper.writeValueAsString(new InstructorCourseView(course));
                 assertEquals(expectedJson, responseString);
 
         }
@@ -148,7 +148,7 @@ public class CoursesControllerTests extends ControllerTestCase {
                 verify(courseRepository, times(1)).save(eq(course));
 
                 String responseString = response.getResponse().getContentAsString();
-                String expectedJson = mapper.writeValueAsString(course);
+                String expectedJson = mapper.writeValueAsString(new InstructorCourseView(course));
                 assertEquals(expectedJson, responseString);
 
         }


### PR DESCRIPTION
In this PR, I allow the creation of courses via the modal created in #199. This is added to the Instructors' course page.

For simplicity and to keep the number of fixtures down, `/api/courses/post` now returns an InstructorCourseView record.

Modal in action:
<img width="1486" height="719" alt="image" src="https://github.com/user-attachments/assets/26121bfb-e5a4-4d3e-9b2b-5a73028aeca7" />

After submit:
<img width="2543" height="816" alt="image" src="https://github.com/user-attachments/assets/6611719f-6d7c-43a6-9093-2e13555ab593" />


Deployed to https://proj-frontiers-division7.dokku-00.cs.ucsb.edu/

Closes #134, merge after #199