### PR TITLE
pc - put course title at top of page above the tabs on InstructorCourseShowPage

### DIFF
--- a/frontend/src/main/pages/Instructor/InstructorCourseShowPage.js
+++ b/frontend/src/main/pages/Instructor/InstructorCourseShowPage.js
@@ -101,9 +101,11 @@ export default function InstructorCourseShowPage() {
           </Button>
         </Modal.Footer>
       </Modal>
+      <h1 data-testid={`${testId}-title`}>
+        Course: {course ? `${course.courseName} (${course.id})` : "Loading..."}
+      </h1>
       <Tabs defaultActiveKey={"default"}>
         <Tab eventKey={"default"} title={"Management"} className="pt-2">
-          <h1>Course</h1>
           <InstructorCoursesTable
             courses={course ? [course] : []}
             currentUser={currentUser}

--- a/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
+++ b/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
@@ -80,6 +80,21 @@ describe("InstructorCourseShowPage tests", () => {
       </QueryClientProvider>,
     );
 
+    const testId = "InstructorCourseShowPage";
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`${testId}-title`)).toBeInTheDocument();
+    });
+
+    const courseName = screen.getByTestId(`${testId}-title`);
+    expect(courseName).toHaveTextContent("Course: Loading...");
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`${testId}-title`)).toHaveTextContent(
+        "Course: CMPSC 156 (1)",
+      );
+    });
+
     const rsTestId = "InstructorCourseShowPage-RosterStudentTable";
 
     await waitFor(() => {


### PR DESCRIPTION
Closes #246 

Deployed to: https://frontiers-qa5.dokku-00.cs.ucsb.edu

In this PR we make a small tweak to the InstructorCourseShowPage so that we can see what course we are working with, regardless of which tab we are on.

# Storybook

https://67da6ee1a47bfcdda4700814-ogcmuffhsj.chromatic.com/?path=/story/pages-instructor-instructorcourseshowpage--example-course-no-students

# UX Diffs

https://www.chromatic.com/test?appId=67da6ee1a47bfcdda4700814&id=688149e9ad15109eda836e98

<img width="1329" height="309" alt="image" src="https://github.com/user-attachments/assets/aa616c88-2969-438e-b53e-ff89badb6af1" />

https://www.chromatic.com/test?appId=67da6ee1a47bfcdda4700814&id=688149e9ad15109eda836e99

<img width="1326" height="200" alt="image" src="https://github.com/user-attachments/assets/2c1c1c58-891d-4aab-a345-d671e470ed04" />

https://www.chromatic.com/test?appId=67da6ee1a47bfcdda4700814&id=688149e9ad15109eda836ec1

<img width="1326" height="249" alt="image" src="https://github.com/user-attachments/assets/4953cc9c-4f73-470a-b6ef-f296d2cbb202" />


# Storybook

https://67da6ee1a47bfcdda4700814-ogcmuffhsj.chromatic.com/?path=/story/pages-instructor-instructorcourseshowpage--example-course-no-students

# Screenshot

Before:

<img width="1020" height="353" alt="image" src="https://github.com/user-attachments/assets/a972dc92-0056-4c19-a606-294114902ccd" />

<img width="1017" height="433" alt="image" src="https://github.com/user-attachments/assets/9b0af905-4df1-458e-91ce-71b31ae027c4" />

After: 

<img width="1010" height="307" alt="image" src="https://github.com/user-attachments/assets/5a741fa7-5de3-4ca2-aef1-d3f0c7eee114" />

<img width="1009" height="515" alt="image" src="https://github.com/user-attachments/assets/98d05604-eeaa-492c-985d-8469e910ac43" />




