### PR TITLE
divyanipunj - refactoring HomePage to HomePageLoggedOut and HomePageLoggedIn

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,51 +18,62 @@ import CoursesIndexPage from "main/pages/Instructors/CoursesIndexPage";
 import InstructorCourseShowPage from "main/pages/Instructor/InstructorCourseShowPage";
 
 function App() {
-  const currentUser = useCurrentUser();
+  const { data: currentUser } = useCurrentUser();
+
+  const userRoutes = hasRole(currentUser, "ROLE_USER") ? (
+    <>
+      <Route exact path="/profile" element={<ProfilePage />} />
+    </>
+  ) : null;
+
+  const adminRoutes = hasRole(currentUser, "ROLE_ADMIN") ? (
+    <>
+      <Route exact path="/admin/users" element={<AdminUsersPage />} />
+      <Route exact path="/admin/admins" element={<AdminsIndexPage />} />
+      <Route exact path="/instructor/courses" element={<CoursesIndexPage />} />
+      <Route
+        exact
+        path="/instructor/courses/:id"
+        element={<InstructorCourseShowPage />}
+      />
+      <Route
+        exact
+        path="/admin/instructors"
+        element={<InstructorsIndexPage />}
+      />
+      <Route exact path="/admin/admins/create" element={<AdminsCreatePage />} />
+      <Route
+        exact
+        path="/admin/instructors/create"
+        element={<InstructorsCreatePage />}
+      />
+    </>
+  ) : null;
+
+  const instructorRoutes = hasRole(currentUser, "ROLE_ADMIN") ? (
+    <>
+      <Route exact path="/instructor/courses" element={<CoursesIndexPage />} />
+      <Route
+        exact
+        path="/instructor/courses/:id"
+        element={<InstructorCourseShowPage />}
+      />
+    </>
+  ) : null;
+
+  const homeRoutes = currentUser?.loggedIn ? (
+    <Route path="/" element={<HomePageLoggedIn />} />
+  ) : (
+    <Route path="/" element={<HomePageLoggedOut />} />
+  );
 
   return (
     <BrowserRouter>
       <Routes>
-        <Route exact path="/" element={<HomePageLoggedOut />} />
-        <Route exact path="/profile" element={<ProfilePage />} />
-        {hasRole(currentUser, "ROLE_ADMIN") && (
-          <Route exact path="/admin/users" element={<AdminUsersPage />} />
-        )}
-        {(hasRole(currentUser, "ROLE_ADMIN") ||
-          hasRole(currentUser, "ROLE_INSTRUCTOR")) && (
-          <>
-            <Route
-              exact
-              path="/instructor/courses"
-              element={<CoursesIndexPage />}
-            />
-            <Route
-              exact
-              path="/instructor/courses/:id"
-              element={<InstructorCourseShowPage />}
-            />
-          </>
-        )}
-        {hasRole(currentUser, "ROLE_ADMIN") && (
-          <>
-            <Route exact path="/admin/admins" element={<AdminsIndexPage />} />
-            <Route
-              exact
-              path="/admin/instructors"
-              element={<InstructorsIndexPage />}
-            />
-            <Route
-              exact
-              path="/admin/admins/create"
-              element={<AdminsCreatePage />}
-            />
-            <Route
-              exact
-              path="/admin/instructors/create"
-              element={<InstructorsCreatePage />}
-            />
-          </>
-        )}
+        {userRoutes}
+        {adminRoutes}
+        {instructorRoutes}
+        {homeRoutes}
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/main/components/Courses/CoursesTable.js
+++ b/frontend/src/main/components/Courses/CoursesTable.js
@@ -20,7 +20,7 @@ const columns = [
   },
 ];
 
-export default function CoursesTable({ courses, storybook = false }) {
+export default function CoursesTable({ courses, testId, storybook = false }) {
   const joinCallback = (cell) => {
     // TODO: Implement the join functionality here
     if (storybook) {
@@ -34,7 +34,6 @@ export default function CoursesTable({ courses, storybook = false }) {
   const viewInviteCallback = (cell) => {
     const organizationName = cell.row.original.orgName;
     const gitInvite = `https://github.com/${organizationName}/invitation`;
-
     window.open(gitInvite, "_blank");
   };
 
@@ -51,7 +50,7 @@ export default function CoursesTable({ courses, storybook = false }) {
             <Button
               variant={"primary"}
               onClick={() => joinCallback(cell)}
-              data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
+              data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
             >
               Join Course
             </Button>
@@ -61,7 +60,7 @@ export default function CoursesTable({ courses, storybook = false }) {
             <Button
               variant={"primary"}
               onClick={() => viewInviteCallback(cell)}
-              data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
+              data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
             >
               View Invite
             </Button>
@@ -76,10 +75,6 @@ export default function CoursesTable({ courses, storybook = false }) {
     },
   ];
   return (
-    <OurTable
-      data={courses}
-      columns={columnsWithStatus}
-      testid={"CoursesTable"}
-    />
+    <OurTable data={courses} columns={columnsWithStatus} testid={testId} />
   );
 }

--- a/frontend/src/main/pages/HomePageLoggedIn.js
+++ b/frontend/src/main/pages/HomePageLoggedIn.js
@@ -1,0 +1,52 @@
+import CoursesTable from "main/components/Courses/CoursesTable";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useBackend } from "main/utils/useBackend";
+import { useCurrentUser } from "main/utils/currentUser";
+
+export default function HomePageLoggedIn() {
+  const { data: currentUser } = useCurrentUser();
+
+  const {
+    data: courses,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/courses/list"],
+    // Stryker disable next-line StringLiteral : The default value for an empty ("") method is GET. Therefore, there is no way to kill a mutation that transforms "GET" to ""
+    { method: "GET", url: "/api/courses/list" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+  const {
+    data: staffCourses,
+    error: _staffError,
+    status: _staffStatus,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/courses/staffCourses"],
+    // Stryker disable next-line StringLiteral : The default value for an empty ("") method is GET.
+    { method: "GET", url: "/api/courses/staffCourses" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Your Student Courses</h1>
+        <CoursesTable
+          courses={courses}
+          testId={"CoursesTable"}
+          currentUser={currentUser}
+        />
+        <h1>Your Staff Courses</h1>
+        <CoursesTable
+          courses={staffCourses}
+          testId={"StaffCoursesTable"}
+          currentUser={currentUser}
+        />
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/HomePageLoggedOut.js
+++ b/frontend/src/main/pages/HomePageLoggedOut.js
@@ -1,12 +1,25 @@
-import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
 
-export default function HomePageLoggedOut() {
-  return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Welcome to Frontiers!</h1>
-        <p>This is the MVP for the Frontiers Project.</p>
-      </div>
-    </BasicLayout>
-  );
-}
+import HomePageLoggedOut from "main/pages/HomePageLoggedOut";
+
+export default {
+  title: "pages/HomePageLoggedOut",
+  component: HomePageLoggedOut,
+};
+
+const Template = () => <HomePageLoggedOut />;
+
+export const LoggedOut = Template.bind({});
+LoggedOut.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(null, { status: 403 });
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+    ],
+  },
+};

--- a/frontend/src/stories/pages/HomePageLoggedIn.stories.js
+++ b/frontend/src/stories/pages/HomePageLoggedIn.stories.js
@@ -1,0 +1,52 @@
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import HomePageLoggedIn from "main/pages/HomePageLoggedIn";
+import coursesFixtures from "fixtures/coursesFixtures";
+
+export default {
+  title: "pages/HomePageLoggedIn",
+  component: HomePageLoggedIn,
+};
+
+const Template = () => <HomePageLoggedIn />;
+export const LoggedInRegularUser = Template.bind({});
+LoggedInRegularUser.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+      http.get("/api/courses/list", () => {
+        return HttpResponse.json(coursesFixtures.oneCourseWithEachStatus);
+      }),
+      http.get("/api/courses/staffCourses", () => {
+        return HttpResponse.json(coursesFixtures.oneCourseWithEachStatus);
+      }),
+    ],
+  },
+};
+
+export const LoggedInAdminUserShowingSwaggerAndH2Console = Template.bind({});
+LoggedInAdminUserShowingSwaggerAndH2Console.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingBoth);
+      }),
+      http.get("/api/courses/list", () => {
+        return HttpResponse.json(coursesFixtures.oneCourseWithEachStatus);
+      }),
+      http.get("/api/courses/staffCourses", () => {
+        return HttpResponse.json(coursesFixtures.oneCourseWithEachStatus);
+      }),
+    ],
+  },
+};

