### PR TITLE
FEATURE: As an admin, I can delete a course, BACKEND only.

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -14,14 +14,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -310,6 +303,17 @@ public class CoursesController extends ApiController {
 
         Iterable<Course> courses = courseRepository.findAllById(courseIds);
         return courses;
+    }
+
+    @Operation(summary = "Delete a course")
+    @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
+    @DeleteMapping("")
+    public Object deleteCourse(@RequestParam Long courseId) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
+        linkerService.unenrollOrganization(course);
+        courseRepository.delete(course);
+        return genericMessage("Course with id %s deleted".formatted(course.getId()));
     }
 
 }


### PR DESCRIPTION
In this PR, I add an endpoint to delete a course.

It can only be ran by someone with permission to manage the course, and will attempt to uninstall Frontiers from the organization if linked.

Deployed to https://frontiers-qa2.dokku-00.cs.ucsb.edu/

Test plan:
1. Create a course
2. Link it to a GitHub Organization
3. Add a Roster Student
4. Add a CourseStaff
5. Attempt to delete the course
6. Ensure that the frontiers app is also no longer installed on GitHub.

Closes #132, Merge after #203