### PR TITLE
Checking Organization Status on Invite Fail

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
@@ -125,7 +125,10 @@ public class CourseStaffController extends ApiController {
         courseStaffRepository.save(courseStaff);
         if(status == OrgStatus.INVITED){
             return ResponseEntity.accepted().body("Successfully invited staff member to Organization");
-        }else{
+        } else if (status == OrgStatus.MEMBER || status == OrgStatus.OWNER) {
+            return ResponseEntity.accepted().body("Already in organization - set status to %s".formatted(status.toString()));
+        }else
+        {
             return ResponseEntity.internalServerError().body("Could not invite staff member to Organization");
         }
     }

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -261,7 +261,10 @@ public class RosterStudentsController extends ApiController {
         rosterStudentRepository.save(rosterStudent);
         if(status == OrgStatus.INVITED){
             return ResponseEntity.accepted().body("Successfully invited student to Organization");
-        }else{
+        }else if (status == OrgStatus.MEMBER || status == OrgStatus.OWNER) {
+            return ResponseEntity.accepted().body("Already in organization - set status to %s".formatted(status.toString()));
+        }else
+        {
             return ResponseEntity.internalServerError().body("Could not invite student to Organization");
         }
     }

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
@@ -128,7 +128,7 @@ public class OrganizationMemberService {
     }
 
     private OrgStatus getMemberStatus(String githubLogin, Course course) throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException {
-        String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/members/" + githubLogin;
+        String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/memberships/" + githubLogin;
         HttpHeaders headers = new HttpHeaders();
         String token = jwtService.getInstallationToken(course);
         headers.add("Authorization", "Bearer " + token);

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.frontiers.services;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.CourseStaff;
@@ -120,11 +121,36 @@ public class OrganizationMemberService {
         String bodyAsJson = objectMapper.writeValueAsString(body);
         HttpEntity<String> entity = new HttpEntity<>(bodyAsJson, headers);
         try{
-            ResponseEntity<String> response = restTemplate.exchange(ENDPOINT, HttpMethod.POST, entity, String.class);
+            restTemplate.exchange(ENDPOINT, HttpMethod.POST, entity, String.class);
         } catch (HttpClientErrorException e) {
-            log.warn("Error while trying to invite member to organization: {}", e.getMessage());
-            return OrgStatus.JOINCOURSE;
+            return getMemberStatus(githubId, course);
         }
         return OrgStatus.INVITED;
+    }
+
+    private OrgStatus getMemberStatus(int githubId, Course course) throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException {
+        String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/members/" + githubId;
+        HttpHeaders headers = new HttpHeaders();
+        String token = jwtService.getInstallationToken(course);
+        headers.add("Authorization", "Bearer " + token);
+        headers.add("Accept", "application/vnd.github+json");
+        headers.add("X-GitHub-Api-Version", "2022-11-28");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        try{
+            ResponseEntity<String> response = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class);
+            JsonNode responseJson = objectMapper.readTree(response.getBody());
+            if(responseJson.get("role").asText().equalsIgnoreCase("admin")){
+                return OrgStatus.OWNER;
+            }else if (responseJson.get("role").asText().equalsIgnoreCase("direct_member")){
+                return OrgStatus.MEMBER;
+            }else{
+                log.warn("Unexpected role {} used in course {}", responseJson.get("role").asText(), course.getCourseName());
+                return OrgStatus.JOINCOURSE;
+            }
+        }catch (HttpClientErrorException e){
+            log.warn("Error while trying to get member status: {}", e.getMessage());
+            return OrgStatus.JOINCOURSE;
+        }
+
     }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
@@ -19,7 +19,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.security.NoSuchAlgorithmException;
@@ -100,15 +99,15 @@ public class OrganizationMemberService {
 
     public OrgStatus inviteOrganizationMember(RosterStudent student) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
         Course course = student.getCourse();
-        return inviteMember(student.getGithubId(), course, "direct_member");
+        return inviteMember(student.getGithubId(), course, "direct_member", student.getGithubLogin());
     }
 
     public OrgStatus inviteOrganizationOwner(CourseStaff staff) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
         Course course = staff.getCourse();
-        return inviteMember(staff.getGithubId(), course, "admin");
+        return inviteMember(staff.getGithubId(), course, "admin", staff.getGithubLogin());
     }
 
