### PR TITLE
FEATURE (BACKEND):  endpoint to get commits from Github GraphQL API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,26 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-graphql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.graphql</groupId>
+      <artifactId>spring-graphql-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+
   </dependencies>
 
   <!-- (24) <repositories/> -->
@@ -467,57 +487,57 @@
                     <condition property="frontend.skip" value="false" else="true">
                       <and>
                         <!-- Frontend directory must exist -->
-                        <available file="${project.basedir}/frontend" type="dir"/>
+                        <available file="${project.basedir}/frontend" type="dir" />
                         <or>
                           <!-- Check if node_modules doesn't exist -->
                           <not>
-                            <available file="${project.basedir}/frontend/node_modules" type="dir"/>
+                            <available file="${project.basedir}/frontend/node_modules" type="dir" />
                           </not>
                           <!-- Check if build directory doesn't exist -->
                           <not>
-                            <available file="${project.basedir}/frontend/build" type="dir"/>
+                            <available file="${project.basedir}/frontend/build" type="dir" />
                           </not>
                           <!-- Check if output build exists -->
                           <not>
-                            <available file="${project.build.outputDirectory}/public" type="dir"/>
+                            <available file="${project.build.outputDirectory}/public" type="dir" />
                           </not>
                           <!-- Check if package.json exists and is newer than node_modules directory -->
                           <and>
-                            <available file="${project.basedir}/frontend/package.json"/>
-                            <available file="${project.basedir}/frontend/node_modules" type="dir"/>
+                            <available file="${project.basedir}/frontend/package.json" />
+                            <available file="${project.basedir}/frontend/node_modules" type="dir" />
                             <not>
                               <uptodate targetfile="${project.basedir}/frontend/node_modules">
-                                <srcfiles file="${project.basedir}/frontend/package.json"/>
+                                <srcfiles file="${project.basedir}/frontend/package.json" />
                               </uptodate>
                             </not>
                           </and>
                           <!-- Check if package-lock.json exists and is newer than node_modules -->
                           <and>
-                            <available file="${project.basedir}/frontend/package-lock.json"/>
-                            <available file="${project.basedir}/frontend/node_modules" type="dir"/>
+                            <available file="${project.basedir}/frontend/package-lock.json" />
+                            <available file="${project.basedir}/frontend/node_modules" type="dir" />
                             <not>
                               <uptodate targetfile="${project.basedir}/frontend/node_modules">
-                                <srcfiles file="${project.basedir}/frontend/package-lock.json"/>
+                                <srcfiles file="${project.basedir}/frontend/package-lock.json" />
                               </uptodate>
                             </not>
                           </and>
                           <!-- Check if source files are newer than build directory -->
                           <and>
-                            <available file="${project.basedir}/frontend/src" type="dir"/>
-                            <available file="${project.basedir}/frontend/build" type="dir"/>
+                            <available file="${project.basedir}/frontend/src" type="dir" />
+                            <available file="${project.basedir}/frontend/build" type="dir" />
                             <not>
                               <uptodate targetfile="${project.basedir}/frontend/build">
-                                <srcfiles dir="${project.basedir}/frontend/src" includes="**/*"/>
+                                <srcfiles dir="${project.basedir}/frontend/src" includes="**/*" />
                               </uptodate>
                             </not>
                           </and>
                           <!-- Check if build files are newer than public directory -->
                           <and>
-                            <available file="${project.build.outputDirectory}/public" type="dir"/>
-                            <available file="${project.basedir}/frontend/build" type="dir"/>
+                            <available file="${project.build.outputDirectory}/public" type="dir" />
+                            <available file="${project.basedir}/frontend/build" type="dir" />
                             <not>
                               <uptodate targetfile="${project.build.outputDirectory}/public">
-                                <srcfiles dir="${project.basedir}/frontend/build" includes="**/*"/>
+                                <srcfiles dir="${project.basedir}/frontend/build" includes="**/*" />
                               </uptodate>
                             </not>
                           </and>
@@ -527,9 +547,9 @@
 
                     <!-- Log the decision -->
                     <condition property="build.message"
-                               value="Frontend changes detected - will rebuild"
-                               else="No frontend changes detected - skipping npm build">
-                      <equals arg1="${frontend.skip}" arg2="false"/>
+                      value="Frontend changes detected - will rebuild"
+                      else="No frontend changes detected - skipping npm build">
+                      <equals arg1="${frontend.skip}" arg2="false" />
                     </condition>
                     <echo message="${build.message}" level="info" />
                   </target>

