### PR TITLE
Adding a Service to Delete a Frontiers Installation

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerService.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.frontiers.services;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.errors.InvalidInstallationTypeException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.security.NoSuchAlgorithmException;
@@ -72,5 +74,29 @@ public class OrganizationLinkerService {
         }
         String orgName = responseJson.get("account").get("login").asText();
         return orgName;
+    }
+
+
+    /**
+     * Removes the Frontiers installation from the linked GitHub org
+     *
+     * @param course The entity for the course about to be deleted
+     */
+    public void unenrollOrganization(Course course) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        if(course.getOrgName() == null || course.getInstallationId() == null){
+            return;
+        }
+        String token = jwtService.getJwt();
+        String ENDPOINT = "https://api.github.com/app/installations/" + course.getInstallationId();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + token);
+        headers.add("Accept", "application/vnd.github+json");
+        headers.add("X-GitHub-Api-Version", "2022-11-28");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(ENDPOINT, HttpMethod.DELETE, entity, String.class);
+        }catch(HttpClientErrorException ignored){
+
+        }
     }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerServiceTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.frontiers.services;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.errors.InvalidInstallationTypeException;
 import edu.ucsb.cs156.frontiers.services.wiremock.WiremockService;
 import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
@@ -9,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -19,9 +21,8 @@ import java.security.spec.InvalidKeySpecException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
 @RestClientTest(OrganizationLinkerService.class)
 @Import({TestConfig.class})
@@ -113,6 +114,50 @@ public class OrganizationLinkerServiceTests {
         });
 
         assertEquals(expectedMessage, thrownException.getMessage());
+    }
+
+    @Test
+    public void earlyReturnOnNoInstallationId() throws Exception{
+        Course course = Course.builder().orgName("ucsb-cs156").build();
+        organizationLinkerService.unenrollOrganization(course);
+        mockRestServiceServer.verify();
+    }
+
+    @Test
+    public void earlyReturnOnNoOrgName() throws Exception{
+        Course course = Course.builder().build();
+        organizationLinkerService.unenrollOrganization(course);
+        mockRestServiceServer.verify();
+    }
+
+    @Test
+    public void testUnenrollOrganization() throws Exception {
+        Course course = Course.builder().orgName("ucsb-cs156").installationId("123456").build();
+
+        doReturn("definitely.real.jwt").when(jwtService).getJwt();
+        mockRestServiceServer.expect(requestTo("https://api.github.com/app/installations/123456"))
+                .andExpect(method(HttpMethod.DELETE))
+                .andExpect(header("Authorization", "Bearer definitely.real.jwt" ))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andRespond(withNoContent());
+        organizationLinkerService.unenrollOrganization(course);
+        mockRestServiceServer.verify();
+    }
+
+    @Test
+    public void testNotInstalled() throws Exception {
+        Course course = Course.builder().orgName("ucsb-cs156").installationId("123456").build();
+
+        doReturn("definitely.real.jwt").when(jwtService).getJwt();
+        mockRestServiceServer.expect(requestTo("https://api.github.com/app/installations/123456"))
+                .andExpect(method(HttpMethod.DELETE))
+                .andExpect(header("Authorization", "Bearer definitely.real.jwt" ))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andRespond(withResourceNotFound());
+        organizationLinkerService.unenrollOrganization(course);
+        mockRestServiceServer.verify();
     }
 
 }


### PR DESCRIPTION
In this PR, I add a method that will uninstall Frontiers from a GitHub organization.

In the case where the installation Id or org name isn't present, it returns prematurely.

This is prep for #132 

Deployed to https://frontiers-qa2.dokku-00.cs.ucsb.edu/