-    private OrgStatus inviteMember(int githubId, Course course, String role) throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException {
+    private OrgStatus inviteMember(int githubId, Course course, String role, String githubLogin) throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException {
         String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/invitations";
         HttpHeaders headers = new HttpHeaders();
         String token = jwtService.getInstallationToken(course);
@@ -123,13 +122,13 @@ public class OrganizationMemberService {
         try{
             restTemplate.exchange(ENDPOINT, HttpMethod.POST, entity, String.class);
         } catch (HttpClientErrorException e) {
-            return getMemberStatus(githubId, course);
+            return getMemberStatus(githubLogin, course);
         }
         return OrgStatus.INVITED;
     }
 
-    private OrgStatus getMemberStatus(int githubId, Course course) throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException {
-        String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/members/" + githubId;
+    private OrgStatus getMemberStatus(String githubLogin, Course course) throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException {
+        String ENDPOINT = "https://api.github.com/orgs/" + course.getOrgName() + "/members/" + githubLogin;
         HttpHeaders headers = new HttpHeaders();
         String token = jwtService.getInstallationToken(course);
         headers.add("Authorization", "Bearer " + token);

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffControllerTests.java
@@ -486,6 +486,102 @@ public class CourseStaffControllerTests extends ControllerTestCase {
 
         @Test
         @WithMockUser(roles = { "USER", "GITHUB"})
+        public void test_already_part_is_member() throws Exception {
+                User currentUser = currentUserService.getUser();
+
+                Course course2 = Course.builder().id(2L).installationId("1234").orgName("ucsb-cs156").courseName("course").creator(currentUser).build();
+
+                CourseStaff courseStaff = CourseStaff.builder()
+                        .id(3L)
+                        .firstName("Test")
+                        .lastName("User")
+                        .email("testuser@ucsb.edu")
+                        .course(course2)
+                        .orgStatus(OrgStatus.JOINCOURSE)
+                        .githubId(null)
+                        .githubLogin(null)
+                        .user(currentUser)
+                        .build();
+
+                CourseStaff courseStaffUpdated = CourseStaff.builder()
+                        .id(3L)
+                        .firstName("Test")
+                        .lastName("User")
+                        .email("testuser@ucsb.edu")
+                        .course(course2)
+                        .orgStatus(OrgStatus.MEMBER)
+                        .githubId(currentUser.getGithubId())
+                        .githubLogin(currentUser.getGithubLogin())
+                        .user(currentUser)
+                        .build();
+
+                when(courseStaffRepository.findById(eq(3L))).thenReturn(Optional.of(courseStaff));
+                when(courseStaffRepository.save(eq(courseStaffUpdated))).thenReturn(courseStaffUpdated);
+                when(organizationMemberService.inviteOrganizationOwner(any(CourseStaff.class))).thenReturn(OrgStatus.MEMBER);
+
+                MvcResult response = mockMvc.perform(put("/api/coursestaff/joinCourse")
+                                .with(csrf())
+                                .param("courseStaffId", "3"))
+                        .andExpect(status().isAccepted())
+                        .andReturn();
+
+
+                verify(courseStaffRepository).findById(eq(3L));
+
+                verify(courseStaffRepository, times(1)).save(eq(courseStaffUpdated));
+                assertEquals("Already in organization - set status to MEMBER", response.getResponse().getContentAsString());
+        }
+
+        @Test
+        @WithMockUser(roles = { "USER", "GITHUB"})
+        public void test_already_part_is_owner() throws Exception {
+                User currentUser = currentUserService.getUser();
+
+                Course course2 = Course.builder().id(2L).installationId("1234").orgName("ucsb-cs156").courseName("course").creator(currentUser).build();
+
+                CourseStaff courseStaff = CourseStaff.builder()
+                        .id(3L)
+                        .firstName("Test")
+                        .lastName("User")
+                        .email("testuser@ucsb.edu")
+                        .course(course2)
+                        .orgStatus(OrgStatus.JOINCOURSE)
+                        .githubId(null)
+                        .githubLogin(null)
+                        .user(currentUser)
+                        .build();
+
+                CourseStaff courseStaffUpdated = CourseStaff.builder()
+                        .id(3L)
+                        .firstName("Test")
+                        .lastName("User")
+                        .email("testuser@ucsb.edu")
+                        .course(course2)
+                        .orgStatus(OrgStatus.OWNER)
+                        .githubId(currentUser.getGithubId())
+                        .githubLogin(currentUser.getGithubLogin())
+                        .user(currentUser)
+                        .build();
+
+                when(courseStaffRepository.findById(eq(3L))).thenReturn(Optional.of(courseStaff));
+                when(courseStaffRepository.save(eq(courseStaffUpdated))).thenReturn(courseStaffUpdated);
+                when(organizationMemberService.inviteOrganizationOwner(any(CourseStaff.class))).thenReturn(OrgStatus.OWNER);
+
+                MvcResult response = mockMvc.perform(put("/api/coursestaff/joinCourse")
+                                .with(csrf())
+                                .param("courseStaffId", "3"))
+                        .andExpect(status().isAccepted())
+                        .andReturn();
+
+
+                verify(courseStaffRepository).findById(eq(3L));
+
+                verify(courseStaffRepository, times(1)).save(eq(courseStaffUpdated));
+                assertEquals("Already in organization - set status to OWNER", response.getResponse().getContentAsString());
+        }
+
+        @Test
+        @WithMockUser(roles = { "USER", "GITHUB"})
         public void cant_invite() throws Exception {
                 User currentUser = currentUserService.getUser();
 

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
@@ -288,7 +288,7 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"message\": \"Error inviting member\"}"));
 
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + "banana"))
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/memberships/" + "banana"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
                 .andExpect(header("Accept", "application/vnd.github+json"))
@@ -326,7 +326,7 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"message\": \"Error inviting member\"}"));
 
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + "banana"))
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/memberships/" + "banana"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
                 .andExpect(header("Accept", "application/vnd.github+json"))