--- a/src/main/java/edu/ucsb/cs156/frontiers/config/GithubGraphQLClientConfig.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/config/GithubGraphQLClientConfig.java
@@ -1,0 +1,18 @@
+package edu.ucsb.cs156.frontiers.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.graphql.client.HttpSyncGraphQlClient;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class GithubGraphQLClientConfig {
+
+    @Bean
+    public HttpSyncGraphQlClient graphQlClient() {
+        RestClient restClient = RestClient.create("https://api.github.com/graphql");
+        HttpSyncGraphQlClient graphQlClient = HttpSyncGraphQlClient.builder(restClient)
+                .build();
+        return graphQlClient;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
@@ -1,11 +1,9 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
-import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
+import java.util.Collection;
+import java.util.Map;
 
-import org.checkerframework.checker.units.qual.Current;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
@@ -13,12 +11,13 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import edu.ucsb.cs156.frontiers.errors.CourseNotAuthorized;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
 import edu.ucsb.cs156.frontiers.models.CurrentUser;
 import edu.ucsb.cs156.frontiers.services.CurrentUserService;
+import lombok.extern.slf4j.Slf4j;
 
-import java.util.Collection;
-import java.util.Map;
 
 /**
  * This is an abstract class that provides common functionality for all API controllers.
@@ -75,7 +74,7 @@ public abstract class ApiController {
   }
 
   /**
-   * This method handles the EntityNotFoundException.
+   * This method handles the EntityNotFoundException.  This maps to a 404/Not Found.
    * @param e the exception
    * @return a map with the type and message of the exception
    */
@@ -89,7 +88,7 @@ public abstract class ApiController {
   }
 
   /**
-   * This method handles the NoLinkedOrganizationException.
+   * This method handles the NoLinkedOrganizationException.  This maps to a 400/Bad Request.
    * @param e the exception
    * @return a map with the type and message of the exception
    */
@@ -103,7 +102,7 @@ public abstract class ApiController {
   }
 
   /**
-   * This method handles the UnsupportedOperationException.
+   * This method handles the UnsupportedOperationException.  This maps to a 403/Forbidden.
    * @param e the exception
    * @return a map with the type and message of the exception
    */
@@ -114,13 +113,27 @@ public abstract class ApiController {
     }
 
   /**
-   * This method handles the NoLinkedOrganizationException.
+   * This method handles the IllegalArgumentException.  This maps to a 400/Bad Request.
    * @param e the exception
    * @return a map with the type and message of the exception
    */
   @ExceptionHandler({ IllegalArgumentException.class })
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public Object handleIllegalArgument(Throwable e) {
+    return Map.of(
+            "type", e.getClass().getSimpleName(),
+            "message", e.getMessage()
+    );
+  }
+
+  /**
+   * This method handles the CourseNotAuthorized exception.  It maps to a 403/Forbidden.
+   * @param e the exception
+   * @return a map with the type and message of the exception
+   */
+  @ExceptionHandler({ CourseNotAuthorized.class })
+  @ResponseStatus(HttpStatus.FORBIDDEN)
+  public Object handleCourseNotAuthorized(Throwable e) {
     return Map.of(
             "type", e.getClass().getSimpleName(),
             "message", e.getMessage()

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/GithubGraphQLController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/GithubGraphQLController.java
@@ -1,0 +1,73 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.services.GithubGraphQLService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import edu.ucsb.cs156.frontiers.errors.CourseNotAuthorized;
+
+
+@Tag(name = "GithubGraphQL")
+@RequestMapping("/api/github/graphql/")
+@RestController
+@Slf4j
+public class GithubGraphQLController extends ApiController {
+
+    private final GithubGraphQLService githubGraphQLService;
+    private final CourseRepository courseRepository;
+
+    public GithubGraphQLController(
+            @Autowired GithubGraphQLService gitHubGraphQLService,
+            @Autowired CourseRepository courseRepository) {
+        this.githubGraphQLService = gitHubGraphQLService;
+        this.courseRepository = courseRepository;
+    }
+
+    /**
+     * Return default branch name for a given repository.
+     * @param courseId the id of the course whose installation is being used for credentails
+     * @param owner the owner of the repository
+     * @param repo the name of the repository
+     * @return the default branch name
+     */
+
+    @Operation(summary = "Get default branch name")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_INSTRUCTOR')")
+    @GetMapping("defaultBranchName")
+    public String getDefaultBranchName(
+       @Parameter Long courseId,
+       @Parameter String owner,
+       @Parameter String repo) throws Exception {
+        log.info("getDefaultBranchName called with courseId: {}, owner: {}, repo: {}", courseId, owner, repo);
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
+
+        log.info("Found course: {}", course);
+
+        if (!isCurrentUserAdmin() && !(course.getCreator().getId() == getCurrentUser().getUser().getId())) {
+            throw new CourseNotAuthorized(courseId);
+        }
+  
+        log.info("Current user is authorized to access course: {}", course.getId());
+
+        String result = this.githubGraphQLService.getDefaultBranchName(course, owner, repo);
+
+        log.info("Result from getDefaultBranchName: {}", result);
+        
+        return result;
+
+    }
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/errors/CourseNotAuthorized.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/errors/CourseNotAuthorized.java
@@ -1,0 +1,17 @@
+package edu.ucsb.cs156.frontiers.errors;
+
+/**
+ * A custom RuntimeException that is thrown when a user is trying to access a course that 
+ * they are not authorized to access.  Admins should never encounter this, but Instructors may encounter
+ * it if/when they try to access a course where they are not the instructor of record.
+ */
+public class CourseNotAuthorized extends RuntimeException {
+  /**
+   * Constructor for the exception
+   * 
+   * @param id the id that was being searched for
+   */
+  public CourseNotAuthorized(Object id) {
+    super(String.format("User not authorized to access course with id %s", id.toString()));
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/GithubGraphQLService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/GithubGraphQLService.java
@@ -2,14 +2,16 @@ package edu.ucsb.cs156.frontiers.services;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Map;
 
+import org.springframework.graphql.GraphQlResponse;
 import org.springframework.graphql.client.HttpSyncGraphQlClient;
-import org.springframework.graphql.client.HttpSyncGraphQlClient.Builder;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
@@ -19,51 +21,120 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GithubGraphQLService {
 
-    private final HttpSyncGraphQlClient graphQlClient;
+        private final HttpSyncGraphQlClient graphQlClient;
 
-    private final JwtService jwtService;
+        private final JwtService jwtService;
 
-    public GithubGraphQLService(
-            HttpSyncGraphQlClient graphQlClient,
-            JwtService jwtService) {
-        this.jwtService = jwtService;
-        this.graphQlClient = graphQlClient;
-    }
+        public GithubGraphQLService(
+                        HttpSyncGraphQlClient graphQlClient,
+                        JwtService jwtService) {
+                this.jwtService = jwtService;
+                this.graphQlClient = graphQlClient;
+        }
 
-    /**
-     * Retrieves the name of the default branch for a given GitHub repository.
-     *
-     * @param owner The owner (username or organization) of the repository.
-     * @param repo  The name of the repository.
-     * @return A Mono emitting the default branch name, or an empty Mono if not
-     *         found.
-     */
-    public String getDefaultBranchName(Course course, String owner, String repo) throws JsonProcessingException,
-            NoSuchAlgorithmException, InvalidKeySpecException, NoLinkedOrganizationException {
-        log.info("getDefaultBranchName called with course.getId(): {} owner: {}, repo: {}", course.getId(), owner,
-                repo);
+        /**
+         * Retrieves the name of the default branch for a given GitHub repository.
+         *
+         * @param owner The owner (username or organization) of the repository.
+         * @param repo  The name of the repository.
+         * @return A Mono emitting the default branch name, or an empty Mono if not
+         *         found.
+         */
+        public String getDefaultBranchName(Course course, String owner, String repo) throws JsonProcessingException,
+                        NoSuchAlgorithmException, InvalidKeySpecException, NoLinkedOrganizationException {
+                log.info("getDefaultBranchName called with course.getId(): {} owner: {}, repo: {}", course.getId(),
+                                owner,
+                                repo);
+                String githubToken = jwtService.getInstallationToken(course);
+
+                log.info("githubToken: {}", githubToken);
+
+                String query = """
+                                query getDefaultBranch($owner: String!, $repo: String!) {
+                                  repository(owner: $owner, name: $repo) {
+                                    defaultBranchRef {
+                                      name
+                                    }
+                                  }
+                                }
+                                """;
+
+                return graphQlClient.mutate()
+                                .header("Authorization", "Bearer " + githubToken)
+                                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                                .build()
+                                .document(query)
+                                .variable("owner", owner)
+                                .variable("repo", repo)
+                                .retrieveSync("repository.defaultBranchRef.name")
+                                .toEntity(String.class);
+        }
+
+    public String getCommits(Course course, String owner, String repo, String branch, int first, String after)
+            throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException,
+            NoLinkedOrganizationException {
+        log.info("getCommits called with course.getId(): {} owner: {}, repo: {}, branch: {}, first: {}, after: {}", course.getId(), owner,
+                repo, branch, first, after);
         String githubToken = jwtService.getInstallationToken(course);
 
         log.info("githubToken: {}", githubToken);
 
         String query = """
-                query getDefaultBranch($owner: String!, $repo: String!) {
-                  repository(owner: $owner, name: $repo) {
-                    defaultBranchRef {
-                      name
+            query GetBranchCommits($owner: String!, $repo: String!, $branch: String!, $first: Int!, $after: String) {
+              repository(owner: $owner, name: $repo) {
+                ref(qualifiedName: $branch) {
+                  target {
+                    ... on Commit {
+                      history(first: $first, after: $after) {
+                        pageInfo {
+                          hasNextPage
+                          endCursor
+                        }
+                        edges {
+                          node {
+                            oid
+                            url
+                            messageHeadline
+                            committedDate
+                            author {
+                              name
+                              email
+                              user {
+                                login
+                              }
+                            }
+                            committer {
+                              name
+                              email
+                              user {
+                                login
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
-                """;
+              }
+            }
+            """;
 
-        return graphQlClient.mutate()
+
+         GraphQlResponse response = graphQlClient.mutate()
                 .header("Authorization", "Bearer " + githubToken)
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build()
                 .document(query)
                 .variable("owner", owner)
                 .variable("repo", repo)
-                .retrieveSync("repository.defaultBranchRef.name")
-                .toEntity(String.class);
+                .variable("branch", branch)
+                .variable("first", first)
+                .variable("after", after)
+                .executeSync();
+
+        Map<String, Object> data = response.getData();
+        String jsonData = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(data);
+        return jsonData;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/GithubGraphQLService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/GithubGraphQLService.java
@@ -1,0 +1,69 @@
+package edu.ucsb.cs156.frontiers.services;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+import org.springframework.graphql.client.HttpSyncGraphQlClient;
+import org.springframework.graphql.client.HttpSyncGraphQlClient.Builder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class GithubGraphQLService {
+
+    private final HttpSyncGraphQlClient graphQlClient;
+
+    private final JwtService jwtService;
+
+    public GithubGraphQLService(
+            HttpSyncGraphQlClient graphQlClient,
+            JwtService jwtService) {
+        this.jwtService = jwtService;
+        this.graphQlClient = graphQlClient;
+    }
+
+    /**
+     * Retrieves the name of the default branch for a given GitHub repository.
+     *
+     * @param owner The owner (username or organization) of the repository.
+     * @param repo  The name of the repository.
+     * @return A Mono emitting the default branch name, or an empty Mono if not
+     *         found.
+     */
+    public String getDefaultBranchName(Course course, String owner, String repo) throws JsonProcessingException,
+            NoSuchAlgorithmException, InvalidKeySpecException, NoLinkedOrganizationException {
+        log.info("getDefaultBranchName called with course.getId(): {} owner: {}, repo: {}", course.getId(), owner,
+                repo);
+        String githubToken = jwtService.getInstallationToken(course);
+
+        log.info("githubToken: {}", githubToken);
+
+        String query = """
+                query getDefaultBranch($owner: String!, $repo: String!) {
+                  repository(owner: $owner, name: $repo) {
+                    defaultBranchRef {
+                      name
+                    }
+                  }
+                }
+                """;
+
+        return graphQlClient.mutate()
+                .header("Authorization", "Bearer " + githubToken)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build()
+                .document(query)
+                .variable("owner", owner)
+                .variable("repo", repo)
+                .retrieveSync("repository.defaultBranchRef.name")
+                .toEntity(String.class);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/config/GithubGraphQLClientConfigTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/config/GithubGraphQLClientConfigTests.java
@@ -1,0 +1,19 @@
+package edu.ucsb.cs156.frontiers.config;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.graphql.client.HttpSyncGraphQlClient;
+
+public class GithubGraphQLClientConfigTests {
+    @Test
+    public void testGraphQlClientBean() {
+        // This test is just to ensure that the graphQlClient bean can be created
+        // without throwing any exceptions.
+        // The actual functionality is tested in the service tests.
+        GithubGraphQLClientConfig config = new GithubGraphQLClientConfig();
+        HttpSyncGraphQlClient client = config.graphQlClient();
+        assertNotNull(config);
+        assertNotNull(client);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/ApiControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/ApiControllerTests.java
@@ -1,28 +1,22 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
-import edu.ucsb.cs156.frontiers.ControllerTestCase;
-import edu.ucsb.cs156.frontiers.controllers.ApiController;
-import edu.ucsb.cs156.frontiers.repositories.UserRepository;
-import edu.ucsb.cs156.frontiers.services.CurrentUserService;
-import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
-import lombok.With;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 
 @WebMvcTest(controllers = DummyController.class)
 public class ApiControllerTests extends ControllerTestCase {

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/GithubGraphQLControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/GithubGraphQLControllerTests.java
@@ -1,0 +1,180 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.services.CurrentUserService;
+import edu.ucsb.cs156.frontiers.services.GithubGraphQLService;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@WebMvcTest(controllers = GithubGraphQLController.class)
+public class GithubGraphQLControllerTests extends ControllerTestCase {
+
+        @MockitoBean
+        private CourseRepository courseRepository;
+
+         @MockitoBean
+         private GithubGraphQLService githubGraphQLService;
+
+        @Autowired
+        private CurrentUserService currentUserService;
+
+        @Autowired
+        private ObjectMapper objectMapper;
+
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void test_getDefaultMainBranch_happyPath_Admin() throws Exception {
+
+                User user = currentUserService.getCurrentUser().getUser();
+
+                // arrange
+                Course course = Course.builder()
+                                .id(1L)
+                                .courseName("CS156")
+                                .term("S25")
+                                .school("UCSB")
+                                .creator(user)
+                                .build();
+
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course));
+                when(githubGraphQLService.getDefaultBranchName(
+                                eq(course), eq("ucsb-cs156-f24"), eq("STARTER-jpa00")))
+                                .thenReturn("main");
+
+                // act
+
+                MvcResult response = mockMvc.perform(get("/api/github/graphql/defaultBranchName")
+                                .param("courseId", "1")
+                                .param("owner", "ucsb-cs156-f24")
+                                .param("repo", "STARTER-jpa00"))
+                                .andExpect(status().isOk())
+                                .andReturn();
+
+                // assert
+
+                verify(courseRepository, times(1)).findById(eq(1L));
+
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals("main", responseString);
+
+        }
+    
+        @Test
+        @WithMockUser(roles = { "INSTRUCTOR" })
+        public void test_getDefaultMainBranch_happyPath_Instructor() throws Exception {
+
+                User user = currentUserService.getCurrentUser().getUser();
+
+                // arrange
+                Course course = Course.builder()
+                                .id(1L)
+                                .courseName("CS156")
+                                .term("S25")
+                                .school("UCSB")
+                                .creator(user)
+                                .build();
+
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course));
+                when(githubGraphQLService.getDefaultBranchName(
+                                eq(course), eq("ucsb-cs156-f24"), eq("STARTER-jpa00")))
+                                .thenReturn("main");
+
+                // act
+
+                MvcResult response = mockMvc.perform(get("/api/github/graphql/defaultBranchName")
+                                .param("courseId", "1")
+                                .param("owner", "ucsb-cs156-f24")
+                                .param("repo", "STARTER-jpa00"))
+                                .andExpect(status().isOk())
+                                .andReturn();
+
+                // assert
+
+                verify(courseRepository, times(1)).findById(eq(1L));
+
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals("main", responseString);
+
+        }
+
+        @Test
+        @WithMockUser(roles = { "INSTRUCTOR" })
+        public void test_getDefaultMainBranch_courseNotFound() throws Exception {
+
+                // arrange
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+                // act & assert
+                mockMvc.perform(get("/api/github/graphql/defaultBranchName")
+                                .param("courseId", "1")
+                                .param("owner", "ucsb-cs156-f24")
+                                .param("repo", "STARTER-jpa00"))
+                                .andExpect(status().isNotFound());
+                
+                verify(courseRepository, times(1)).findById(eq(1L));
+        }
+
+        @Test
+        @WithMockUser(roles = { "INSTRUCTOR" })
+        public void test_getDefaultMainBranch_unauthorized() throws Exception {
+                // arrange
+                User user = currentUserService.getCurrentUser().getUser();
+                User otherUser = User.builder()
+                                .id(user.getId() + 1L)
+                                .build();
+                Course course = Course.builder()
+                                .id(1L)
+                                .courseName("CS156")
+                                .term("S25")    
+                                .school("UCSB")
+                                .creator(otherUser)
+                                .build();
+
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course));
+
+                // act & assert
+                 MvcResult response = mockMvc.perform(get("/api/github/graphql/defaultBranchName")
+                                .param("courseId", "1")
+                                .param("owner", "ucsb-cs156-f24")
+                                .param("repo", "STARTER-jpa00")
+                                .with(csrf()))
+                                .andExpect(status().isForbidden())
+                                .andReturn();
+               
+                verify(courseRepository, times(1)).findById(eq(1L));
+                Map<String, String> expectedResponse = Map.of(
+                        "type", "CourseNotAuthorized",
+                        "message", "User not authorized to access course with id 1"
+                );
+                String expectedJson = objectMapper.writeValueAsString(expectedResponse);
+
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+}
+
+

--- a/src/test/java/edu/ucsb/cs156/frontiers/fixtures/GithubGraphQLFixtures.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/fixtures/GithubGraphQLFixtures.java
@@ -1,0 +1,81 @@
+package edu.ucsb.cs156.frontiers.fixtures;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class GithubGraphQLFixtures {
+
+
+
+
+  public static final ObjectMapper objectMapper = new ObjectMapper();
+  public static final String COMMITS_RESPONSE = """
+      {
+        "repository" : {
+          "ref" : {
+            "target" : {
+              "history" : {
+                "pageInfo" : {
+                  "hasNextPage" : true,
+                  "endCursor" : "79a22f53b228b10212b44f1a59c84a2999c23ecf 1"
+                },
+                "edges" : [ {
+                  "node" : {
+                    "oid" : "79a22f53b228b10212b44f1a59c84a2999c23ecf",
+                    "url" : "https://github.com/ucsb-cs156/proj-frontiers/commit/79a22f53b228b10212b44f1a59c84a2999c23ecf",
+                    "messageHeadline" : "Update azure-active-directory.md - formatting and clarification fixes",
+                    "committedDate" : "2025-07-22T22:26:12Z",
+                    "author" : {
+                      "name" : "Phill Conrad",
+                      "email" : "pconrad@cs.ucsb.edu",
+                      "user" : {
+                        "login" : "pconrad"
+                      }
+                    },
+                    "committer" : {
+                      "name" : "GitHub",
+                      "email" : "noreply@github.com",
+                      "user" : null
+                    }
+                  }
+                }, {
+                  "node" : {
+                    "oid" : "13f8c8a8821b3f0636597f2d42d2359ad34183b5",
+                    "url" : "https://github.com/ucsb-cs156/proj-frontiers/commit/13f8c8a8821b3f0636597f2d42d2359ad34183b5",
+                    "messageHeadline" : "Merge pull request #228 from ucsb-cs156/dj-addAppropriateOrgStatus",
+                    "committedDate" : "2025-07-22T22:04:48Z",
+                    "author" : {
+                      "name" : "Phill Conrad",
+                      "email" : "pconrad@cs.ucsb.edu",
+                      "user" : {
+                        "login" : "pconrad"
+                      }
+                    },
+                    "committer" : {
+                      "name" : "GitHub",
+                      "email" : "noreply@github.com",
+                      "user" : null
+                    }
+                  }
+                } ]
+              }
+            }
+          }
+        }
+      }
+      """;
+
+  
+  public static final Map<String, Object> COMMITS_RESPONSE_MAP;
+  static {
+    try {
+      COMMITS_RESPONSE_MAP = objectMapper.readValue(COMMITS_RESPONSE,
+        new TypeReference<Map<String, Object>>() {});
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/GithubGraphQLServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/GithubGraphQLServiceTests.java
@@ -5,71 +5,158 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import java.util.Map;
+import com.fasterxml.jackson.core.type.TypeReference;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.graphql.client.HttpSyncGraphQlClient;
 import org.springframework.graphql.client.HttpSyncGraphQlClient.Builder;
+
+import org.springframework.graphql.GraphQlResponse;
+import org.springframework.graphql.client.ClientGraphQlResponse;
 import org.springframework.graphql.client.GraphQlClient.RequestSpec;
 import org.springframework.graphql.client.GraphQlClient.RetrieveSyncSpec;
 
 import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.fixtures.GithubGraphQLFixtures;
 
 @ExtendWith(MockitoExtension.class)
 public class GithubGraphQLServiceTests {
 
-    @Mock
-    private JwtService jwtService;
+        @Mock
+        private JwtService jwtService;
 
-    @Mock
-    private HttpSyncGraphQlClient graphQlClient;
+        @Mock
+        private HttpSyncGraphQlClient graphQlClient;
 
-    @Mock
-    private HttpSyncGraphQlClient.Builder graphQlClientBuilder;
+        @Mock
+        private HttpSyncGraphQlClient.Builder graphQlClientBuilder;
 
-    @Mock
-    private RequestSpec requestSpec;
+        @Mock
+        private RequestSpec requestSpec;
 
-    @Mock
-    private RetrieveSyncSpec retrieveSyncSpec;
+        @Mock
+        private RetrieveSyncSpec retrieveSyncSpec;
 
-    Course course = Course.builder()
-            .id(1L)
-            .installationId("12345")
-            .orgName("test-org")
-            .courseName("Test Course")
-            .term("Fall 2023")
-            .school("UCSB")
-            .build();
+        @Mock
+        private ClientGraphQlResponse clientGraphQlResponse;
 
-    @Test
-    public void testGetDefaultBranchName() throws Exception {
-        assertNotNull(course);
-        when(jwtService.getInstallationToken(eq(course))).thenReturn("mocked-token");
+        Course course = Course.builder()
+                        .id(1L)
+                        .installationId("12345")
+                        .orgName("test-org")
+                        .courseName("Test Course")
+                        .term("Fall 2023")
+                        .school("UCSB")
+                        .build();
 
-        when(graphQlClient.mutate()).thenReturn(graphQlClientBuilder);
-        when(graphQlClientBuilder.header(anyString(), anyString()))
-                .thenReturn(graphQlClientBuilder);
-        when(graphQlClientBuilder.build())
-                .thenReturn(graphQlClient);
-        when(graphQlClient.document(anyString()))
-                .thenReturn(requestSpec);
-        when(requestSpec.variable(anyString(), anyString()))
-                .thenReturn(requestSpec);
-        when(requestSpec.retrieveSync(anyString()))
-                .thenReturn(retrieveSyncSpec);
-        when(retrieveSyncSpec.toEntity(eq(String.class)))
-                .thenReturn("main");
+        @BeforeEach
+        public void setup() {
+                MockitoAnnotations.openMocks(this);
+        }
 
-        GithubGraphQLService githubGraphQLService = new GithubGraphQLService(
-                graphQlClient,
-                jwtService);
-        String defaultBranchName = githubGraphQLService.getDefaultBranchName(course, "test-owner", "test-repo");
-        assertEquals("main", defaultBranchName);
-    }
-   
+        @AfterEach
+        public void tearDown() {
+                Mockito.reset(jwtService, graphQlClient, graphQlClientBuilder, requestSpec, retrieveSyncSpec,
+                                clientGraphQlResponse); // Reset specific mocks
+        }
+
+        @Test
+        public void testGetDefaultBranchName() throws Exception {
+                assertNotNull(course);
+                when(jwtService.getInstallationToken(eq(course))).thenReturn("mocked-token");
+
+                when(graphQlClient.mutate()).thenReturn(graphQlClientBuilder);
+                when(graphQlClientBuilder.header(anyString(), anyString()))
+                                .thenReturn(graphQlClientBuilder);
+                when(graphQlClientBuilder.build())
+                                .thenReturn(graphQlClient);
+                when(graphQlClient.document(anyString()))
+                                .thenReturn(requestSpec);
+                when(requestSpec.variable(anyString(), anyString()))
+                                .thenReturn(requestSpec);
+                when(requestSpec.retrieveSync(anyString()))
+                                .thenReturn(retrieveSyncSpec);
+                when(retrieveSyncSpec.toEntity(eq(String.class)))
+                                .thenReturn("main");
+
+                GithubGraphQLService githubGraphQLService = new GithubGraphQLService(
+                                graphQlClient,
+                                jwtService);
+                String defaultBranchName = githubGraphQLService.getDefaultBranchName(course, "test-owner", "test-repo");
+                assertEquals("main", defaultBranchName);
+        }
+
+        @Test
+        public void testGetCommits() throws Exception {
+
+                TypeReference<Map<String, Object>> typeRef = new TypeReference<Map<String, Object>>() {
+                };
+
+                when(clientGraphQlResponse.getData()).thenReturn(GithubGraphQLFixtures.COMMITS_RESPONSE_MAP);
+
+                when(graphQlClient.mutate()).thenReturn(graphQlClientBuilder);
+                when(graphQlClientBuilder.header(anyString(), anyString()))
+                                .thenReturn(graphQlClientBuilder);
+                when(graphQlClientBuilder.build())
+                                .thenReturn(graphQlClient);
+                when(graphQlClient.document(anyString()))
+                                .thenReturn(requestSpec);
+                when(requestSpec.variable(anyString(), any()))
+                                .thenReturn(requestSpec);
+                when(requestSpec.executeSync())
+                                .thenReturn(clientGraphQlResponse);
+                when(requestSpec.retrieveSync(anyString()))
+                                .thenReturn(retrieveSyncSpec);
+
+                assertNotNull(course);
+                when(jwtService.getInstallationToken(eq(course))).thenReturn("mocked-token");
+
+                when(graphQlClient.mutate()).thenReturn(graphQlClientBuilder);
+                when(graphQlClientBuilder.header(anyString(), anyString()))
+                                .thenReturn(graphQlClientBuilder);
+                when(graphQlClientBuilder.build())
+                                .thenReturn(graphQlClient);
+                when(graphQlClient.document(anyString()))
+                                .thenReturn(requestSpec);
+                when(requestSpec.variable(anyString(), anyString()))
+                                .thenReturn(requestSpec);
+                when(requestSpec.executeSync())
+                                .thenReturn(clientGraphQlResponse);
+                when(requestSpec.retrieveSync(anyString()))
+                                .thenReturn(retrieveSyncSpec);
+
+                when(clientGraphQlResponse.getData())
+                                .thenReturn(GithubGraphQLFixtures.COMMITS_RESPONSE_MAP);
+
+                GithubGraphQLService githubGraphQLService = new GithubGraphQLService(
+                                graphQlClient,
+                                jwtService);
+                String commitsJson = githubGraphQLService.getCommits(course, "test-owner", "test-repo", "main", 10,
+                                null);
+
+                verify(graphQlClient).mutate();
+                verify(graphQlClientBuilder).header("Authorization", "Bearer mocked-token");
+                verify(graphQlClientBuilder).header("Content-Type", "application/json");
+                verify(graphQlClientBuilder).build();
+                verify(requestSpec).variable("owner", "test-owner");
+                verify(requestSpec).variable("repo", "test-repo");
+                verify(requestSpec).variable("branch", "main");
+                verify(requestSpec).variable("first", 10);
+                verify(requestSpec).variable("after", null);
+                verify(requestSpec).executeSync();
+                verify(clientGraphQlResponse).getData();
+
+                assertEquals(GithubGraphQLFixtures.COMMITS_RESPONSE.trim(), commitsJson.trim());
+        }
 
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/GithubGraphQLServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/GithubGraphQLServiceTests.java
@@ -1,0 +1,75 @@
+package edu.ucsb.cs156.frontiers.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.graphql.client.HttpSyncGraphQlClient;
+import org.springframework.graphql.client.HttpSyncGraphQlClient.Builder;
+import org.springframework.graphql.client.GraphQlClient.RequestSpec;
+import org.springframework.graphql.client.GraphQlClient.RetrieveSyncSpec;
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+
+@ExtendWith(MockitoExtension.class)
+public class GithubGraphQLServiceTests {
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private HttpSyncGraphQlClient graphQlClient;
+
+    @Mock
+    private HttpSyncGraphQlClient.Builder graphQlClientBuilder;
+
+    @Mock
+    private RequestSpec requestSpec;
+
+    @Mock
+    private RetrieveSyncSpec retrieveSyncSpec;
+
+    Course course = Course.builder()
+            .id(1L)
+            .installationId("12345")
+            .orgName("test-org")
+            .courseName("Test Course")
+            .term("Fall 2023")
+            .school("UCSB")
+            .build();
+
+    @Test
+    public void testGetDefaultBranchName() throws Exception {
+        assertNotNull(course);
+        when(jwtService.getInstallationToken(eq(course))).thenReturn("mocked-token");
+
+        when(graphQlClient.mutate()).thenReturn(graphQlClientBuilder);
+        when(graphQlClientBuilder.header(anyString(), anyString()))
+                .thenReturn(graphQlClientBuilder);
+        when(graphQlClientBuilder.build())
+                .thenReturn(graphQlClient);
+        when(graphQlClient.document(anyString()))
+                .thenReturn(requestSpec);
+        when(requestSpec.variable(anyString(), anyString()))
+                .thenReturn(requestSpec);
+        when(requestSpec.retrieveSync(anyString()))
+                .thenReturn(retrieveSyncSpec);
+        when(retrieveSyncSpec.toEntity(eq(String.class)))
+                .thenReturn("main");
+
+        GithubGraphQLService githubGraphQLService = new GithubGraphQLService(
+                graphQlClient,
+                jwtService);
+        String defaultBranchName = githubGraphQLService.getDefaultBranchName(course, "test-owner", "test-repo");
+        assertEquals("main", defaultBranchName);
+    }
+   
+
+}


### PR DESCRIPTION
Merge after #231   Closes #220


In this PR, we add an endpoint to get commits for a repo on any branch.

The endpoint exposes the paging that is a part of the graphql API; you can specify a `first` parameter, which gives you the first n commits after the "cursor".  Initially, the cursor should be empty; this is passed as the parameter `after`.   

In subsequent calls, if you copy/paste the value of the cursor, the call will start at that point.

# Testing

1. Create a course an install the Github App
   <img width="1279" height="287" alt="image" src="https://github.com/user-attachments/assets/171b06b5-5039-42a8-a101-70e82176d264" />

2. Remember the course id number (e.g. `1` in this example)

3. Navigate to Swagger to the endpoint shown

    [`GET /api/github/graphql/defaultBranchName`](http://localhost:8080/swagger-ui/index.html#/GithubGraphQL/getDefaultBranchName)

4. Fill in values:
    * course Id number, owner (organization), repo name, and branch name are self explanatory
    * For `first` fill in any number between 1 and 100.  This is the maximum number of commits that will be returned.
    * For `after`, on your first query, leave it blank.  

5. It should return JSON for the commits, starting with the most recent commit on that branch and proceeding in reverse chronological order.
6. To get commits beyond the first `n`, copy/paste the value of the `cursor` returned in the JSON.  It will be a hex string followed by a space followed by an integer; paste the entire thing as is, without the quotation marks.