--- a/frontend/src/tests/components/Courses/CoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/CoursesTable.test.js
@@ -9,7 +9,10 @@ describe("CoursesTable tests", () => {
   test("Has the expected column headers and content", () => {
     render(
       <BrowserRouter>
-        <CoursesTable courses={coursesFixtures.oneCourseWithEachStatus} />
+        <CoursesTable
+          courses={coursesFixtures.oneCourseWithEachStatus}
+          testId={"CoursesTable"}
+        />
       </BrowserRouter>,
     );
 
@@ -77,7 +80,10 @@ describe("CoursesTable tests", () => {
   test("Does not call window.alert in default case for button 'Join Course'", () => {
     render(
       <BrowserRouter>
-        <CoursesTable courses={coursesFixtures.oneCourseWithEachStatus} />
+        <CoursesTable
+          courses={coursesFixtures.oneCourseWithEachStatus}
+          testId={"CoursesTable"}
+        />
       </BrowserRouter>,
     );
 
@@ -98,6 +104,7 @@ describe("CoursesTable tests", () => {
         <CoursesTable
           courses={coursesFixtures.oneCourseWithEachStatus}
           storybook={true}
+          testId={"CoursesTable"}
         />
       </BrowserRouter>,
     );
@@ -123,6 +130,7 @@ describe("CoursesTable tests", () => {
         <CoursesTable
           courses={coursesFixtures.oneCourseWithEachStatus}
           storybook={false}
+          testId={"CoursesTable"}
         />
       </BrowserRouter>,
     );
@@ -142,7 +150,10 @@ describe("CoursesTable tests", () => {
   test("Does not call window.alert in default case for button'View Invite'", () => {
     render(
       <BrowserRouter>
-        <CoursesTable courses={coursesFixtures.oneCourseWithEachStatus} />
+        <CoursesTable
+          courses={coursesFixtures.oneCourseWithEachStatus}
+          testId={"CoursesTable"}
+        />
       </BrowserRouter>,
     );
 
@@ -163,6 +174,7 @@ describe("CoursesTable tests", () => {
         <CoursesTable
           courses={coursesFixtures.oneCourseWithEachStatus}
           storybook={true}
+          testId={"CoursesTable"}
         />
       </BrowserRouter>,
     );
@@ -182,6 +194,7 @@ describe("CoursesTable tests", () => {
         <CoursesTable
           courses={coursesFixtures.oneCourseWithEachStatus}
           storybook={false}
+          testId={"CoursesTable"}
         />
       </BrowserRouter>,
     );

--- a/frontend/src/tests/pages/HomePageLoggedIn.test.js
+++ b/frontend/src/tests/pages/HomePageLoggedIn.test.js
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import {  MemoryRouter } from "react-router-dom";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import coursesFixtures from "fixtures/coursesFixtures";
+import HomePageLoggedIn from "main/pages/HomePageLoggedIn";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+let axiosMock = new AxiosMockAdapter(axios);
+
+describe("HomePageLoggedIn tests", () => {
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+  });
+
+  const queryClient = new QueryClient();
+
+   const setupUserOnly = () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  test("tables render correctly", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/courses/staffCourses")
+      .reply(200, coursesFixtures.oneCourseWithEachStatus);
+    axiosMock
+      .onGet("/api/courses/list")
+      .reply(200, coursesFixtures.oneCourseWithEachStatus);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HomePageLoggedIn />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`CoursesTable-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(
+      screen.getByTestId(`CoursesTable-cell-row-1-col-id`),
+    ).toHaveTextContent("2");
+    expect(
+      screen.getByTestId(`CoursesTable-cell-row-2-col-id`),
+    ).toHaveTextContent("3");
+    expect(
+      screen.getByTestId(`CoursesTable-cell-row-0-col-courseName`),
+    ).toHaveTextContent("CMPSC 156");
+    expect(
+      screen.getByTestId(`CoursesTable-cell-row-0-col-term`),
+    ).toHaveTextContent("Spring 2025");
+    expect(
+      screen.getByTestId(`CoursesTable-cell-row-0-col-school`),
+    ).toHaveTextContent("UCSB");
+    expect(
+      screen.getByTestId(`CoursesTable-cell-row-0-col-studentStatus`),
+    ).toHaveTextContent("Pending");
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`StaffCoursesTable-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(
+      screen.getByTestId(`StaffCoursesTable-cell-row-1-col-id`),
+    ).toHaveTextContent("2");
+    expect(
+      screen.getByTestId(`StaffCoursesTable-cell-row-2-col-id`),
+    ).toHaveTextContent("3");
+    expect(
+      screen.getByTestId(`StaffCoursesTable-cell-row-0-col-courseName`),
+    ).toHaveTextContent("CMPSC 156");
+    expect(
+      screen.getByTestId(`StaffCoursesTable-cell-row-0-col-term`),
+    ).toHaveTextContent("Spring 2025");
+    expect(
+      screen.getByTestId(`StaffCoursesTable-cell-row-0-col-school`),
+    ).toHaveTextContent("UCSB");
+    expect(
+      screen.getByTestId(`StaffCoursesTable-cell-row-0-col-studentStatus`),
+    ).toHaveTextContent("Pending");
+  });
+});

--- a/frontend/src/tests/pages/HomePageLoggedOut.test.js
+++ b/frontend/src/tests/pages/HomePageLoggedOut.test.js
@@ -29,3 +29,4 @@ describe("HomePageLoggedOut tests", () => {
     await screen.findByText(/Welcome to Frontiers!/);
   });
 });
+


### PR DESCRIPTION
This PR addresses https://github.com/ucsb-cs156/proj-frontiers/issues/84. 

This PR:
Adds HomePageLoggedIn, HomePageLoggedIn stories and HomePageLoggedIn tests.
Updates HomePageLoggedOut stories (which was originally HomePage until https://github.com/ucsb-cs156/proj-frontiers/pull/200)
Updates the parameters for CourseTable to include testId as a parameter (and updated tests).
Updated and reformatted App.js based on the code from [HappyCows](https://github.com/ucsb-cs156/proj-happycows/blob/144425696adbb24ea4c41594fc4ff0f77ea5fd2e/frontend/src/App.js#L104) according to this [message](https://ucsb-cs156-f25.slack.com/archives/C096M8WKZ6U/p1752621373952949) on Slack.
Storybook: ADD
Dokku: https://frontiers-divyanipunj.dokku-00.cs.ucsb.edu/

Test Plan (for interactive testing)
View the homepage logged out (to confirm that the homepage is only displays the welcome message)
View the homepage logged in (to confirm that both headers tables show up)
View the homepage logged in as a user who has student courses and/or staff courses