@@ -364,7 +364,7 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"message\": \"Error inviting member\"}"));
 
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + "banana"))
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/memberships/" + "banana"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
                 .andExpect(header("Accept", "application/vnd.github+json"))
@@ -402,7 +402,7 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"message\": \"Error inviting member\"}"));
 
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + "banana"))
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/memberships/" + "banana"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
                 .andExpect(header("Accept", "application/vnd.github+json"))

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
@@ -269,6 +269,7 @@ public class OrganizationMemberServiceTests {
     void testInviteOrganizationMember_failure_is_member() throws Exception {
         RosterStudent testStudent = RosterStudent.builder()
                 .githubId(12345)
+                .githubLogin("banana")
                 .course(testCourse)
                 .build();
 
@@ -287,7 +288,7 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"message\": \"Error inviting member\"}"));
 
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + 12345))
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + "banana"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
                 .andExpect(header("Accept", "application/vnd.github+json"))
@@ -306,6 +307,7 @@ public class OrganizationMemberServiceTests {
     void testInviteOrganizationMember_failure_is_owner() throws Exception {
         RosterStudent testStudent = RosterStudent.builder()
                 .githubId(12345)
+                .githubLogin("banana")
                 .course(testCourse)
                 .build();
 
@@ -324,7 +326,7 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"message\": \"Error inviting member\"}"));
 
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + 12345))
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + "banana"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
                 .andExpect(header("Accept", "application/vnd.github+json"))
@@ -343,6 +345,7 @@ public class OrganizationMemberServiceTests {
     void testInviteOrganizationMember_failure_is_unexpected_role() throws Exception {
         RosterStudent testStudent = RosterStudent.builder()
                 .githubId(12345)
+                .githubLogin("banana")
                 .course(testCourse)
                 .build();
 
@@ -361,7 +364,7 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"message\": \"Error inviting member\"}"));
 
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + 12345))
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + "banana"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
                 .andExpect(header("Accept", "application/vnd.github+json"))
@@ -380,6 +383,7 @@ public class OrganizationMemberServiceTests {
     void testInviteOrganizationMember_failure_is_not_found() throws Exception {
         RosterStudent testStudent = RosterStudent.builder()
                 .githubId(12345)
+                .githubLogin("banana")
                 .course(testCourse)
                 .build();
 
@@ -398,7 +402,7 @@ public class OrganizationMemberServiceTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"message\": \"Error inviting member\"}"));
 
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + 12345))
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + "banana"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
                 .andExpect(header("Accept", "application/vnd.github+json"))
@@ -437,34 +441,6 @@ public class OrganizationMemberServiceTests {
 
         mockServer.verify();
         assertEquals(OrgStatus.INVITED, result);
-    }
-
-    @Test
-    void testInviteOrganizationOwner_Failure() throws Exception {
-        CourseStaff testStaff = CourseStaff.builder()
-                .githubId(12345)
-                .course(testCourse)
-                .build();
-
-        Map<String, Object> expectedRequestBody = new HashMap<>();
-        expectedRequestBody.put("invitee_id", 12345);
-        expectedRequestBody.put("role", "admin");
-        String expectedRequestBodyJson = objectMapper.writeValueAsString(expectedRequestBody);
-
-        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/invitations"))
-                .andExpect(method(HttpMethod.POST))
-                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
-                .andExpect(header("Accept", "application/vnd.github+json"))
-                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
-                .andExpect(content().json(expectedRequestBodyJson))
-                .andRespond(withStatus(HttpStatus.UNPROCESSABLE_ENTITY)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .body("{\"message\": \"Error inviting member\"}"));
-
-        OrgStatus result = organizationMemberService.inviteOrganizationOwner(testStaff);
-
-        mockServer.verify();
-        assertEquals(OrgStatus.JOINCOURSE, result);
     }
 
     @Test

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
@@ -266,7 +266,7 @@ public class OrganizationMemberServiceTests {
     }
 
     @Test
