### PR TITLE
Enabling the Roster Student Edit Button

### DIFF
--- a/frontend/src/main/components/RosterStudent/RosterStudentForm.js
+++ b/frontend/src/main/components/RosterStudent/RosterStudentForm.js
@@ -6,6 +6,7 @@ function RosterStudentForm({
   initialContents,
   submitAction,
   buttonLabel = "Create",
+  cancelDisabled = false,
 }) {
   // Stryker disable all
   const {
@@ -103,13 +104,15 @@ function RosterStudentForm({
       <Button type="submit" data-testid={testIdPrefix + "-submit"}>
         {buttonLabel}
       </Button>
-      <Button
-        variant="Secondary"
-        onClick={() => navigate(-1)}
-        data-testid={testIdPrefix + "-cancel"}
-      >
-        Cancel
-      </Button>
+      {!cancelDisabled && (
+        <Button
+          variant="Secondary"
+          onClick={() => navigate(-1)}
+          data-testid={testIdPrefix + "-cancel"}
+        >
+          Cancel
+        </Button>
+      )}
     </Form>
   );
 }

--- a/frontend/src/main/pages/Instructor/InstructorCourseShowPage.js
+++ b/frontend/src/main/pages/Instructor/InstructorCourseShowPage.js
@@ -8,7 +8,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import RosterStudentTable from "main/components/RosterStudent/RosterStudentTable";
 import Modal from "react-bootstrap/Modal";
-import { Button } from "react-bootstrap";
+import { Button, Card, Col, Row, Tab, Tabs } from "react-bootstrap";
 
 export default function InstructorCourseShowPage() {
   const currentUser = useCurrentUser();
@@ -72,22 +72,43 @@ export default function InstructorCourseShowPage() {
           </Button>
         </Modal.Footer>
       </Modal>
-      <div className="pt-2">
-        <h1>Course</h1>
-        <InstructorCoursesTable
-          courses={course ? [course] : []}
-          currentUser={currentUser}
-          testId={testId}
-        />
-        <h2>Roster Students</h2>
-        <RosterStudentTable
-          // Stryker disable next-line ArrayDeclaration : checking for ["Stryker was here"] is tough
-          students={rosterStudents || []}
-          currentUser={currentUser}
-          courseId={course ? course.id : ""}
-          testIdPrefix={`${testId}-RosterStudentTable`}
-        />
-      </div>
+      <Tabs defaultActiveKey={"default"}>
+        <Tab eventKey={"default"} title={"Management"} className="pt-2">
+          <h1>Course</h1>
+          <InstructorCoursesTable
+            courses={course ? [course] : []}
+            currentUser={currentUser}
+            testId={testId}
+          />
+        </Tab>
+        <Tab eventKey={"enrollment"} title={"Enrollment"} className="pt-2">
+          <Row md={2} className="g-3 p-3">
+            <Col>
+              <Card>
+                <Card.Body>
+                  Temporary Text For Uploading Roster Students
+                </Card.Body>
+              </Card>
+            </Col>
+            <Col>
+              <Card>
+                <Card.Body>
+                  Temporary Text for Manually Adding Student
+                </Card.Body>
+              </Card>
+            </Col>
+          </Row>
+          <Row>
+            <RosterStudentTable
+              // Stryker disable next-line ArrayDeclaration : checking for ["Stryker was here"] is tough
+              students={rosterStudents || []}
+              currentUser={currentUser}
+              courseId={course ? course.id : ""}
+              testIdPrefix={`${testId}-RosterStudentTable`}
+            />
+          </Row>
+        </Tab>
+      </Tabs>
     </BasicLayout>
   );
 }

--- a/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
+++ b/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
@@ -308,4 +308,53 @@ describe("InstructorCourseShowPage tests", () => {
     clearTimeoutSpy.mockRestore();
     jest.useRealTimers();
   });
+
+  test("Tab assertions", () => {
+    setupInstructorUser();
+
+    const theCourse = {
+      ...coursesFixtures.oneCourseWithEachStatus[0],
+      id: 1,
+      createdByEmail: "phtcon@ucsb.edu",
+    };
+
+    axiosMock.onGet("/api/courses/7").reply(200, theCourse);
+
+    axiosMock
+      .onGet("/api/rosterstudents/course/7")
+      .reply(200, rosterStudentFixtures.threeStudents);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/instructor/courses/7"]}>
+          <Routes>
+            <Route
+              path="/instructor/courses/:id"
+              element={<InstructorCourseShowPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expect(screen.getByText("Management")).toHaveAttribute(
+      "data-rr-ui-event-key",
+      "default",
+    );
+    expect(screen.getByText("Enrollment")).toHaveAttribute(
+      "data-rr-ui-event-key",
+      "enrollment",
+    );
+    expect(screen.getByText("Management")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    const changeTabs = screen.getByText("Enrollment");
+    fireEvent.click(changeTabs);
+    expect(
+      screen.getByText("Temporary Text For Uploading Roster Students"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Temporary Text for Manually Adding Student"),
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
In this PR, I enable the callback for the edit button in RosterStudentsTable. This is based on #236 to how it will fit into the page.

Additionally, I modify RosterStudentForm to allow disabling of the cancel button for use in the modal.

Modal demonstration:
<img width="1278" height="696" alt="image" src="https://github.com/user-attachments/assets/a5acdb5d-765a-4d11-8f48-ccd88a020e3d" />

Test plan:
1. Add a roster student
2. Edit it
3. See that it has been updated in the RosterStudentTable on the CourseShowPage.

Merge after #236 

Contributes to #117 

Deployed to https://proj-frontiers-division7.dokku-00.cs.ucsb.edu/