### PR TITLE
pc - schedule the MembershipAuditJob to run once per day on prod, once every 10 minutes on dev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,7 @@
             <exclude>**/${app.packagePath}/services/GoogleSignInServiceImpl.*</exclude>
             <exclude>**/${app.packagePath}/errors/NotAuthenticatedWithGoogleException.*</exclude>
             <exclude>**/${app.packagePath}/startup/AzureProfileEnabler.*</exclude>
+            <exclude>**/${app.packagePath}/jobs/ScheduledJobs.*</exclude>
           </excludes>
         </configuration>
         <executions>
@@ -366,6 +367,7 @@
             <param>${app.package}.services.GithubSignInServiceImpl</param>
             <param>${app.package}.services.GoogleSignInServiceImpl</param>
             <param>${app.package}.errors.NotAuthenticatedWithGoogleException</param>
+            <param>${app.package}.jobs.ScheduledJobs</param>
           </excludedClasses>
           <excludedTestClasses>
             <param>edu.ucsb.cs156.frontiers.web.*</param>

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/ScheduledJobs.java
@@ -1,0 +1,57 @@
+package edu.ucsb.cs156.frontiers.jobs;
+
+import edu.ucsb.cs156.frontiers.entities.CourseStaff;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.CourseStaffRepository;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobContextConsumer;
+import edu.ucsb.cs156.frontiers.services.jobs.JobService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.aspectj.weaver.ast.Or;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class contains methods that are scheduled to run at certain times to launch particular jobs.
+ *
+ * <p>The value of the <code>cron</code> parameter to the <code>&#64;Scheduled</code> annotation is
+ * a Spring Boot cron expression, which is similar to a Unix cron expression, but with an extra
+ * field at the beginning for the seconds.
+ *
+ * @see <a href=
+ *     "https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/support/CronExpression.html">Spring
+ *     Cron Syntax</a>
+ */
+@Component("scheduledJobs")
+@Slf4j
+public class ScheduledJobs {
+
+  @Autowired private JobService jobService;
+
+  @Autowired private RosterStudentRepository rosterStudentRepository;
+  
+  @Autowired private CourseRepository courseRepository;
+
+  @Autowired private OrganizationMemberService organizationMemberService; 
+
+  @Autowired private CourseStaffRepository courseStaffRepository;
+
+  @Scheduled(cron = "${app.jobs.MembershipAuditJob.cron}", zone = "${spring.jackson.time-zone}")
+  public void runMembershipAuditJobBasedOnCron() throws Exception {
+     MembershipAuditJob job = MembershipAuditJob.builder()
+            .rosterStudentRepository(rosterStudentRepository)
+            .courseRepository(courseRepository)
+            .organizationMemberService(organizationMemberService)
+            .courseStaffRepository(courseStaffRepository)
+            .build();
+
+    jobService.runAsJob(job);
+    log.info("runMembershipAuditJobBasedOnCron: running");
+
+  }
+}

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -10,3 +10,7 @@ app.showSwaggerUILink=true
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always
 spring.config.import=optional:file:./secrets.yaml
+
+
+# 0 */10 * * * * = every 10 minutes
+app.jobs.MembershipAuditJob.cron=${MEMBERSHIP_AUDIT_JOB_CRON:${env.MEMBERSHIP_AUDIT_JOB_CRON:0 */10 * * * *}}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,3 +35,11 @@ app.client.id=${GITHUB_CLIENT_ID:${env.GITHUB_CLIENT_ID:github_client_id_unset}}
 
 spring.jpa.hibernate.ddl-auto=none
 spring.liquibase.change-log=db/migration/changelog-master.json
+
+# CRON Expressions for scheduled jobs
+# Examples:
+#   0 0 0 * * * = midnight every day
+#   0 0 * * * * = top of every hour
+#   0 */20 * * * * = every 20 minutes
+spring.jackson.time-zone=America/Los_Angeles
+app.jobs.MembershipAuditJob.cron=${MEMBERSHIP_AUDIT_JOB_CRON:${env.MEMBERSHIP_AUDIT_JOB_CRON:0 0 0 * * *}}


### PR DESCRIPTION
Closes #88, Closes #6

Deployed: https://frontiers-qa7.dokku-00.cs.ucsb.edu

In this PR, we complete the final issue for Epic #6 by scheduling the MembershipAuditJob to run (by default):
* Once per day at midnight on Prod
* Once every 10 minutes on Dev

The schedule can be overridden on localhost with an environment variable in .env or defined in the shell, and on dokku (i.e. in production) via a dokku config:set variable.

The variable is called `MEMBERSHIP_AUDIT_JOB_CRON` and the syntax is documented in the application.properties file and in application-development.properties

The syntax is also defined in the [Spring Boot documentation](https://spring.io/blog/2020/11/10/new-in-spring-5-3-improved-cron-expressions) 