### PR TITLE
Handling Not Found on the CourseShowPage

### DIFF
--- a/frontend/src/main/pages/Instructor/InstructorCourseShowPage.js
+++ b/frontend/src/main/pages/Instructor/InstructorCourseShowPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useBackend } from "main/utils/useBackend";
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
@@ -7,10 +7,13 @@ import { useCurrentUser } from "main/utils/currentUser";
 import { useNavigate, useParams } from "react-router-dom";
 
 import RosterStudentTable from "main/components/RosterStudent/RosterStudentTable";
+import Modal from "react-bootstrap/Modal";
+import { Button } from "react-bootstrap";
 
 export default function InstructorCourseShowPage() {
   const currentUser = useCurrentUser();
   const courseId = useParams().id;
+  const [showErrorModal, setShowErrorModal] = useState(false);
 
   const {
     data: course,
@@ -42,6 +45,7 @@ export default function InstructorCourseShowPage() {
   const navigate = useNavigate();
   useEffect(() => {
     if (getCourseFailed) {
+      setShowErrorModal(true);
       const timer = setTimeout(() => {
         navigate("/instructor/courses", { replace: true });
       }, 3000);
@@ -51,23 +55,23 @@ export default function InstructorCourseShowPage() {
     }
   }, [getCourseFailed, navigate]);
 
-  if (getCourseFailed) {
-    return (
-      <BasicLayout>
-        <div className="pt-2">
-          <h1>Course</h1>
-          <p>
-            Course not found. You will be returned to the course list in 3
-            seconds.
-          </p>
-        </div>
-      </BasicLayout>
-    );
-  }
-
   const testId = "InstructorCourseShowPage";
   return (
     <BasicLayout>
+      <Modal show={showErrorModal}>
+        <Modal.Header>
+          <Modal.Title>Course Not Found</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          Course not found. You will be returned to the course list in 3
+          seconds.
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={() => setShowErrorModal(false)} variant={"primary"}>
+            Close
+          </Button>
+        </Modal.Footer>
+      </Modal>
       <div className="pt-2">
         <h1>Course</h1>
         <InstructorCoursesTable

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -25,7 +25,12 @@ import { toast } from "react-toastify";
 //     []
 // );
 
-export function useBackend(queryKey, axiosParameters, initialData) {
+export function useBackend(
+  queryKey,
+  axiosParameters,
+  initialData,
+  suppressToasts = false,
+) {
   return useQuery(
     queryKey,
     async () => {
@@ -34,7 +39,9 @@ export function useBackend(queryKey, axiosParameters, initialData) {
         return response.data;
       } catch (e) {
         const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
-        toast(errorMessage);
+        if (!suppressToasts) {
+          toast(errorMessage);
+        }
         console.error(errorMessage, e);
         throw e;
       }

--- a/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
+++ b/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
@@ -101,6 +101,7 @@ describe("InstructorCourseShowPage tests", () => {
     expect(studentId0).toHaveTextContent(
       rosterStudentFixtures.threeStudents[0].studentId,
     );
+    expect(screen.queryByText("Course Not Found")).not.toBeInTheDocument();
 
     jest.advanceTimersByTime(3000);
     expect(mockedNavigate).not.toHaveBeenCalled();
@@ -252,7 +253,12 @@ describe("InstructorCourseShowPage tests", () => {
       "Course not found. You will be returned to the course list in 3 seconds.",
     );
     expect(mockToast).not.toHaveBeenCalled();
-    expect(screen.getByText("Course")).toBeInTheDocument();
+    expect(screen.getByText("Course Not Found")).toBeInTheDocument();
+    expect(screen.getByText("Close")).toHaveClass("btn-primary");
+    fireEvent.click(screen.getByText("Close"));
+    await waitFor(() =>
+      expect(screen.queryByText("Course Not Found")).not.toBeInTheDocument(),
+    );
     act(() => {
       jest.advanceTimersByTime(5000);
     });
@@ -287,11 +293,16 @@ describe("InstructorCourseShowPage tests", () => {
     await screen.findByText(
       "Course not found. You will be returned to the course list in 3 seconds.",
     );
+    fireEvent.keyPress(screen.getByText("Course Not Found"), {
+      key: "Escape",
+      code: 27,
+      charCode: 27,
+    });
     fireEvent.click(
       within(screen.getByRole("navigation")).getByText("Frontiers"),
     );
     await waitFor(() =>
-      expect(clearTimeoutSpy.mock.results.length).toBeGreaterThanOrEqual(6),
+      expect(clearTimeoutSpy.mock.results.length).toBeGreaterThanOrEqual(8),
     );
     setTimeoutSpy.mockRestore();
     clearTimeoutSpy.mockRestore();


### PR DESCRIPTION
In this PR, I handle the backend returning a "Not Found" on the CourseShowPage.

If the useBackend() query fails, a modal will be displayed informing the user that the course does not exist.

I decided against making this modal into a proper component because it is essentially a straight bootstrap modal with some text in it.

<img width="2535" height="792" alt="image" src="https://github.com/user-attachments/assets/739952d7-2737-4086-a21a-a7f20a63e965" />


After 3 seconds, it will return them to the Instructors' Course list.

Test Plan:
1. Sign in as an account with instructor permissions
2. Go to the url of a nonexistent course, like https://frontiers-qa4.dokku-00.cs.ucsb.edu/instructor/courses/47
3. Observe the modal and the change of pages.

Deployed to https://frontiers-qa4.dokku-00.cs.ucsb.edu/
Closes #206 