### PR TITLE
Adding backend disconnect for GitHub accounts

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/GithubController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/GithubController.java
@@ -1,0 +1,52 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import org.eclipse.jetty.security.Constraint;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/github")
+public class GithubController extends ApiController {
+
+    private final UserRepository userRepository;
+
+    public GithubController(UserRepository userRepository) {
+        super();
+        this.userRepository = userRepository;
+    }
+
+    @PreAuthorize("hasRole('ROLE_GITHUB')")
+    @DeleteMapping("/disconnect")
+    public Object disconnect(SecurityContext context) {
+        User currentUser = getCurrentUser().getUser();
+        currentUser.setGithubId(null);
+        currentUser.setGithubLogin(null);
+        userRepository.save(currentUser);
+        Authentication auth = context.getAuthentication();
+        List<? extends GrantedAuthority> removedAuthority = auth.getAuthorities().stream()
+                .filter(r -> !"ROLE_GITHUB".equals(r.getAuthority()))
+                .toList();
+        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) context.getAuthentication();
+        context.setAuthentication(new OAuth2AuthenticationToken((OidcUser) auth.getPrincipal(), removedAuthority, token.getAuthorizedClientRegistrationId()));
+        SecurityContextHolder.setContext(context);
+        return genericMessage("Disconnected from GitHub. You may now log in with a different account.");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,7 @@ spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID:$
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET:${env.GOOGLE_CLIENT_SECRET:client_secret_unset}}
 spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID:${env.GITHUB_CLIENT_ID:client_id_unset}}
 spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET:${env.GITHUB_CLIENT_SECRET:client_secret_unset}}
+spring.security.oauth2.client.provider.github.authorization-uri=https://github.com/login/oauth/authorize?prompt=consent
 
 springdoc.swagger-ui.tryItOutEnabled=true
 # see: https://medium.com/@thecodinganalyst/configure-spring-security-csrf-for-testing-on-swagger-e9e6461ee0c1

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/GithubControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/GithubControllerTests.java
@@ -1,0 +1,69 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.models.CurrentUser;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.services.CurrentUserService;
+import edu.ucsb.cs156.frontiers.testconfig.MockCurrentUserServiceImpl;
+import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.*;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = GithubController.class)
+public class GithubControllerTests extends ControllerTestCase {
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @Autowired
+    private CurrentUserService currentUserService;
+
+    @Test
+    public void successfulDisconnect() throws Exception {
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+
+        MvcResult response = mockMvc.perform(delete("/api/github/disconnect")
+                        .with(csrf())
+                        .with(oidcLogin().authorities(
+                                new SimpleGrantedAuthority("ROLE_USER"),
+                                new SimpleGrantedAuthority("ROLE_GITHUB"))))
+                .andExpect(status().isOk())
+                .andExpect(authenticated().withRoles("USER"))
+                .andReturn();
+
+        verify(userRepository).save(userCaptor.capture());
+
+        assertNull(userCaptor.getValue().getGithubId());
+        assertNull(userCaptor.getValue().getGithubLogin());
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Disconnected from GitHub. You may now log in with a different account.", json.get("message"));
+    }
+}


### PR DESCRIPTION
In this PR, I add a new Controller (`GithubController`) with a DELETE endpoint that disconnects a user account from GitHub.

Additionally, I manually configure the GitHub authorization url so that the user will be reprompted to authorize to GitHub every time they connect (so they can switch accounts if need be).


It is jointly deployed with #234 on https://frontiers-daniel.dokku-00.cs.ucsb.edu/

Test plan:
1. Log In
2. Link a GitHub Account
3. Go to the profile page
4. Unlink your github account
5. Make sure your credentials are gone.

Closes #161 with #234