### PR TITLE
Adding a Sign In Card for Use on the Sign In Page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "react-bootstrap": "^2.10.4",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
+        "react-icons": "^5.5.0",
         "react-inspector": "^6.0.2",
         "react-query": "^3.39.3",
         "react-router-dom": "^6.26.1",
@@ -22902,6 +22903,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-inspector": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "react-bootstrap": "^2.10.4",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
+    "react-icons": "^5.5.0",
     "react-inspector": "^6.0.2",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.26.1",

--- a/frontend/src/main/components/Auth/SignInCard.js
+++ b/frontend/src/main/components/Auth/SignInCard.js
@@ -1,0 +1,30 @@
+import { Button, Card } from "react-bootstrap";
+
+export default function SignInCard({
+  url,
+  Icon,
+  title,
+  description,
+  testid = "default",
+}) {
+  return (
+    <Card style={{ width: "18rem" }} data-testid={`SignInCard-base-${testid}`}>
+      <Card.Body
+        className={"text-center"}
+        data-testid={`SignInCard-header-${testid}`}
+      >
+        <Icon />
+      </Card.Body>
+      <Card.Body>
+        <Card.Title>{title}</Card.Title>
+        <Card.Text>{description}</Card.Text>
+        <Card.Footer
+          className={"text-center"}
+          data-testid={`SignInCard-footer-${testid}`}
+        >
+          <Button href={url}>Log In</Button>
+        </Card.Footer>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/frontend/src/stories/components/Auth/SignInCard.stories.js
+++ b/frontend/src/stories/components/Auth/SignInCard.stories.js
@@ -1,0 +1,34 @@
+import SignInCard from "main/components/Auth/SignInCard";
+import { FcGoogle } from "react-icons/fc";
+import { FaMicrosoft } from "react-icons/fa";
+
+export default {
+  title: "components/Auth/SignInCard",
+  component: SignInCard,
+};
+
+const Template = (args) => <SignInCard {...args} />;
+
+export const Google = Template.bind({});
+
+Google.args = {
+  url: "/oauth2/authorization/google",
+  Icon: () => {
+    return <FcGoogle size={"10em"} />;
+  },
+  title: "Sign in with Google",
+  description:
+    "If you are a University of California-Santa Barbara student, sign in with your NetID.",
+};
+
+export const Microsoft = Template.bind({});
+
+Microsoft.args = {
+  url: "/oauth2/authorization/azure-dev",
+  Icon: () => {
+    return <FaMicrosoft size={"10em"} />;
+  },
+  title: "Sign in with Microsoft",
+  description:
+    "If you are an Oregon State University student, sign in with your ONID.",
+};

--- a/frontend/src/stories/components/Auth/SignInCard.stories.js
+++ b/frontend/src/stories/components/Auth/SignInCard.stories.js
@@ -18,7 +18,7 @@ Google.args = {
   },
   title: "Sign in with Google",
   description:
-    "If you are a University of California-Santa Barbara student, sign in with your NetID.",
+    "If you have a University of California-Santa Barbara login credentials, sign in with Google",
 };
 
 export const Microsoft = Template.bind({});

--- a/frontend/src/stories/components/Auth/SignInCard.stories.js
+++ b/frontend/src/stories/components/Auth/SignInCard.stories.js
@@ -18,7 +18,7 @@ Google.args = {
   },
   title: "Sign in with Google",
   description:
-    "If you have a University of California-Santa Barbara login credentials, sign in with Google",
+    "If you have University of California-Santa Barbara login credentials, sign in with Google",
 };
 
 export const Microsoft = Template.bind({});

--- a/frontend/src/stories/components/Auth/SignInCard.stories.js
+++ b/frontend/src/stories/components/Auth/SignInCard.stories.js
@@ -30,5 +30,5 @@ Microsoft.args = {
   },
   title: "Sign in with Microsoft",
   description:
-    "If you are an Oregon State University student, sign in with your ONID.",
+    "If you have Oregon State University login credentials, sign in with Microsoft.",
 };

--- a/frontend/src/tests/components/Auth/SignInCard.test.js
+++ b/frontend/src/tests/components/Auth/SignInCard.test.js
@@ -1,0 +1,64 @@
+import { FcGoogle } from "react-icons/fc";
+import { render, screen } from "@testing-library/react";
+import SignInCard from "main/components/Auth/SignInCard";
+
+const exampleIcon = () => {
+  return <FcGoogle size={"10em"} />;
+};
+
+describe("SignInCard Tests", () => {
+  test("Card renders with required properties", () => {
+    render(
+      <SignInCard
+        Icon={exampleIcon}
+        title={"Sign In with Google"}
+        description={"Boilerplate description"}
+        url={"/fakeUrl/fakePath"}
+        testid={"google"}
+      />,
+    );
+
+    expect(screen.getByText("Sign In with Google")).toBeInTheDocument();
+    expect(screen.getByText("Boilerplate description")).toBeInTheDocument();
+    expect(screen.getByText("Log In")).toHaveAttribute(
+      "href",
+      "/fakeUrl/fakePath",
+    );
+    expect(screen.getByTestId("SignInCard-footer-google")).toHaveClass(
+      "text-center",
+    );
+    expect(screen.getByTestId("SignInCard-header-google")).toHaveClass(
+      "text-center",
+    );
+    expect(screen.getByTestId("SignInCard-base-google")).toHaveStyle(
+      "width: 18rem",
+    );
+  });
+
+  test("Card renders with default testId", () => {
+    render(
+      <SignInCard
+        Icon={exampleIcon}
+        title={"Sign In with Google"}
+        description={"Boilerplate description"}
+        url={"/fakeUrl/fakePath"}
+      />,
+    );
+
+    expect(screen.getByText("Sign In with Google")).toBeInTheDocument();
+    expect(screen.getByText("Boilerplate description")).toBeInTheDocument();
+    expect(screen.getByText("Log In")).toHaveAttribute(
+      "href",
+      "/fakeUrl/fakePath",
+    );
+    expect(screen.getByTestId("SignInCard-footer-default")).toHaveClass(
+      "text-center",
+    );
+    expect(screen.getByTestId("SignInCard-header-default")).toHaveClass(
+      "text-center",
+    );
+    expect(screen.getByTestId("SignInCard-base-default")).toHaveStyle(
+      "width: 18rem",
+    );
+  });
+});


### PR DESCRIPTION
In this PR I add a sign in card that can be used for various OIDC sign-in methods.

Storybook link: https://67da6ee1a47bfcdda4700814-qznveqhnvc.chromatic.com/?path=/story/components-auth-signincard--google

<img width="460" height="632" alt="image" src="https://github.com/user-attachments/assets/d818836b-f7d5-45c1-986b-f53331fc7d9f" />

Additionally, this PR adds [React-Icons](https://react-icons.github.io/react-icons/), a popular icon bundler for React, for the Google and Microsoft logos.