### PR TITLE
pc/dj - add rosterStudentId and staffId to the backend endpoints we use to populate home page so that we can join courses

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
@@ -92,6 +92,13 @@ public class CourseStaffController extends ApiController {
                 .email(email)
                 .course(course)
                 .build();
+
+        if(course.getInstallationId() != null) {
+            courseStaff.setOrgStatus(OrgStatus.JOINCOURSE);
+        } else {
+            courseStaff.setOrgStatus(OrgStatus.PENDING);
+        }
+
         CourseStaff savedCourseStaff = courseStaffRepository.save(courseStaff);
 
         return savedCourseStaff;

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffControllerTests.java
@@ -98,8 +98,25 @@ public class CourseStaffControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "ADMIN" })
         public void testPostCourseStaff() throws Exception {
 
-                when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));
-                when(courseStaffRepository.save(any(CourseStaff.class))).thenReturn(cs1);
+                Course course2 = Course.builder()
+                        .id(1L)
+                        .courseName("CS156")
+                        .orgName("ucsb-cs156-s25")
+                        .term("S25")
+                        .school("UCSB")
+                        .build();
+
+                CourseStaff cs2 = CourseStaff.builder()
+                        .firstName("Chris")
+                        .lastName("Gaucho")
+                        .email("cgaucho@example.org")
+                        .course(course2)
+                        .orgStatus(OrgStatus.PENDING)
+                        .build();
+
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course2));
+                when(courseStaffRepository.save(any(CourseStaff.class))).thenReturn(cs2);
+
 
                 // act
 
@@ -115,10 +132,60 @@ public class CourseStaffControllerTests extends ControllerTestCase {
                 // assert
 
                 verify(courseRepository, times(1)).findById(eq(1L));
-                verify(courseStaffRepository, times(1)).save(eq(cs1));
+                verify(courseStaffRepository, times(1)).save(eq(cs2));
 
                 String responseString = response.getResponse().getContentAsString();
-                String expectedJson = mapper.writeValueAsString(cs1);
+                String expectedJson = mapper.writeValueAsString(cs2);
+                assertEquals(expectedJson, responseString);
+
+        }
+
+        /**
+         * Test the POST endpoint
+         */
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void test_post_course_staff_join_course_status() throws Exception {
+
+                Course course2 = Course.builder()
+                        .id(1L)
+                        .courseName("CS156")
+                        .orgName("ucsb-cs156-s25")
+                        .installationId("12345")
+                        .term("S25")
+                        .school("UCSB")
+                        .build();
+
+                CourseStaff cs2 = CourseStaff.builder()
+                        .firstName("Chris")
+                        .lastName("Gaucho")
+                        .email("cgaucho@example.org")
+                        .course(course2)
+                        .orgStatus(OrgStatus.JOINCOURSE)
+                        .build();
+
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course2));
+                when(courseStaffRepository.save(any(CourseStaff.class))).thenReturn(cs2);
+
+
+                // act
+
+                MvcResult response = mockMvc.perform(post("/api/coursestaff/post")
+                                .with(csrf())
+                                .param("firstName", "Chris")
+                                .param("lastName", "Gaucho")
+                                .param("email", "cgaucho@example.org")
+                                .param("courseId", "1"))
+                        .andExpect(status().isOk())
+                        .andReturn();
+
+                // assert
+
+                verify(courseRepository, times(1)).findById(eq(1L));
+                verify(courseStaffRepository, times(1)).save(eq(cs2));
+
+                String responseString = response.getResponse().getContentAsString();
+                String expectedJson = mapper.writeValueAsString(cs2);
                 assertEquals(expectedJson, responseString);
 
         }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 import edu.ucsb.cs156.frontiers.ControllerTestCase;
 import edu.ucsb.cs156.frontiers.controllers.CoursesController.InstructorCourseView;
+import edu.ucsb.cs156.frontiers.controllers.CoursesController.StaffCoursesDTO;
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.CourseStaff;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
@@ -495,6 +496,7 @@ public class CoursesControllerTests extends ControllerTestCase {
                 expected.put("term", course.getTerm());
                 expected.put("school", course.getSchool());
                 expected.put("studentStatus", new RosterStudentDTO(rs).orgStatus());
+                expected.put("rosterStudentId", rs.getId());
 
                 String expectedJson = mapper.writeValueAsString(List.of(expected));
                 assertEquals(expectedJson, result.getResponse().getContentAsString());
@@ -531,6 +533,7 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .email("user@example.org")
                                 .course(course1)
                                 .user(currentUser)
+                                .id(37L)
                                 .build();
 
                 CourseStaff cs2 = CourseStaff.builder()
@@ -539,7 +542,28 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .email("user@example.org")
                                 .course(course2)
                                 .user(currentUser)
+                                .id(42L)
                                 .build();
+
+                StaffCoursesDTO staffCourse1 = new StaffCoursesDTO(
+                                course1.getId(),
+                                course1.getInstallationId(),
+                                course1.getOrgName(),
+                                course1.getCourseName(),
+                                course1.getTerm(),
+                                course1.getSchool(),
+                                cs1.getOrgStatus(),
+                                cs1.getId());
+
+                StaffCoursesDTO staffCourse2 = new StaffCoursesDTO(
+                                course2.getId(),
+                                course2.getInstallationId(),
+                                course2.getOrgName(),
+                                course2.getCourseName(),
+                                course2.getTerm(),
+                                course2.getSchool(),
+                                cs2.getOrgStatus(),
+                                cs2.getId());
 
                 when(courseStaffRepository.findAllByEmail("user@example.org"))
                                 .thenReturn(List.of(cs1, cs2));
@@ -555,7 +579,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // assert
                 String responseString = response.getResponse().getContentAsString();
-                String expectedJson = mapper.writeValueAsString(List.of(course1, course2));
+                String expectedJson = mapper.writeValueAsString(List.of(staffCourse1, staffCourse2));
                 assertEquals(expectedJson, responseString);
         }
 


### PR DESCRIPTION
In this PR, we add a field to each of two API endpoints as described below:

* For /api/courses/list, which is the endpoint where a student can see what courses they are on the roster of, we add rosterStudentId
* For /api/courses/staffCourses, which is the endpoint where a user can see what courses they are on the staff roster for, we add staffId

Both of these are in service of the same purpose: to make sure we have the id we need in order to implement the JoinCourse button, which needs these values to call the endpoints to join a course.

Deployed to: https://frontiers-qa1.dokku-00.cs.ucsb.edu