### PR TITLE
divyanipunj -  Added HomePageConnectGithub Component and Updated Related Files

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,6 +19,7 @@ import InstructorCourseShowPage from "main/pages/Instructor/InstructorCourseShow
 import HomePageLoggedIn from "main/pages/HomePageLoggedIn";
 import LoadingPage from "main/pages/LoadingPage";
 import SignInPage from "main/pages/Auth/SignInPage";
+import HomePageConnectGithub from "main/pages/HomePageConnectGithub";
 
 function App() {
   const currentUserData = useCurrentUser();
@@ -53,6 +54,19 @@ function App() {
           <Route path="/" element={<HomePageLoggedOut />} />
           <Route path="*" element={<HomePageLoggedOut />} />
           <Route exact path="/login" element={<SignInPage />} />
+        </Routes>
+      </BrowserRouter>
+    );
+  }
+
+  //if you reach here, the user is logged in BUT does not have a github connected.. lead to page to connect github
+  //the existing checks in Githublogin.js and signinpage.js (?) are not neccessary since those checks are done above
+  if (!currentUserData.githubLogin) {
+    return (
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<HomePageConnectGithub />} />
+          <Route path="*" element={<HomePageConnectGithub />} />
         </Routes>
       </BrowserRouter>
     );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -59,8 +59,6 @@ function App() {
     );
   }
 
