### PR TITLE
pc - add links to course org and course org installation settings

### DIFF
--- a/frontend/src/main/components/Courses/InstructorCoursesTable.js
+++ b/frontend/src/main/components/Courses/InstructorCoursesTable.js
@@ -1,6 +1,7 @@
 import OurTable from "main/components/OurTable";
 import { hasRole } from "main/utils/currentUser";
 import { Button } from "react-bootstrap";
+import { FaGithub } from "react-icons/fa";
 
 const columns = [
   {
@@ -48,19 +49,19 @@ export default function InstructorCoursesTable({
 
   const canInstall = (row) => {
     if ("orgName" in row.values && row.values.orgName) {
-      return { canInstall: false, reason: "already-installed" };
+      return false;
     }
     if (hasRole(currentUser, "ROLE_ADMIN")) {
-      return { canInstall: true, reason: "admin" };
+      return true;
     }
     if (
       hasRole(currentUser, "ROLE_INSTRUCTOR") &&
       row.values.createdByEmail === currentUser.root.user.email
     ) {
-      return { canInstall: true, reason: "instructor-created-course" };
+      return true;
     }
 
-    return { canInstall: false, reason: "not-authorized" };
+    return false;
   };
 
   const columnsWithInstall = [
@@ -70,24 +71,56 @@ export default function InstructorCoursesTable({
       accessor: "orgName",
       Cell: ({ cell }) => {
         const result = canInstall(cell.row);
-        if (result.canInstall) {
+        if (result) {
           return (
             <Button
               variant={"primary"}
               onClick={() => installCallback(cell)}
               data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
-              data-reason={result.reason}
             >
               Install Github App
             </Button>
           );
-        } else {
+        } else if (!cell.value) {
           return (
             <span
-              data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-cannot-install-${result.reason}`}
+              data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-no-org`}
+            ></span>
+          );
+        } else {
+          return (
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                width: "100%",
+              }}
+              data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-div`}
             >
-              {cell.value}
-            </span>
+              <span>
+                <a
+                  href={`https://github.com/${cell.value}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-github-link`}
+                >
+                  {cell.value}
+                </a>
+              </span>
+              <span>
+                <a
+                  href={`https://github.com/organizations/${cell.value}/settings/installations/${cell.row.original.installationId}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-github-settings-link`}
+                >
+                  <FaGithub
+                    size={"1.5em"}
+                    data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-github-icon`}
+                  />
+                </a>
+              </span>
+            </div>
           );
         }
       },

--- a/frontend/src/tests/components/Courses/InstructorCoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/InstructorCoursesTable.test.js
@@ -82,10 +82,21 @@ describe("InstructorCoursesTable tests", () => {
     ).toHaveTextContent("ucsb-cs156-s25");
 
     const row0_already_installed = screen.getByTestId(
-      `${testId}-cell-row-0-col-orgName-cannot-install-already-installed`,
+      `${testId}-cell-row-0-col-orgName-github-link`,
     );
     expect(row0_already_installed).toBeInTheDocument();
     expect(row0_already_installed).toHaveTextContent("ucsb-cs156-s25");
+    expect(row0_already_installed).toHaveAttribute(
+      "href",
+      "https://github.com/ucsb-cs156-s25",
+    );
+
+    const div0 = screen.getByTestId(`${testId}-cell-row-0-col-orgName-div`);
+    expect(div0).toBeInTheDocument();
+    expect(div0).toHaveAttribute(
+      "style",
+      "display: flex; justify-content: space-between; width: 100%;",
+    );
 
     const button3 = screen.getByTestId(
       `${testId}-cell-row-2-col-orgName-button`,
@@ -93,14 +104,12 @@ describe("InstructorCoursesTable tests", () => {
     expect(button3).toBeInTheDocument();
     expect(button3).toHaveTextContent("Install Github App");
     expect(button3).toHaveAttribute("class", "btn btn-primary");
-    expect(button3).toHaveAttribute("data-reason", "instructor-created-course");
 
-    const span4 = screen.getByTestId(
-      `${testId}-cell-row-3-col-orgName-cannot-install-not-authorized`,
+    const noOrgSpan = screen.getByTestId(
+      `${testId}-cell-row-3-col-orgName-no-org`,
     );
-    expect(span4).toBeInTheDocument();
-    // This span should be empty since the course has no orgName
-    expect(span4).toBeEmptyDOMElement();
+    expect(noOrgSpan).toBeInTheDocument();
+    expect(noOrgSpan).toBeEmptyDOMElement();
 
     const firstCourseLink = screen.getByTestId(
       "CoursesTable-cell-row-0-col-courseName-link",
@@ -131,7 +140,6 @@ describe("InstructorCoursesTable tests", () => {
     expect(button3).toBeInTheDocument();
     expect(button3).toHaveTextContent("Install Github App");
     expect(button3).toHaveAttribute("class", "btn btn-primary");
-    expect(button3).toHaveAttribute("data-reason", "admin");
 
     const button4 = screen.getByTestId(
       `${testId}-cell-row-3-col-orgName-button`,
@@ -139,7 +147,6 @@ describe("InstructorCoursesTable tests", () => {
     expect(button4).toBeInTheDocument();
     expect(button4).toHaveTextContent("Install Github App");
     expect(button4).toHaveAttribute("class", "btn btn-primary");
-    expect(button4).toHaveAttribute("data-reason", "admin");
   });
 
   test("Calls window.alert when the button is pressed on storybook", async () => {
@@ -193,6 +200,34 @@ describe("InstructorCoursesTable tests", () => {
     });
 
     expect(window.location.href).toBe("/api/courses/redirect?courseId=3");
+  });
+
+  test("Tests for Github link and icon", async () => {
+    render(
+      <BrowserRouter>
+        <InstructorCoursesTable
+          courses={coursesFixtures.severalCourses}
+          currentUser={currentUserFixtures.instructorUser}
+          storybook={false}
+        />
+      </BrowserRouter>,
+    );
+
+    const githubIcon = screen.getByTestId(
+      `CoursesTable-cell-row-0-col-orgName-github-icon`,
+    );
+    expect(githubIcon).toBeInTheDocument();
+    expect(githubIcon).toHaveAttribute("height", "1.5em");
+    expect(githubIcon).toHaveAttribute("width", "1.5em");
+
+    const githubLink = screen.getByTestId(
+      `CoursesTable-cell-row-0-col-orgName-github-settings-link`,
+    );
+    expect(githubLink).toBeInTheDocument();
+    expect(githubLink).toHaveAttribute(
+      "href",
+      "https://github.com/organizations/ucsb-cs156-s25/settings/installations/123456",
+    );
   });
 
   test("Tests that when storybook is false by default all works as expected", async () => {


### PR DESCRIPTION
In this PR, we make the course organization be a link to the course organization on Github, and also add a Github Icon that links to the settings for the installation.

Also refactor InstructorCourseTable to simplify table and testing (remove the "reason" field that was tracking why a course was or was not appearing in the table with a link.)

Deployed on: TODO: Add deployment.

# Screenshots

Before.  Notice the organization column just lists the name of the organization. 

<img width="1012" height="266" alt="image" src="https://github.com/user-attachments/assets/fa077ac1-758a-438d-994c-1b6e99479a8b" />


After.  Notice organization now has a link to the organization, and an icon to link to the installation settings.

<img width="1062" height="265" alt="image" src="https://github.com/user-attachments/assets/69181d41-b534-4af1-b57c-629a16fb7b74" />

# Storybook

TODO: Add storybook link