### PR TITLE
Creating an Event System

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/enums/EventType.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/enums/EventType.java
@@ -1,0 +1,5 @@
+package edu.ucsb.cs156.frontiers.enums;
+
+public enum EventType {
+    REGISTER, LINK_GITHUB
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/queue/Event.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/queue/Event.java
@@ -1,0 +1,6 @@
+package edu.ucsb.cs156.frontiers.queue;
+
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.enums.EventType;
+
+public record Event (User user, EventType eventType) {}

--- a/src/main/java/edu/ucsb/cs156/frontiers/queue/EventHandler.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/queue/EventHandler.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.frontiers.queue;
+
+import edu.ucsb.cs156.frontiers.enums.EventType;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Component
+public @interface EventHandler {
+    EventType[] value();
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/queue/EventManager.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/queue/EventManager.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.frontiers.queue;
+
+import edu.ucsb.cs156.frontiers.enums.EventType;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class EventManager {
+
+    private final Map<EventType, List<EventRunner>> eventHandlerMap;
+
+    public EventManager(List<EventRunner> eventRunners){
+        this.eventHandlerMap = new HashMap<>();
+        eventRunners.stream()
+                .filter(handler -> handler.getClass().isAnnotationPresent(EventHandler.class))
+                .forEach(handler -> {
+                    EventType[] eventTypes = handler.getClass().getAnnotation(EventHandler.class).value();
+                    for (EventType eventType : eventTypes) {
+                        eventHandlerMap.computeIfAbsent(eventType, k -> new ArrayList<>()).add(handler);
+                    }
+                });
+
+    }
+
+    public void fireEvent(@NotNull Event event){
+        eventHandlerMap.get(event.eventType()).forEach(handler -> handler.handleEvent(event));
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/queue/EventRunner.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/queue/EventRunner.java
@@ -1,0 +1,7 @@
+package edu.ucsb.cs156.frontiers.queue;
+
+import edu.ucsb.cs156.frontiers.enums.EventType;
+
+public interface EventRunner {
+    void handleEvent(Event event);
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/queue/handlers/UpdateUserHandler.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/queue/handlers/UpdateUserHandler.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.frontiers.queue.handlers;
+
+import edu.ucsb.cs156.frontiers.enums.EventType;
+import edu.ucsb.cs156.frontiers.queue.Event;
+import edu.ucsb.cs156.frontiers.queue.EventHandler;
+import edu.ucsb.cs156.frontiers.queue.EventRunner;
+import edu.ucsb.cs156.frontiers.services.UpdateUserService;
+
+@EventHandler({EventType.LINK_GITHUB})
+public class UpdateUserHandler implements EventRunner {
+    private final UpdateUserService updateUserService;
+
+    public UpdateUserHandler(UpdateUserService updateUserService) {
+        this.updateUserService = updateUserService;
+    }
+
+    @Override
+    public void handleEvent(Event event){
+        updateUserService.attachCourseStaff(event.user());
+        updateUserService.attachRosterStudents(event.user());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/queue/DummyEventHandler.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/queue/DummyEventHandler.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.frontiers.queue;
+
+import edu.ucsb.cs156.frontiers.enums.EventType;
+
+@EventHandler({EventType.REGISTER, EventType.LINK_GITHUB})
+public class DummyEventHandler implements EventRunner{
+    public void handleEvent(Event event) {
+        // Do nothing
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/queue/EventManagerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/queue/EventManagerTests.java
@@ -1,0 +1,49 @@
+package edu.ucsb.cs156.frontiers.queue;
+
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.enums.EventType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+@Import( {EventManager.class})
+public class EventManagerTests {
+    @MockitoBean
+    DummyEventHandler dummyEventHandler;
+
+    @Autowired
+    EventManager eventManager;
+
+    @Test
+    public void eventmanager_calls_events() {
+        User user = User.builder().build();
+        Event firedEvent = new Event(user, EventType.REGISTER);
+        eventManager.fireEvent(firedEvent);
+        verify(dummyEventHandler).handleEvent(eq(firedEvent));
+
+        Event firedEvent2 = new Event(user, EventType.LINK_GITHUB);
+        eventManager.fireEvent(firedEvent2);
+        verify(dummyEventHandler).handleEvent(eq(firedEvent2));
+    }
+
+    @Test
+    public void appropriately_filtered_handlers() {
+        User user = User.builder().build();
+        EventRunner noAnnotation = mock(EventRunner.class);
+        EventManager withNoAnnotationMock = new EventManager(List.of(dummyEventHandler, noAnnotation));
+        Event firedEvent = new Event(user, EventType.REGISTER);
+        withNoAnnotationMock.fireEvent(firedEvent);
+        verify(noAnnotation, never()).handleEvent(eq(firedEvent));
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/queue/handlers/UpdateUserHandlerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/queue/handlers/UpdateUserHandlerTests.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.frontiers.queue.handlers;
+
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.enums.EventType;
+import edu.ucsb.cs156.frontiers.queue.Event;
+import edu.ucsb.cs156.frontiers.queue.EventHandler;
+import edu.ucsb.cs156.frontiers.services.UpdateUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class UpdateUserHandlerTests {
+    @Mock
+    UpdateUserService updateUserService;
+
+    @InjectMocks
+    UpdateUserHandler updateUserHandler;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testUpdateUserHandler() {
+        assertTrue(Arrays.stream(updateUserHandler.getClass().getAnnotation(EventHandler.class).value()).anyMatch(event -> event == EventType.LINK_GITHUB));
+        Event event = new Event(User.builder().build(), EventType.LINK_GITHUB);
+        updateUserHandler.handleEvent(event);
+        verify(updateUserService).attachRosterStudents(eq(event.user()));
+        verify(updateUserService).attachCourseStaff(eq(event.user()));
+        verifyNoMoreInteractions(updateUserService);
+    }
+}


### PR DESCRIPTION
In this PR, I create an extensible event system that in the future can be used for actions that are queued behind a person registering or linking their GitHub account.

It is made of several pieces:
1. An `EventRunner`
   - This is an interface with one required method: handleEvent, which takes an event
   - They can be subscribed to any number of events via the `@EventHandler` annotation, which takes any number of events from the `EventType` enum
   - These are called and handed a copy of the event when it occurs.
2. An `EventManager`
   - This bean autowires a list of every bean that implements the `EventRunner class` and sorts them into a map based on what they are subscribed to
   - Has the `fireEvent` method which can be called to notify beans of an Event`
3. The `Event` class
   - Currently has two fields: The type of event, and the User in question.
   - EventRunners are expected to maintain their own method of holding queued actions for the event (ie, separate table)

Prep work for possible teams work.

Deployed to https://frontiers-qa1.dokku-00.cs.ucsb.edu/