-    void testInviteOrganizationMember_Failure() throws Exception {
+    void testInviteOrganizationMember_failure_is_member() throws Exception {
         RosterStudent testStudent = RosterStudent.builder()
                 .githubId(12345)
                 .course(testCourse)
@@ -286,6 +286,124 @@ public class OrganizationMemberServiceTests {
                 .andRespond(withStatus(HttpStatus.UNPROCESSABLE_ENTITY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"message\": \"Error inviting member\"}"));
+
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + 12345))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{ \"role\": \"direct_member\" }"));
+
+        OrgStatus result = organizationMemberService.inviteOrganizationMember(testStudent);
+
+        mockServer.verify();
+        assertEquals(OrgStatus.MEMBER, result);
+    }
+
+    @Test
+    void testInviteOrganizationMember_failure_is_owner() throws Exception {
+        RosterStudent testStudent = RosterStudent.builder()
+                .githubId(12345)
+                .course(testCourse)
+                .build();
+
+        Map<String, Object> expectedRequestBody = new HashMap<>();
+        expectedRequestBody.put("invitee_id", 12345);
+        expectedRequestBody.put("role", "direct_member");
+        String expectedRequestBodyJson = objectMapper.writeValueAsString(expectedRequestBody);
+
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/invitations"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andExpect(content().json(expectedRequestBodyJson))
+                .andRespond(withStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"message\": \"Error inviting member\"}"));
+
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + 12345))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{ \"role\": \"admin\" }"));
+
+        OrgStatus result = organizationMemberService.inviteOrganizationMember(testStudent);
+
+        mockServer.verify();
+        assertEquals(OrgStatus.OWNER, result);
+    }
+
+    @Test
+    void testInviteOrganizationMember_failure_is_unexpected_role() throws Exception {
+        RosterStudent testStudent = RosterStudent.builder()
+                .githubId(12345)
+                .course(testCourse)
+                .build();
+
+        Map<String, Object> expectedRequestBody = new HashMap<>();
+        expectedRequestBody.put("invitee_id", 12345);
+        expectedRequestBody.put("role", "direct_member");
+        String expectedRequestBodyJson = objectMapper.writeValueAsString(expectedRequestBody);
+
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/invitations"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andExpect(content().json(expectedRequestBodyJson))
+                .andRespond(withStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"message\": \"Error inviting member\"}"));
+
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + 12345))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{ \"role\": \"billing_manager\" }"));
+
+        OrgStatus result = organizationMemberService.inviteOrganizationMember(testStudent);
+
+        mockServer.verify();
+        assertEquals(OrgStatus.JOINCOURSE, result);
+    }
+
+    @Test
+    void testInviteOrganizationMember_failure_is_not_found() throws Exception {
+        RosterStudent testStudent = RosterStudent.builder()
+                .githubId(12345)
+                .course(testCourse)
+                .build();
+
+        Map<String, Object> expectedRequestBody = new HashMap<>();
+        expectedRequestBody.put("invitee_id", 12345);
+        expectedRequestBody.put("role", "direct_member");
+        String expectedRequestBodyJson = objectMapper.writeValueAsString(expectedRequestBody);
+
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/invitations"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andExpect(content().json(expectedRequestBodyJson))
+                .andRespond(withStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"message\": \"Error inviting member\"}"));
+
+        mockServer.expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/" + 12345))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+                .andExpect(header("Accept", "application/vnd.github+json"))
+                .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
 
         OrgStatus result = organizationMemberService.inviteOrganizationMember(testStudent);
 


### PR DESCRIPTION
In this PR, I check the organization status of a user if joinCourse fails to invite them to the organization.

It checks to see and labels them appropriately if they are either an Owner or a Direct Member, and will warn if another unexpected role is used (I don't expect students to be marked as a billing manager, etc).

Previous changes from #212 are included so that all statuses can be updated in the same sweep.

Test plan:
1. Add a roster student to a linked course, with the owner of the roster student already being part of the organization
2. Have the roster student owner attempt to join the course
3. Check their status via swagger.

Deployed to https://frontiers-qa3.dokku-00.cs.ucsb.edu/

Closes #160, Merge after #212