### PR TITLE
Making the Navbar More Mobile Friendly

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -22,7 +22,7 @@ export default function AppNavbar({
         <AppNavbarLocalhost url={currentUrl} />
       )}
       <Navbar
-        expand="xl"
+        expand="md"
         variant="dark"
         bg="dark"
         sticky="top"
@@ -35,25 +35,22 @@ export default function AppNavbar({
 
           <Navbar.Toggle />
 
-          <Nav className="me-auto">
-            {systemInfo?.springH2ConsoleEnabled && (
-              <>
-                <Nav.Link href="/h2-console">H2Console</Nav.Link>
-              </>
-            )}
-            {systemInfo?.showSwaggerUILink && (
-              <>
-                <Nav.Link href="/swagger-ui/index.html">Swagger</Nav.Link>
-              </>
-            )}
-          </Nav>
-
           <>
             {/* be sure that each NavDropdown has a unique id and data-testid  */}
           </>
 
           <Navbar.Collapse className="justify-content-between">
             <Nav className="mr-auto">
+              {systemInfo?.showSwaggerUILink && (
+                <>
+                  <Nav.Link href="/swagger-ui/index.html">Swagger</Nav.Link>
+                </>
+              )}
+              {systemInfo?.springH2ConsoleEnabled && (
+                <>
+                  <Nav.Link href="/h2-console">H2Console</Nav.Link>
+                </>
+              )}
               {hasRole(currentUser, "ROLE_ADMIN") && (
                 <NavDropdown
                   title="Admin"


### PR DESCRIPTION
In this PR, I make the navbar more mobile friendly by moving the Swagger and H2 console links inside of the collapsible navbar. The Hamburger menu will now move right on smaller displays, and will fold at small display size, expanding at medium rather than expanding at extra larger.

Deployed to https://frontiers-qa1.dokku-00.cs.ucsb.edu/