### PR TITLE
pc - remove unnecessary error check

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
@@ -117,11 +117,6 @@ public class CourseStaffController extends ApiController {
             throw new IllegalArgumentException(String.format("This operation is restricted to the user associated with staff member with id %d", courseStaff.getId()));
         }
 
-        if ((courseStaff.getGithubId() != null && courseStaff.getGithubId() != 0) && courseStaff.getGithubLogin() != null) {
-            return ResponseEntity.badRequest().body("This course staff has already joined the course with a GitHub account.");
-        }
-
-
         if(courseStaff.getCourse().getOrgName() == null || courseStaff.getCourse().getInstallationId() == null) {
             return ResponseEntity.badRequest().body("Course has not been set up. Please ask your instructor for help.");
         }

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/JobsController.java
@@ -8,6 +8,7 @@ import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import edu.ucsb.cs156.frontiers.jobs.MembershipAuditJob;
 import edu.ucsb.cs156.frontiers.jobs.UpdateAllJob;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.CourseStaffRepository;
 import edu.ucsb.cs156.frontiers.repositories.JobsRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
@@ -46,6 +47,8 @@ public class JobsController extends ApiController {
     private CourseRepository courseRepository;
     @Autowired
     private OrganizationMemberService organizationMemberService;
+    @Autowired
+    private CourseStaffRepository courseStaffRepository;
 
   @Operation(summary = "List all jobs")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -118,6 +121,7 @@ public class JobsController extends ApiController {
             .rosterStudentRepository(rosterStudentRepository)
             .courseRepository(courseRepository)
             .organizationMemberService(organizationMemberService)
+            .courseStaffRepository(courseStaffRepository)
             .build();
     return jobService.runAsJob(job);
   }

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
@@ -1,10 +1,12 @@
 package edu.ucsb.cs156.frontiers.jobs;
 
 import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.CourseStaff;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.models.OrgMember;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.CourseStaffRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
 import edu.ucsb.cs156.frontiers.services.jobs.JobContext;
@@ -20,6 +22,7 @@ public class MembershipAuditJob implements JobContextConsumer {
     CourseRepository courseRepository;
     OrganizationMemberService organizationMemberService;
     RosterStudentRepository rosterStudentRepository;
+    CourseStaffRepository courseStaffRepository;
 
     @Override
     public void accept(JobContext ctx) throws Exception {
@@ -31,6 +34,7 @@ public class MembershipAuditJob implements JobContextConsumer {
                 Iterable<OrgMember> admins = organizationMemberService.getOrganizationAdmins(course);
                 Iterable<OrgMember> invitees = organizationMemberService.getOrganizationInvitees(course);
                 List<RosterStudent> rosterStudents = course.getRosterStudents();
+                List<CourseStaff> courseStaff = course.getCourseStaff();
                 for (int i = 0; i < rosterStudents.size(); i++ ) {
                     Integer studentGithubId = rosterStudents.get(i).getGithubId();
                     String studentGithubLogin = rosterStudents.get(i).getGithubLogin();
@@ -39,7 +43,7 @@ public class MembershipAuditJob implements JobContextConsumer {
                         Optional<OrgMember> admin = StreamSupport.stream(admins.spliterator(), false).filter(s -> studentGithubId.equals(s.getGithubId())).findFirst();
                         Optional<OrgMember> invitee = StreamSupport.stream(invitees.spliterator(), false).filter(s -> studentGithubId.equals(s.getGithubId())).findFirst();
 
-                        OrgStatus updatedStatus = OrgStatus.PENDING;
+                        OrgStatus updatedStatus = OrgStatus.JOINCOURSE;
 
                         if (admin.isPresent()) {
                             updatedStatus = OrgStatus.OWNER;
@@ -52,6 +56,28 @@ public class MembershipAuditJob implements JobContextConsumer {
                     }
                 }
                 rosterStudentRepository.saveAll(rosterStudents);
+
+                for(int i = 0; i < courseStaff.size(); i++){
+                    Integer staffGithubId = courseStaff.get(i).getGithubId();
+                    String staffGithubLogin = courseStaff.get(i).getGithubLogin();
+                    if(staffGithubId != null && staffGithubLogin != null){
+                        Optional<OrgMember> member = StreamSupport.stream(members.spliterator(), false).filter(s -> staffGithubId.equals(s.getGithubId())).findFirst();
+                        Optional<OrgMember> admin = StreamSupport.stream(admins.spliterator(), false).filter(s -> staffGithubId.equals(s.getGithubId())).findFirst();
+                        Optional<OrgMember> invitee = StreamSupport.stream(invitees.spliterator(), false).filter(s -> staffGithubId.equals(s.getGithubId())).findFirst();
+
+                        OrgStatus updatedStatus = OrgStatus.JOINCOURSE;
+
+                        if (admin.isPresent()) {
+                            updatedStatus = OrgStatus.OWNER;
+                        } else if (member.isPresent()) {
+                            updatedStatus = OrgStatus.MEMBER;
+                        } else if (invitee.isPresent()) {
+                            updatedStatus = OrgStatus.INVITED;
+                        }
+                        courseStaff.get(i).setOrgStatus(updatedStatus);
+                    }
+                }
+                courseStaffRepository.saveAll(courseStaff);
             }
         }
         ctx.log("Done");

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffControllerTests.java
@@ -375,41 +375,6 @@ public class CourseStaffControllerTests extends ControllerTestCase {
                 verify(courseStaffRepository, never()).save(any(CourseStaff.class));
         }
 
-        @Test
-        @WithMockUser(roles = { "USER", "GITHUB"})
-        public void testJoinCourseOnGitHub_alreadyJoined() throws Exception {
-                User currentUser = currentUserService.getUser();
-
-                CourseStaff courseStaff = CourseStaff.builder()
-                        .id(5L)
-                        .firstName("Already")
-                        .lastName("Linked")
-                        .email("alreadylinked@ucsb.edu")
-                        .course(course1)
-                        .orgStatus(OrgStatus.PENDING)
-                        .githubId(98765)
-                        .githubLogin("existinguser")
-                        .user(currentUser)
-                        .build();
-
-                when(courseStaffRepository.findById(eq(5L))).thenReturn(Optional.of(courseStaff));
-
-                // Act
-                MvcResult response = mockMvc.perform(put("/api/coursestaff/joinCourse")
-                                .with(csrf())
-                                .param("courseStaffId", "5"))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
-
-                // Assert
-                verify(courseStaffRepository).findById(eq(5L));
-                verify(courseStaffRepository, never()).save(any(CourseStaff.class));
-                verify(organizationMemberService, times(0)).inviteOrganizationOwner(any(CourseStaff.class));
-
-                assertEquals("This course staff has already joined the course with a GitHub account.", response.getResponse().getContentAsString());
-        }
-
-
 
         @Test
         @WithMockUser(roles = { "USER", "GITHUB"})

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/JobsControllerDetailedTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/JobsControllerDetailedTests.java
@@ -19,10 +19,7 @@ import edu.ucsb.cs156.frontiers.ControllerTestCase;
 import edu.ucsb.cs156.frontiers.entities.Job;
 import edu.ucsb.cs156.frontiers.entities.User;
 import edu.ucsb.cs156.frontiers.jobs.UpdateAllJob;
-import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
-import edu.ucsb.cs156.frontiers.repositories.JobsRepository;
-import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
-import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.repositories.*;
 import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
 import edu.ucsb.cs156.frontiers.services.UpdateUserService;
 import edu.ucsb.cs156.frontiers.services.jobs.JobService;
@@ -69,6 +66,9 @@ public class JobsControllerDetailedTests extends ControllerTestCase {
 
   @MockitoBean
   CourseRepository courseRepository;
+
+  @MockitoBean
+  CourseStaffRepository courseStaffRepository;
 
   @MockitoBean
   UpdateUserService updateUserService; // This will be used in the UpdateAllJob to call the GithubSignInService

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/JobsControllerJobsTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/JobsControllerJobsTests.java
@@ -9,6 +9,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import edu.ucsb.cs156.frontiers.repositories.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -24,10 +25,6 @@ import edu.ucsb.cs156.frontiers.entities.Job;
 import edu.ucsb.cs156.frontiers.entities.User;
 import edu.ucsb.cs156.frontiers.jobs.MembershipAuditJob;
 import edu.ucsb.cs156.frontiers.jobs.UpdateAllJob;
-import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
-import edu.ucsb.cs156.frontiers.repositories.JobsRepository;
-import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
-import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
 import edu.ucsb.cs156.frontiers.services.UpdateUserService;
 import edu.ucsb.cs156.frontiers.services.jobs.JobService;
@@ -67,6 +64,9 @@ public class JobsControllerJobsTests extends ControllerTestCase {
 
   @MockitoBean
   OrganizationMemberService organizationMemberService;
+
+  @MockitoBean
+  CourseStaffRepository courseStaffRepository;
 
   @Autowired
   ObjectMapper objectMapper;

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJobTests.java
@@ -1,11 +1,13 @@
 package edu.ucsb.cs156.frontiers.jobs;
 
 import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.CourseStaff;
 import edu.ucsb.cs156.frontiers.entities.Job;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.models.OrgMember;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.CourseStaffRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
@@ -39,6 +41,9 @@ public class MembershipAuditJobTests {
     @Mock
     private CourseRepository courseRepository;
 
+    @Mock
+    CourseStaffRepository courseStaffRepository;
+
 
     Job jobStarted = Job.builder().build();
     JobContext ctx = new JobContext(null, jobStarted);
@@ -49,13 +54,15 @@ public class MembershipAuditJobTests {
     }
 
     @Test
-    public void match_students_correctly() throws Exception {
+    public void match_students_and_staff_correctly() throws Exception {
         OrgMember orgMember1 = OrgMember.builder().githubId(123456).githubLogin("division7").build();
         OrgMember orgMember2 = OrgMember.builder().githubId(123457).githubLogin("division8").build();
-        List<OrgMember> orgMembers = List.of(orgMember1, orgMember2);
+        OrgMember orgMember5 = OrgMember.builder().githubId(781).githubLogin("division11").build();
+        List<OrgMember> orgMembers = List.of(orgMember1, orgMember2, orgMember5);
         OrgMember orgMember3 = OrgMember.builder().githubId(123455).githubLogin("division9").build();
         OrgMember orgMember4 = OrgMember.builder().githubId(772).githubLogin("unmatched").build();
-        List<OrgMember> secondCourse = List.of(orgMember3, orgMember4);
+        OrgMember orgMember6 = OrgMember.builder().githubId(738).githubLogin("division6").build();
+        List<OrgMember> secondCourse = List.of(orgMember3, orgMember4, orgMember6);
 
         List<OrgMember> emptyAdmins = List.of();
 
@@ -66,17 +73,31 @@ public class MembershipAuditJobTests {
         RosterStudent student1 = RosterStudent.builder().studentId("banana").githubLogin("division7").githubId(123456).course(course).build();
         RosterStudent student2 = RosterStudent.builder().studentId("apple").githubLogin("division8").githubId(123457).course(course).build();
         course.setRosterStudents(List.of(student1, student2));
+
+        CourseStaff courseStaff1 = CourseStaff.builder().githubLogin("division11").githubId(781).course(course).build();
+        course.setCourseStaff(List.of(courseStaff1));
+
         RosterStudent student3 = RosterStudent.builder().studentId("banana").githubLogin("division9").githubId(123455).course(course2).build();
         RosterStudent student4 = RosterStudent.builder().studentId("apple").githubLogin("division10").githubId(123454).course(course2).build();
         RosterStudent student5 = RosterStudent.builder().studentId("orange").githubLogin(null).githubId(null).course(course2).build();
         RosterStudent student6 = RosterStudent.builder().studentId("grape").githubLogin(null).githubId(123455).course(course3).build();
         course2.setRosterStudents(List.of(student3, student4, student5, student6));
+
+        CourseStaff courseStaff2 = CourseStaff.builder().githubLogin("division6").githubId(738).course(course2).build();
+        CourseStaff courseStaff3 = CourseStaff.builder().githubLogin(null).githubId(null).course(course2).build();
+        CourseStaff courseStaff4 = CourseStaff.builder().githubLogin(null).githubId(722).course(course2).build();
+        course2.setCourseStaff(List.of(courseStaff2, courseStaff3, courseStaff4));
+
         RosterStudent student1Updated = RosterStudent.builder().studentId("banana").githubLogin("division7").githubId(123456).course(course).orgStatus(OrgStatus.MEMBER).build();
         RosterStudent student2Updated = RosterStudent.builder().studentId("apple").githubLogin("division8").githubId(123457).course(course).orgStatus(OrgStatus.MEMBER).build();
         RosterStudent student3Updated = RosterStudent.builder().studentId("banana").githubLogin("division9").githubId(123455).course(course2).orgStatus(OrgStatus.MEMBER).build();
-        RosterStudent student4Updated = RosterStudent.builder().studentId("apple").githubLogin("division10").githubId(123454).course(course2).orgStatus(OrgStatus.PENDING).build();
+        RosterStudent student4Updated = RosterStudent.builder().studentId("apple").githubLogin("division10").githubId(123454).course(course2).orgStatus(OrgStatus.JOINCOURSE).build();
         RosterStudent student5Updated = RosterStudent.builder().studentId("orange").githubLogin(null).githubId(null).course(course2).build();
         RosterStudent student6Updated = RosterStudent.builder().studentId("grape").githubLogin(null).githubId(123455).course(course3).build();
+        CourseStaff courseStaff1Updated = CourseStaff.builder().githubLogin("division11").githubId(781).course(course).orgStatus(OrgStatus.MEMBER).build();
+        CourseStaff courseStaff2Updated = CourseStaff.builder().githubLogin("division6").githubId(738).course(course2).orgStatus(OrgStatus.MEMBER).build();
+        CourseStaff courseStaff3Updated = CourseStaff.builder().githubLogin(null).githubId(null).course(course2).build();
+        CourseStaff courseStaff4Updated = CourseStaff.builder().githubLogin(null).githubId(722).course(course2).build();
 
 
 
@@ -90,6 +111,7 @@ public class MembershipAuditJobTests {
                 .rosterStudentRepository(rosterStudentRepository)
                 .organizationMemberService(organizationMemberService)
                 .courseRepository(courseRepository)
+                .courseStaffRepository(courseStaffRepository)
                 .build());
 
         matchJob.accept(ctx);
@@ -99,8 +121,12 @@ public class MembershipAuditJobTests {
         assertEquals(expected, jobStarted.getLog());
 
         verify(rosterStudentRepository, atLeastOnce()).saveAll(eq(List.of(student1Updated, student2Updated)));
+        verify(courseStaffRepository, atLeastOnce()).saveAll(eq(List.of(courseStaff1Updated)));
+        verify(courseStaffRepository, atLeastOnce()).saveAll(eq(List.of(courseStaff2Updated,courseStaff3Updated,courseStaff4Updated)));
         verify(rosterStudentRepository, atLeastOnce()).saveAll(eq(List.of(student3Updated, student4Updated, student5Updated, student6Updated)));
         verify(rosterStudentRepository, times(2)).saveAll(any());
+        verify(courseStaffRepository, times(2)).saveAll(any());
+        verifyNoMoreInteractions(courseStaffRepository, rosterStudentRepository);
     }
 
 
@@ -113,15 +139,20 @@ public class MembershipAuditJobTests {
         Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
         RosterStudent student1 = RosterStudent.builder().studentId("banana").githubLogin("division7").githubId(123456).course(course).build();
         course.setRosterStudents(List.of(student1));
-        RosterStudent student1Updated = RosterStudent.builder().studentId("banana").githubLogin("division7").githubId(123456).course(course).orgStatus(OrgStatus.PENDING).build();
+        CourseStaff courseStaff1 = CourseStaff.builder().githubLogin("apple").githubId(123457).course(course).build();
+        course.setCourseStaff(List.of(courseStaff1));
+        RosterStudent student1Updated = RosterStudent.builder().studentId("banana").githubLogin("division7").githubId(123456).course(course).orgStatus(OrgStatus.JOINCOURSE).build();
+        CourseStaff courseStaff1Updated = CourseStaff.builder().githubLogin("apple").githubId(123457).course(course).orgStatus(OrgStatus.JOINCOURSE).build();
         when(organizationMemberService.getOrganizationMembers(course)).thenReturn(orgMembers);
         when(organizationMemberService.getOrganizationAdmins(course)).thenReturn(emptyAdmins);
+        when(organizationMemberService.getOrganizationInvitees(course)).thenReturn(List.of());
         when(courseRepository.findAll()).thenReturn(List.of(course));
 
         var matchJob = spy(MembershipAuditJob.builder()
                 .rosterStudentRepository(rosterStudentRepository)
                 .organizationMemberService(organizationMemberService)
                 .courseRepository(courseRepository)
+                .courseStaffRepository(courseStaffRepository)
                 .build());
 
         matchJob.accept(ctx);
@@ -131,23 +162,33 @@ public class MembershipAuditJobTests {
         assertEquals(expected, jobStarted.getLog());
 
         verify(rosterStudentRepository, times(1)).saveAll(eq(List.of(student1Updated)));
+        verify(courseStaffRepository, times(1)).saveAll(eq(List.of(courseStaff1Updated)));
+        verifyNoMoreInteractions(courseStaffRepository, rosterStudentRepository);
     }
 
     @Test
-    public void match_admin_students_correctly() throws Exception {
+    public void match_admin_students_and_staff_correctly() throws Exception {
         OrgMember orgMember2 = OrgMember.builder().githubId(123457).githubLogin("division8").build();
-        List<OrgMember> orgMembers = List.of(orgMember2);
+        OrgMember orgMember4 = OrgMember.builder().githubId(752).githubLogin("division11").build();
+        List<OrgMember> orgMembers = List.of(orgMember2, orgMember4);
 
         OrgMember orgAdmin2 = OrgMember.builder().githubId(123455).githubLogin("division9").build();
-        List<OrgMember> orgAdmins = List.of(orgAdmin2);
+        OrgMember orgAdmin3 = OrgMember.builder().githubId(772).githubLogin("division6").build();
+        List<OrgMember> orgAdmins = List.of(orgAdmin2,orgAdmin3);
 
         Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
         RosterStudent student2 = RosterStudent.builder().studentId("apple").githubLogin("division8").githubId(123457).course(course).build();
         RosterStudent student3 = RosterStudent.builder().studentId("orange").githubLogin("division9").githubId(123455).course(course).build();
         course.setRosterStudents(List.of(student2, student3));
 
+        CourseStaff courseStaff1 = CourseStaff.builder().githubLogin("division6").githubId(772).course(course).build();
+        CourseStaff courseStaff2 = CourseStaff.builder().githubLogin("division11").githubId(752).course(course).build();
+        course.setCourseStaff(List.of(courseStaff1, courseStaff2));
+
         RosterStudent student2Updated = RosterStudent.builder().studentId("apple").githubLogin("division8").githubId(123457).course(course).orgStatus(OrgStatus.MEMBER).build();
         RosterStudent student3Updated = RosterStudent.builder().studentId("orange").githubLogin("division9").githubId(123455).course(course).orgStatus(OrgStatus.OWNER).build();
+        CourseStaff courseStaff1Updated = CourseStaff.builder().githubLogin("division6").githubId(772).course(course).orgStatus(OrgStatus.OWNER).build();
+        CourseStaff courseStaff2Updated = CourseStaff.builder().githubLogin("division11").githubId(752).course(course).orgStatus(OrgStatus.MEMBER).build();
 
         doReturn(orgMembers).when(organizationMemberService).getOrganizationMembers(eq(course));
         doReturn(orgAdmins).when(organizationMemberService).getOrganizationAdmins(eq(course));
@@ -157,6 +198,7 @@ public class MembershipAuditJobTests {
                 .rosterStudentRepository(rosterStudentRepository)
                 .organizationMemberService(organizationMemberService)
                 .courseRepository(courseRepository)
+                .courseStaffRepository(courseStaffRepository)
                 .build());
 
         matchJob.accept(ctx);
@@ -166,13 +208,16 @@ public class MembershipAuditJobTests {
         assertEquals(expected, jobStarted.getLog());
 
         verify(rosterStudentRepository, times(1)).saveAll(eq(List.of(student2Updated, student3Updated)));
+        verify(courseStaffRepository, times(1)).saveAll(eq(List.of(courseStaff1Updated, courseStaff2Updated)));
+        verifyNoMoreInteractions(courseStaffRepository, rosterStudentRepository);
     }
     @Test
-    public void match_invited_students_correctly() throws Exception {
+    public void match_invited_students_and_staff_correctly() throws Exception {
         List<OrgMember> emptyMembers = List.of();
         List<OrgMember> emptyAdmins = List.of();
         OrgMember invitee = OrgMember.builder().githubId(123456).githubLogin("division7").build();
-        List<OrgMember> orgInvitees = List.of(invitee);
+        OrgMember invitee2 = OrgMember.builder().githubId(777).githubLogin("division6").build();
+        List<OrgMember> orgInvitees = List.of(invitee, invitee2);
 
         Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
 
@@ -189,10 +234,16 @@ public class MembershipAuditJobTests {
                 .githubLogin("division11")
                 .githubId(241789)
                 .course(course)
-                .orgStatus(OrgStatus.PENDING)
+                .orgStatus(OrgStatus.JOINCOURSE)
                 .build();
 
+        CourseStaff courseStaff1 = CourseStaff.builder().githubLogin("division6").orgStatus(OrgStatus.MEMBER).githubId(777).course(course).build();
+
+        CourseStaff courseStaff2 = CourseStaff.builder().githubLogin("division14").githubId(7310).course(course).orgStatus(OrgStatus.JOINCOURSE).build();
+
         course.setRosterStudents(List.of(student, student2));
+
+        course.setCourseStaff(List.of(courseStaff1, courseStaff2));
 
         RosterStudent studentUpdated = RosterStudent.builder()
             .studentId("banana")
@@ -207,8 +258,11 @@ public class MembershipAuditJobTests {
                 .githubLogin("division11")
                 .githubId(241789)
                 .course(course)
-                .orgStatus(OrgStatus.PENDING)
+                .orgStatus(OrgStatus.JOINCOURSE)
                 .build();
+
+        CourseStaff courseStaff1Updated = CourseStaff.builder().githubLogin("division6").orgStatus(OrgStatus.INVITED).githubId(777).course(course).build();
+        CourseStaff courseStaff2NotUpdated = CourseStaff.builder().githubLogin("division14").githubId(7310).course(course).orgStatus(OrgStatus.JOINCOURSE).build();
 
         doReturn(emptyMembers).when(organizationMemberService).getOrganizationMembers(eq(course));
         doReturn(emptyAdmins).when(organizationMemberService).getOrganizationAdmins(eq(course));
@@ -219,6 +273,7 @@ public class MembershipAuditJobTests {
                 .rosterStudentRepository(rosterStudentRepository)
                 .organizationMemberService(organizationMemberService)
                 .courseRepository(courseRepository)
+                .courseStaffRepository(courseStaffRepository)
                 .build());
 
         matchJob.accept(ctx);
@@ -229,5 +284,7 @@ public class MembershipAuditJobTests {
         assertEquals(expected, jobStarted.getLog());
 
         verify(rosterStudentRepository, times(1)).saveAll(eq(List.of(studentUpdated, student2NotUpdated)));
+        verify(courseStaffRepository).saveAll(eq(List.of(courseStaff1Updated, courseStaff2NotUpdated)));
+        verifyNoMoreInteractions(courseStaffRepository, rosterStudentRepository);
     }
 }


### PR DESCRIPTION
In this PR we remove an error check that actually seems to be getting in the way.

If a user is in the JoinCourse status, they need to be able to go through the logic that sets their status correctly.

This check prevents them from ever reaching that logic.

Deployed to https://frontiers-qa7.dokku-00.cs.ucsb.edu