### PR TITLE
Creating a Tab System on the CourseShowPage

### DIFF
--- a/frontend/src/main/pages/Instructor/InstructorCourseShowPage.js
+++ b/frontend/src/main/pages/Instructor/InstructorCourseShowPage.js
@@ -8,7 +8,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import RosterStudentTable from "main/components/RosterStudent/RosterStudentTable";
 import Modal from "react-bootstrap/Modal";
-import { Button } from "react-bootstrap";
+import { Button, Card, Col, Row, Tab, Tabs } from "react-bootstrap";
 
 export default function InstructorCourseShowPage() {
   const currentUser = useCurrentUser();
@@ -72,22 +72,43 @@ export default function InstructorCourseShowPage() {
           </Button>
         </Modal.Footer>
       </Modal>
-      <div className="pt-2">
-        <h1>Course</h1>
-        <InstructorCoursesTable
-          courses={course ? [course] : []}
-          currentUser={currentUser}
-          testId={testId}
-        />
-        <h2>Roster Students</h2>
-        <RosterStudentTable
-          // Stryker disable next-line ArrayDeclaration : checking for ["Stryker was here"] is tough
-          students={rosterStudents || []}
-          currentUser={currentUser}
-          courseId={course ? course.id : ""}
-          testIdPrefix={`${testId}-RosterStudentTable`}
-        />
-      </div>
+      <Tabs defaultActiveKey={"default"}>
+        <Tab eventKey={"default"} title={"Management"} className="pt-2">
+          <h1>Course</h1>
+          <InstructorCoursesTable
+            courses={course ? [course] : []}
+            currentUser={currentUser}
+            testId={testId}
+          />
+        </Tab>
+        <Tab eventKey={"enrollment"} title={"Enrollment"} className="pt-2">
+          <Row md={2} className="g-3 p-3">
+            <Col>
+              <Card>
+                <Card.Body>
+                  Temporary Text For Uploading Roster Students
+                </Card.Body>
+              </Card>
+            </Col>
+            <Col>
+              <Card>
+                <Card.Body>
+                  Temporary Text for Manually Adding Student
+                </Card.Body>
+              </Card>
+            </Col>
+          </Row>
+          <Row>
+            <RosterStudentTable
+              // Stryker disable next-line ArrayDeclaration : checking for ["Stryker was here"] is tough
+              students={rosterStudents || []}
+              currentUser={currentUser}
+              courseId={course ? course.id : ""}
+              testIdPrefix={`${testId}-RosterStudentTable`}
+            />
+          </Row>
+        </Tab>
+      </Tabs>
     </BasicLayout>
   );
 }

--- a/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
+++ b/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
@@ -308,4 +308,53 @@ describe("InstructorCourseShowPage tests", () => {
     clearTimeoutSpy.mockRestore();
     jest.useRealTimers();
   });
+
+  test("Tab assertions", () => {
+    setupInstructorUser();
+
+    const theCourse = {
+      ...coursesFixtures.oneCourseWithEachStatus[0],
+      id: 1,
+      createdByEmail: "phtcon@ucsb.edu",
+    };
+
+    axiosMock.onGet("/api/courses/7").reply(200, theCourse);
+
+    axiosMock
+      .onGet("/api/rosterstudents/course/7")
+      .reply(200, rosterStudentFixtures.threeStudents);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/instructor/courses/7"]}>
+          <Routes>
+            <Route
+              path="/instructor/courses/:id"
+              element={<InstructorCourseShowPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expect(screen.getByText("Management")).toHaveAttribute(
+      "data-rr-ui-event-key",
+      "default",
+    );
+    expect(screen.getByText("Enrollment")).toHaveAttribute(
+      "data-rr-ui-event-key",
+      "enrollment",
+    );
+    expect(screen.getByText("Management")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    const changeTabs = screen.getByText("Enrollment");
+    fireEvent.click(changeTabs);
+    expect(
+      screen.getByText("Temporary Text For Uploading Roster Students"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Temporary Text for Manually Adding Student"),
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
In this PR, I add tabs to the CourseShowPage, moving the RosterStudentTable to Enrollment, with spaces for uploading a CSV of roster students or adding individual ones.

My vision is that the Management page is mostly dedicated to managing assignments.
Management tab:
<img width="1450" height="855" alt="image" src="https://github.com/user-attachments/assets/a2428c81-98f8-4368-ab93-c79eea67425c" />

Enrollment Tab:
<img width="1902" height="818" alt="image" src="https://github.com/user-attachments/assets/442b3b68-86a8-4e02-b649-8454238940a1" />


Deployed to https://frontiers-daniel.dokku-00.cs.ucsb.edu/