### PR TITLE
Loosening the Assignment Repo Permissions

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RepositoryController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RepositoryController.java
@@ -48,7 +48,6 @@ public class RepositoryController extends ApiController {
     @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
     public Job createRepos(@RequestParam Long courseId, @RequestParam String repoPrefix, @RequestParam Optional<Boolean> isPrivate) {
         Course course = courseRepository.findById(courseId).orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
-        if (getCurrentUser().getUser().getId() == course.getCreator().getId()) {
             if (course.getOrgName() == null || course.getInstallationId() == null) {
                 throw new NoLinkedOrganizationException(course.getCourseName());
             } else {
@@ -59,9 +58,6 @@ public class RepositoryController extends ApiController {
                         .course(course)
                         .build();
                 return jobService.runAsJob(job);
-            }
-        } else {
-            throw new AccessDeniedException("You do not have permission to create student repositories on this course");
         }
     }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RepositoryControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RepositoryControllerTests.java
@@ -50,7 +50,7 @@ public class RepositoryControllerTests extends ControllerTestCase {
     private ObjectMapper objectMapper;
 
     @Test
-    @WithMockUser(roles = {"ADMIN"})
+    @WithMockUser(roles = {"INSTRUCTOR"})
     public void not_the_creator() throws Exception {
         Course course = Course.builder().creator(User.builder().build()).build();
         doReturn(Optional.of(course)).when(courseRepository).findById(eq(2L));


### PR DESCRIPTION
In this PR, I loosen the permissions on who is allowed to create student assignment repositories in a GitHub organization.

Previously, it was restricted to the creator only -- now, the creator or an administrator can create repositories (via `CourseSecurity`)

Jointly deployed with #257 to https://frontiers-qa1.dokku-00.cs.ucsb.edu/