### PR TITLE
Adding GitHub disconnect button to profile page

### DIFF
--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -167,6 +167,10 @@ const apiCurrentUserFixturesWithGithub = {
       githubId: 123456, // Adding a Github ID to simulate Github login
       githubLogin: "phtcon-github", // Simulating a Github login
     },
+    roles: [
+      ...apiCurrentUserFixtures.adminUser.roles,
+      { authority: "ROLE_GITHUB" },
+    ],
   },
   instructorUser: {
     user: {
@@ -174,6 +178,10 @@ const apiCurrentUserFixturesWithGithub = {
       githubId: 987654, // Adding a Github ID to simulate Github login
       githubLogin: "dmirza-github", // Simulating a Github login
     },
+    roles: [
+      ...apiCurrentUserFixtures.instructorUser.roles,
+      { authority: "ROLE_GITHUB" },
+    ],
   },
   userOnly: {
     user: {
@@ -181,6 +189,10 @@ const apiCurrentUserFixturesWithGithub = {
       githubId: 654321, // Adding a Github ID to simulate Github login
       githubLogin: "cgaucho-github", // Simulating a Github login
     },
+    roles: [
+      ...apiCurrentUserFixtures.userOnly.roles,
+      { authority: "ROLE_GITHUB" },
+    ],
   },
 };
 

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -1,19 +1,49 @@
-import { Row, Col } from "react-bootstrap";
+import { Row, Col, Button } from "react-bootstrap";
 import RoleBadge from "main/components/Profile/RoleBadge";
-import { useCurrentUser } from "main/utils/currentUser";
+import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 
 import { Inspector } from "react-inspector";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+import { useState } from "react";
+import ConfirmationModal from "main/components/Common/ConfirmationModal";
+
 const ProfilePage = () => {
   const currentUser = useCurrentUser();
+  const onSuccess = (message) => {
+    toast(message);
+  };
+
+  const disconnectGithub = useBackendMutation(
+    () => {
+      return {
+        url: "/api/github/disconnect",
+        method: "DELETE",
+      };
+    },
+    { onSuccess: onSuccess },
+    ["current user"],
+  );
+
+  const [viewModal, setViewModal] = useState(false);
 
   if (!currentUser.loggedIn) {
     return <p>Not logged in.</p>;
   }
 
   const { email, pictureUrl, fullName } = currentUser.root.user;
+
   return (
     <BasicLayout>
+      <ConfirmationModal
+        onYes={disconnectGithub.mutate}
+        showModal={viewModal}
+        setShowModal={setViewModal}
+      >
+        <p>Are you sure you want to disconnect your Github account?</p>
+        <p>Please only do so if you know what you're doing.</p>
+      </ConfirmationModal>
       <Row className="align-items-center profile-header mb-5 text-center text-md-left">
         <Col md={2}>
           <img
@@ -32,6 +62,19 @@ const ProfilePage = () => {
       </Row>
       <Row className="text-left">
         <Inspector data={currentUser.root} />
+      </Row>
+      <Row className={"mt-3 g-3"} data-testid={"ProfilePage-advancedFeatures"}>
+        <h2>Advanced Features</h2>
+        {hasRole(currentUser, "ROLE_GITHUB") && (
+          <>
+            {" "}
+            <Col md={2}>
+              <Button variant={"danger"} onClick={() => setViewModal(true)}>
+                Disconnect GitHub
+              </Button>
+            </Col>
+          </>
+        )}
       </Row>
     </BasicLayout>
   );

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -1,18 +1,43 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import {
+  apiCurrentUserFixtures,
+  apiCurrentUserFixturesWithGithub,
+} from "fixtures/currentUserFixtures";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import ProfilePage from "main/pages/ProfilePage";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
-describe("ProfilePage tests", () => {
-  const queryClient = new QueryClient();
+const axiosMock = new AxiosMockAdapter(axios);
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
 
+const mockToast = jest.fn();
+
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("ProfilePage tests", () => {
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    queryClient.clear();
+  });
   test("renders correctly for regular logged in user", async () => {
-    const axiosMock = new AxiosMockAdapter(axios);
     axiosMock
       .onGet("/api/currentUser")
       .reply(200, apiCurrentUserFixtures.userOnly);
@@ -33,7 +58,6 @@ describe("ProfilePage tests", () => {
   });
 
   test("renders correctly for admin user", async () => {
-    const axiosMock = new AxiosMockAdapter(axios);
     axiosMock
       .onGet("/api/currentUser")
       .reply(200, apiCurrentUserFixtures.adminUser);
@@ -54,5 +78,68 @@ describe("ProfilePage tests", () => {
     expect(screen.getByTestId("role-badge-user")).toBeInTheDocument();
     expect(screen.getByTestId("role-badge-admin")).toBeInTheDocument();
     expect(screen.getByTestId("role-badge-member")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("ConfirmationModal-base"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("GitHub disconnect appears", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixturesWithGithub.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock
+      .onDelete("/api/github/disconnect")
+      .reply(
+        200,
+        "Disconnected from GitHub. You may now log in with a different account.",
+      );
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ProfilePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    await screen.findByText("Disconnect GitHub");
+    const disconnectButton = screen.getByText("Disconnect GitHub");
+    expect(disconnectButton).toHaveClass("btn btn-danger");
+    expect(screen.getByTestId("ProfilePage-advancedFeatures")).toHaveClass(
+      "mt-3 g-3",
+    );
+    fireEvent.click(disconnectButton);
+    await screen.findByTestId("ConfirmationModal-base");
+    expect(
+      screen.getByText(
+        "Are you sure you want to disconnect your Github account?",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Please only do so if you know what you're doing."),
+    ).toBeInTheDocument();
+    const fire = screen.getByText("Yes, I'd like to do this");
+    const updateCount =
+      queryClient.getQueryState("current user").dataUpdateCount;
+    const systemInfoCount =
+      queryClient.getQueryState("systemInfo").dataUpdateCount;
+    fireEvent.click(fire);
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("ConfirmationModal-base"),
+      ).not.toBeInTheDocument(),
+    );
+    expect(axiosMock.history.delete.length).toBe(1);
+    expect(axiosMock.history.delete[0].url).toBe("/api/github/disconnect");
+    expect(mockToast).toBeCalledWith(
+      "Disconnected from GitHub. You may now log in with a different account.",
+    );
+    expect(queryClient.getQueryState("current user").dataUpdateCount).toBe(
+      updateCount + 1,
+    );
+    expect(queryClient.getQueryState("systemInfo").dataUpdateCount).toBe(
+      systemInfoCount,
+    );
   });
 });


### PR DESCRIPTION
In this PR, I add a disconnect button to the Profile Page.

It removes the linked GithubLogin and GithubId from a user.

Deployed with #233 on https://frontiers-daniel.dokku-00.cs.ucsb.edu/