-  //if you reach here, the user is logged in BUT does not have a github connected.. lead to page to connect github
-  //the existing checks in Githublogin.js and signinpage.js (?) are not neccessary since those checks are done above
   if (!currentUserData.githubLogin) {
     return (
       <BrowserRouter>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -59,7 +59,9 @@ function App() {
     );
   }
 
-  if (!currentUserData.githubLogin) {
+  const currentUser = currentUserData;
+
+  if (!hasRole(currentUser, "ROLE_GITHUB")) {
     return (
       <BrowserRouter>
         <Routes>
@@ -69,8 +71,6 @@ function App() {
       </BrowserRouter>
     );
   }
-
-  const currentUser = currentUserData;
 
   const userRoutes = hasRole(currentUser, "ROLE_USER") ? (
     <>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -81,9 +81,14 @@ export default function AppNavbar({
                 </NavDropdown>
               )}
             </Nav>
-            <Nav className="ml-auto">
-              <GithubLogin currentUser={currentUser} systemInfo={systemInfo} />
-            </Nav>
+            {hasRole(currentUser, "ROLE_GITHUB") && (
+              <Nav className="ml-auto">
+                <GithubLogin
+                  currentUser={currentUser}
+                  systemInfo={systemInfo}
+                />
+              </Nav>
+            )}
             <Nav className="ml-auto">
               <GoogleLogin
                 currentUser={currentUser}

--- a/frontend/src/main/pages/HomePageConnectGithub.js
+++ b/frontend/src/main/pages/HomePageConnectGithub.js
@@ -1,0 +1,42 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { FaGithubSquare } from "react-icons/fa";
+import { useSystemInfo } from "main/utils/systemInfo";
+import { Row } from "react-bootstrap";
+import SignInCard from "main/components/Auth/SignInCard";
+// import { useCurrentUser } from "main/utils/currentUser";
+
+export default function HomePageConnectGithub() {
+  const githubIcon = () => {
+    return (
+      <span data-testid={"HomePageConnectGithub-githubIcon"}>
+        <FaGithubSquare size={"10em"} role={"img"} />
+      </span>
+    );
+  };
+
+  const { data: systemInfo } = useSystemInfo();
+
+  var githubOauthLogin =
+    systemInfo?.githubOauthLogin || "/oauth2/authorization/github";
+
+  return (
+    <BasicLayout>
+      <Row
+        xs={1}
+        md={2}
+        className={"g-5 d-flex gap-5 justify-content-center align-items-center"}
+        data-testid={"HomePageConnectGithub-cardDisplay"}
+      >
+        <SignInCard
+          Icon={githubIcon}
+          title={"Sign in with Github"}
+          description={
+            "Please connect your account with a GitHub account to continue to Frontiers."
+          }
+          url={githubOauthLogin}
+          testid={"github"}
+        />
+      </Row>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/LoadingPage.js
+++ b/frontend/src/main/pages/LoadingPage.js
@@ -1,6 +1,6 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 
-export default function HomePage() {
+export default function LoadingPage() {
   return (
     <div data-testid={"LoadingPage-main-div"}>
       <BasicLayout></BasicLayout>

--- a/frontend/src/stories/pages/HomePageConnectGithub.stories.js
+++ b/frontend/src/stories/pages/HomePageConnectGithub.stories.js
@@ -1,0 +1,26 @@
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import HomePageConnectGithub from "main/pages/HomePageConnectGithub";
+
+export default {
+  title: "pages/HomePageConnectGithub",
+  component: HomePageConnectGithub,
+};
+
+const Template = () => <HomePageConnectGithub />;
+
+export const NoGitHubRegularUser = Template.bind({});
+NoGitHubRegularUser.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+    ],
+  },
+};

--- a/frontend/src/stories/pages/HomePageLoggedIn.stories.js
+++ b/frontend/src/stories/pages/HomePageLoggedIn.stories.js
@@ -3,8 +3,6 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { http, HttpResponse } from "msw";
 import { QueryClient, QueryClientProvider } from "react-query";
 
-// import { useCurrentUser } from "main/utils/currentUser";
-
 import HomePageLoggedIn from "main/pages/HomePageLoggedIn";
 import coursesFixtures from "fixtures/coursesFixtures";
 

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -1,7 +1,10 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import {
+  currentUserFixtures,
+  currentUserFixturesWithGithub,
+} from "fixtures/currentUserFixtures";
 
 import AppNavbar from "main/components/Nav/AppNavbar";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
@@ -186,5 +189,32 @@ describe("AppNavbar tests", () => {
     await screen.findByText("Log In");
     fireEvent.click(screen.getByText("Log In"));
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith("/login"));
+  });
+
+  test("If user does not have ROLE_GITHUB, it does not render Github login button", async () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AppNavbar currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByText("Sign in with Github")).not.toBeInTheDocument();
+  });
+  test("If user does have ROLE_GITHUB, it does renders the connected to github", async () => {
+    const currentUser = currentUserFixturesWithGithub.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AppNavbar currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText("Github: cgaucho-github")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -190,20 +190,6 @@ describe("AppNavbar tests", () => {
     fireEvent.click(screen.getByText("Log In"));
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith("/login"));
   });
-
-  test("If user does not have ROLE_GITHUB, it does not render Github login button", async () => {
-    const currentUser = currentUserFixtures.userOnly;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <AppNavbar currentUser={currentUser} />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-
-    expect(screen.queryByText("Sign in with Github")).not.toBeInTheDocument();
-  });
   test("If user does have ROLE_GITHUB, it does renders the connected to github", async () => {
     const currentUser = currentUserFixturesWithGithub.userOnly;
 

--- a/frontend/src/tests/components/Nav/GithubLogin.test.js
+++ b/frontend/src/tests/components/Nav/GithubLogin.test.js
@@ -174,4 +174,25 @@ describe("GithubLogin tests", () => {
 
     await screen.findByText("Github: phtcon-github");
   });
+  test("If systemInfo is not available, use the default githubOauthLogin", async () => {
+    const currentUser = currentUserFixtures.userOnly;
+    const doLogin = jest.fn();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GithubLogin
+            currentUser={currentUser}
+            systemInfo={undefined}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const loginButton = await screen.findByRole("button", {
+      name: "Connect Github",
+    });
+    expect(loginButton).toBeInTheDocument();
+    expect(loginButton).toHaveAttribute("href", "/oauth2/authorization/github");
+  });
 });

--- a/frontend/src/tests/pages/HomePageConnectGithub.test.js
+++ b/frontend/src/tests/pages/HomePageConnectGithub.test.js
@@ -1,0 +1,75 @@
+import { render, screen, within } from "@testing-library/react";
+import HomePageConnectGithub from "main/pages/HomePageConnectGithub";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("HomePageConnectGithub tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+  axiosMock
+    .onGet("/api/currentUser")
+    .reply(200, apiCurrentUserFixtures.userOnly);
+  axiosMock
+    .onGet("/api/systemInfo")
+    .reply(200, systemInfoFixtures.showingNeither);
+
+  const queryClient = new QueryClient();
+  test("renders without crashing", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HomePageConnectGithub />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    await screen.findByText(/Sign in with Github/);
+    expect(
+      screen.getByTestId("HomePageConnectGithub-githubIcon"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Sign in with Github")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Please connect your account with a GitHub account to continue to Frontiers.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("SignInCard-base-github")).getByText("Log In"),
+    ).toHaveAttribute("href", "/oauth2/authorization/github");
+    expect(screen.getByRole("img")).toHaveAttribute("height", "10em");
+    expect(screen.getByRole("img")).toHaveAttribute("width", "10em");
+  });
+  test("Base environment test", () => {
+    axiosMock.onGet("/api/systemInfo").timeout();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HomePageConnectGithub />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId("HomePageConnectGithub-cardDisplay")).toHaveClass(
+      "g-5 justify-content-center align-items-center",
+      "d-flex",
+      "gap-5",
+    );
+  });
+  test("If systemInfo is not available, use the default githubOauthLogin", async () => {
+    axiosMock.onGet("/api/systemInfo").reply(200, undefined);
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HomePageConnectGithub />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const footer = await screen.findByTestId("SignInCard-footer-github");
+    const button = within(footer).getByRole("button", { name: /log in/i });
+    expect(button).toHaveAttribute("href", "/oauth2/authorization/github");
+  });
+});


### PR DESCRIPTION
This PR addresses #229 

**This PR**:
- Adds the HomePageConnectGithub page (plus tests and stories).
- Updates App.js so that when a user is logged in, but has not yet connected their GitHub account they are directed to the HomePageConnectGithub.
- Updates the navigation bar so when on the user is on the HomePageConnectGithub page they do not see the connect github button. 
- Updates testing for AppNavBar and GithubLoginTest to cover a mutation. 
- Does very small changes to HomePageLoggedIn stories and the loading page to clean up the files.


**Dokku**: https://frontiers-divyanipunj.dokku-00.cs.ucsb.edu/
**Storybook**: https://67da6ee1a47bfcdda4700814-sfhuewtuer.chromatic.com/?path=/story/pages-homepageconnectgithub--no-git-hub-regular-user

**NOTES/DISCUSSION**: The user will not be able to access Frontiers beyond the HomePageConnectGithub until they login with GitHub. This is good if we want to avoid issues like the one we encountered yesterday, where it was possible to access components that require connecting to Github first. Doing this also gets rid of the need for the **Connect Github** button on the navigation bar since users cannot navigate away until their GitHub is connected. 

Additionally, if this our intended functionality, do we even want to show admins and instructors the rest of the navigation bar until they connect their GitHub? Since they wont be able to click into the _Instructor_ or _Admin_ pages until they login with GitHub, it may be confusing to have them on the navigation bar. 

**Testing Plan**: 
- [ ] Have a normal user who has not yet connected their GitHub account to log onto Frontiers and see what page appears.
- [ ] Have the normal user use HomePageConnectGithub to login with GitHub and view the home page after. 
- [ ] Have an admin and/or instructor user who has not yet connected their GitHub account to log onto Frontiers and see what page appears.
- [ ] Have the admin and/or instructor user use HomePageConnectGithub to login with GitHub and view the home page after. 