### PR TITLE
dj - fixed member inference to say member rather than direct_member

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/services/GoogleSignInServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/GoogleSignInServiceImpl.java
@@ -71,7 +71,7 @@ public class GoogleSignInServiceImpl extends OidcUserService implements GoogleSi
                 user.setPictureUrl(oidcUser.getPicture());
                 changed = true;
             }
-            if (user.getGithubId() != 0 && user.getGithubLogin() != null) {
+            if (user.getGithubId() != null && user.getGithubLogin() != null) {
                 authorities.add(new SimpleGrantedAuthority("ROLE_GITHUB"));
             }
 

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
@@ -140,7 +140,7 @@ public class OrganizationMemberService {
             JsonNode responseJson = objectMapper.readTree(response.getBody());
             if(responseJson.get("role").asText().equalsIgnoreCase("admin")){
                 return OrgStatus.OWNER;
-            }else if (responseJson.get("role").asText().equalsIgnoreCase("direct_member")){
+            }else if (responseJson.get("role").asText().equalsIgnoreCase("member")){
                 return OrgStatus.MEMBER;
             }else{
                 log.warn("Unexpected role {} used in course {}", responseJson.get("role").asText(), course.getCourseName());

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
@@ -295,7 +295,7 @@ public class OrganizationMemberServiceTests {
                 .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
                 .andRespond(withStatus(HttpStatus.OK)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .body("{ \"role\": \"direct_member\" }"));
+                        .body("{ \"role\": \"member\" }"));
 
         OrgStatus result = organizationMemberService.inviteOrganizationMember(testStudent);
 


### PR DESCRIPTION
Currently, when joining a course, if a person is already an organization member, when pressing Join Course, it will error out. 
This is because the GitHub API returns "member" rather than "direct_member".

Additionally, I fix the check to see if githubId is set by checking now against null rather than 0.

This PR corrects this.

Deployed to https://frontiers-qa3.dokku-00.cs.ucsb.edu/