### PR TITLE
Paginating the Users Table (One Consolidated PR)

### DIFF
--- a/frontend/src/main/components/Common/OurPagination.js
+++ b/frontend/src/main/components/Common/OurPagination.js
@@ -1,0 +1,112 @@
+import React from "react";
+import { Pagination } from "react-bootstrap";
+
+export const emptyArray = () => []; // factored out for Stryker testing
+
+const OurPagination = ({
+  currentActivePage,
+  updateActivePage,
+  totalPages = 10,
+  testId = "OurPagination",
+}) => {
+  const nextPage = () => {
+    const newPage = Math.min(currentActivePage + 1, totalPages);
+    updateActivePage(newPage);
+  };
+  const prevPage = () => {
+    const newPage = Math.max(currentActivePage - 1, 1);
+    updateActivePage(newPage);
+  };
+  const thisPage = (page) => {
+    updateActivePage(page);
+  };
+
+  const pageButton = (number) => (
+    <Pagination.Item
+      key={number}
+      active={number === currentActivePage}
+      onClick={() => thisPage(number)}
+      data-testid={`${testId}-${number}`}
+    >
+      {number}
+    </Pagination.Item>
+  );
+
+  const generateSimplePaginationItems = () => {
+    const paginationItems = emptyArray();
+    for (let number = 1; number <= totalPages; number++) {
+      paginationItems.push(pageButton(number));
+    }
+    return paginationItems;
+  };
+
+  const generateComplexPaginationItems = () => {
+    const paginationItems = emptyArray();
+
+    // Always show page 1 and totalPages
+    paginationItems.push(pageButton(1));
+
+    // Case 1: currentActivePage is near the beginning (1, 2, 3, 4)
+    if (currentActivePage < 5) {
+      paginationItems.push(pageButton(2));
+      paginationItems.push(pageButton(3));
+      paginationItems.push(pageButton(4));
+      paginationItems.push(pageButton(5));
+      paginationItems.push(
+        <Pagination.Ellipsis
+          key="right-ellipsis"
+          data-testid={`${testId}-right-ellipsis`}
+        />,
+      );
+    }
+    // Case 2: currentActivePage is near the end (totalPages - 3, totalPages - 2, totalPages - 1, totalPages)
+    else if (currentActivePage > totalPages - 4) {
+      paginationItems.push(
+        <Pagination.Ellipsis
+          key="left-ellipsis"
+          data-testid={`${testId}-left-ellipsis`}
+        />,
+      );
+      paginationItems.push(pageButton(totalPages - 4));
+      paginationItems.push(pageButton(totalPages - 3));
+      paginationItems.push(pageButton(totalPages - 2));
+      paginationItems.push(pageButton(totalPages - 1));
+    }
+    // Case 3: currentActivePage is in the middle
+    else {
+      paginationItems.push(
+        <Pagination.Ellipsis
+          key="left-ellipsis"
+          data-testid={`${testId}-left-ellipsis`}
+        />,
+      );
+      paginationItems.push(pageButton(currentActivePage - 1));
+      paginationItems.push(pageButton(currentActivePage));
+      paginationItems.push(pageButton(currentActivePage + 1));
+      paginationItems.push(
+        <Pagination.Ellipsis
+          key="right-ellipsis"
+          data-testid={`${testId}-right-ellipsis`}
+        />,
+      );
+    }
+
+    paginationItems.push(pageButton(totalPages));
+    return paginationItems;
+  };
+
+  const generatePaginationItems = () =>
+    totalPages <= 7
+      ? generateSimplePaginationItems()
+      : generateComplexPaginationItems();
+
+  return (
+    <Pagination>
+      <Pagination.Prev onClick={prevPage} data-testid={`${testId}-prev`} />
+      {generatePaginationItems()}
+      <Pagination.Next onClick={nextPage} data-testid={`${testId}-next`} />
+    </Pagination>
+  );
+};
+
+export default OurPagination;

--- a/frontend/src/main/pages/Admin/AdminUsersPage.js
+++ b/frontend/src/main/pages/Admin/AdminUsersPage.js
@@ -2,22 +2,36 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import UsersTable from "main/components/Users/UsersTable";
 
 import { useBackend } from "main/utils/useBackend";
+import OurPagination from "main/components/Common/OurPagination";
+import { useState } from "react";
 const AdminUsersPage = () => {
+  const [currentPage, setCurrentPage] = useState(1);
   const {
     data: users,
     error: _error,
     status: _status,
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
-    ["/api/admin/users"],
-    { method: "GET", url: "/api/admin/users" },
-    [],
+    [`/api/admin/users/${currentPage - 1}`],
+    {
+      method: "GET",
+      url: `/api/admin/users`,
+      params: { page: currentPage - 1, size: 50, sort: "id" },
+    },
+    { content: [], page: { totalPages: 1 } },
   );
 
   return (
     <BasicLayout>
       <h2>Users</h2>
-      <UsersTable users={users} />
+      <UsersTable users={users.content} />
+      <div className="d-flex justify-content-evenly">
+        <OurPagination
+          currentActivePage={currentPage}
+          updateActivePage={setCurrentPage}
+          totalPages={users.page.totalPages}
+        />
+      </div>
     </BasicLayout>
   );
 };

--- a/frontend/src/stories/components/Common/OurPagination.stories.js
+++ b/frontend/src/stories/components/Common/OurPagination.stories.js
@@ -1,0 +1,30 @@
+import OurPagination from "main/components/Common/OurPagination";
+import { useState } from "react";
+
+export default {
+  title: "components/Common/OurPagination",
+  component: OurPagination,
+};
+
+const Template = (args) => {
+  const [currentActivePage, setCurrentActivePage] = useState(1);
+  return (
+    <OurPagination
+      currentActivePage={currentActivePage}
+      updateActivePage={setCurrentActivePage}
+      {...args}
+    />
+  );
+};
+
+export const Total_10_Max_5 = Template.bind({});
+Total_10_Max_5.args = {
+  totalPages: 10,
+  maxPages: 5,
+};
+
+export const Total_5_Max_10 = Template.bind({});
+Total_5_Max_10.args = {
+  totalPages: 5,
+  maxPages: 10,
+};

--- a/frontend/src/stories/pages/Admin/AdminUsersPage.stories.js
+++ b/frontend/src/stories/pages/Admin/AdminUsersPage.stories.js
@@ -1,0 +1,64 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import AdminUsersPage from "main/pages/Admin/AdminUsersPage";
+import usersFixtures from "fixtures/usersFixtures";
+
+export default {
+  title: "pages/Admins/AdminUsersPage",
+  component: AdminUsersPage,
+};
+
+const Template = () => <AdminUsersPage storybook={true} />;
+
+export const Empty = Template.bind({});
+
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/admin/users", () => {
+      return HttpResponse.json(
+        { content: [], page: { totalPages: 1 } },
+        { status: 200 },
+      );
+    }),
+  ],
+};
+
+export const TwoItemsAdminUser = Template.bind({});
+
+TwoItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/admin/users", ({ request }) => {
+      const url = new URL(request.url);
+      if (url.searchParams.get("page") === "0") {
+        return HttpResponse.json({
+          content: [usersFixtures.threeUsers[0]],
+          page: { totalPages: 2 },
+        });
+      } else {
+        return HttpResponse.json({
+          content: [usersFixtures.threeUsers[1]],
+          page: { totalPages: 2 },
+        });
+      }
+    }),
+  ],
+};

--- a/frontend/src/tests/components/Common/OurPagination.test.js
+++ b/frontend/src/tests/components/Common/OurPagination.test.js
@@ -1,0 +1,323 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import OurPagination, {
+  emptyArray,
+} from "main/components/Common/OurPagination";
+import { useState } from "react";
+
+const checkTestIdsInOrder = (testIds) => {
+  const links = screen.getAllByTestId(/OurPagination-/);
+  expect(links.length).toBe(testIds.length);
+
+  for (var i = 0; i < links.length; i++) {
+    expect(screen.getByTestId(testIds[i])).toBe(links[i]);
+  }
+};
+
+const mockStateWrapper = jest.fn();
+
+const PaginationWrapper = ({ beginActivePage, args }) => {
+  const [activePage, setActivePage] = useState(beginActivePage);
+  const aliasActivePage = (x) => {
+    mockStateWrapper(x);
+    setActivePage(x);
+  };
+  return (
+    <OurPagination
+      currentActivePage={activePage}
+      updateActivePage={aliasActivePage}
+      {...args}
+    />
+  );
+};
+
+describe("OurPagination tests", () => {
+  test("emptyArray returns empty array", () => {
+    expect(emptyArray()).toStrictEqual([]);
+  });
+
+  test("renders correctly for totalPages = 5 (less than or equal to 7)", async () => {
+    render(<PaginationWrapper beginActivePage={1} args={{ totalPages: 5 }} />);
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders correctly for totalPages = 7 (less than or equal to 7)", async () => {
+    render(<PaginationWrapper beginActivePage={1} args={{ totalPages: 7 }} />);
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-6",
+      "OurPagination-7",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders correctly for totalPages = 12 (greater than 7), initial state (activePage=1)", async () => {
+    render(<PaginationWrapper beginActivePage={1} args={{ totalPages: 12 }} />);
+    // Expected: 1, 2, 3, 4, 5, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders correctly for totalPages = 12, activePage = 4", async () => {
+    render(<PaginationWrapper beginActivePage={4} args={{ totalPages: 12 }} />);
+
+    // Click to page 4
+    fireEvent.click(screen.getByTestId("OurPagination-4"));
+
+    // Expected: 1, 2, 3, 4, 5, ..., 12 (activePage < 5)
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders correctly for totalPages = 12, activePage = 5 (middle range)", async () => {
+    render(<PaginationWrapper beginActivePage={5} args={{ totalPages: 12 }} />);
+    fireEvent.click(screen.getByTestId("OurPagination-5"));
+    // Expected: 1, ..., 4, 5, 6, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-6",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders correctly for totalPages = 12, activePage = 8 (middle range, next clicks)", async () => {
+    render(<PaginationWrapper beginActivePage={1} args={{ totalPages: 12 }} />);
+
+    const nextButton = screen.getByTestId("OurPagination-next");
+    fireEvent.click(nextButton); // page 2
+    fireEvent.click(nextButton); // page 3
+    fireEvent.click(nextButton); // page 4
+    fireEvent.click(nextButton); // page 5
+    // Expected: 1, ..., 4, 5, 6, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-6",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+    fireEvent.click(nextButton); // page 6
+    // Expected: 1, ..., 5, 6, 7, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-5",
+      "OurPagination-6",
+      "OurPagination-7",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+    fireEvent.click(nextButton); // page 7
+    // Expected: 1, ..., 6, 7, 8, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-6",
+      "OurPagination-7",
+      "OurPagination-8",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+    fireEvent.click(nextButton); // page 8
+    // Expected: 1, ..., 7, 8, 9, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-7",
+      "OurPagination-8",
+      "OurPagination-9",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders correctly for totalPages = 12, activePage = 9 (near end)", async () => {
+    render(<PaginationWrapper beginActivePage={9} args={{ totalPages: 12 }} />);
+    // Click to page 9 (totalPages - 3)
+    // This requires multiple clicks on next or direct jump if available.
+    // For simplicity, we'll simulate state by clicking next multiple times
+    for (let i = 0; i < 8; i++) {
+      // 1 -> 2 -> ... -> 9
+      fireEvent.click(screen.getByTestId("OurPagination-next"));
+    }
+    // Expected: 1, ..., 8, 9, 10, 11, 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-8",
+      "OurPagination-9",
+      "OurPagination-10",
+      "OurPagination-11",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+    expect(screen.queryByText("stryker was here")).not.toBeInTheDocument();
+  });
+
+  test("renders correctly for totalPages = 12, activePage = 12 (end)", async () => {
+    render(
+      <PaginationWrapper beginActivePage={12} args={{ totalPages: 12 }} />,
+    );
+    fireEvent.click(screen.getByTestId("OurPagination-12"));
+    // Expected: 1, ..., 8, 9, 10, 11, 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-8",
+      "OurPagination-9",
+      "OurPagination-10",
+      "OurPagination-11",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("navigation: prev button works correctly", async () => {
+    render(<PaginationWrapper beginActivePage={1} args={{ totalPages: 12 }} />);
+    // Go to page 5
+    fireEvent.click(screen.getByTestId("OurPagination-5"));
+    expect(
+      within(screen.getByTestId("OurPagination-5")).getByText("(current)"),
+    ).toBeInTheDocument();
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-6",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+
+    const prevButton = screen.getByTestId("OurPagination-prev");
+    fireEvent.click(prevButton); // Go to page 4
+
+    // Assert that page 4 is now active
+    expect(
+      within(screen.getByTestId("OurPagination-4")).getByText("(current)"),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("OurPagination-5")).queryByText("(current)"),
+    ).not.toBeInTheDocument();
+
+    // Expected: 1, 2, 3, 4, 5, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("navigation: clicking page 1 from a middle page", async () => {
+    render(<PaginationWrapper beginActivePage={1} args={{ totalPages: 12 }} />);
+    // Go to page 5
+    fireEvent.click(screen.getByTestId("OurPagination-5"));
+    checkTestIdsInOrder([
+      // Page 5
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-6",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+
+    fireEvent.click(screen.getByTestId("OurPagination-1"));
+    // Expected: 1, 2, 3, 4, 5, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("checks active class on buttons", async () => {
+    render(<PaginationWrapper beginActivePage={1} args={{ totalPages: 5 }} />);
+
+    // Initial state: page 1 is active
+    expect(
+      within(screen.getByTestId("OurPagination-1")).getByText("(current)"),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("OurPagination-2")).queryByText("(current)"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("OurPagination-next")); // page 2
+
+    // After re-render: page 2 should be active. Re-query elements.
+    expect(
+      within(screen.getByTestId("OurPagination-1")).queryByText("(current)"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("OurPagination-2")).getByText("(current)"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/main/java/edu/ucsb/cs156/frontiers/FrontiersMain.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/FrontiersMain.java
@@ -15,11 +15,14 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.ClassPathResource;
 
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import edu.ucsb.cs156.frontiers.services.wiremock.WiremockService;
 import lombok.extern.slf4j.Slf4j;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 /**
  * The FrontiersMain class is the main entry point for the application.
@@ -29,6 +32,8 @@ import lombok.extern.slf4j.Slf4j;
 @EnableAsync // for @Async annotation for JobsService
 @EnableScheduling // for @Scheduled annotation for JobsService
 // enables automatic population of @CreatedDate and @LastModifiedDate
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO) //Replaces PageImpl instances with a permanent type PagedModel that is not subject to change
+//See https://docs.spring.io/spring-data/commons/reference/repositories/core-extensions.html#core.web.page
 public class FrontiersMain {
 
   /**

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/UsersController.java
@@ -8,6 +8,8 @@ import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 
 import edu.ucsb.cs156.frontiers.services.UserDataDTOService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +19,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This is a REST controller for getting information about the users.
@@ -40,8 +43,8 @@ public class UsersController extends ApiController {
     @Operation(summary= "Get a list of all users")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("")
-    public List<UserDataDTO> users()
+    public Page<UserDataDTO> users(Pageable pageable)
             throws JsonProcessingException {
-        return userDataDTOService.getUserDataDTOs();
+        return userDataDTOService.getUserDataDTOs(pageable);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/UserRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/UserRepository.java
@@ -1,11 +1,12 @@
 package edu.ucsb.cs156.frontiers.repositories;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import edu.ucsb.cs156.frontiers.entities.User;
 
-import javax.swing.text.html.Option;
 import java.util.Optional;
 
 /**
@@ -19,6 +20,8 @@ public interface UserRepository extends CrudRepository<User, Long> {
    * @return Optional of User (empty if not found)
    */
   Optional<User> findByEmail(String email);
+
+  Page<User> findAll(Pageable pageable);
 
   Optional<User> findByGoogleSub(String googleSub);
 

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/UserDataDTOService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/UserDataDTOService.java
@@ -9,6 +9,9 @@ import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
 import edu.ucsb.cs156.frontiers.repositories.InstructorRepository;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -27,16 +30,17 @@ public class UserDataDTOService {
         this.instructorRepository = instructorRepository;
     }
 
-    public List<UserDataDTO> getUserDataDTOs() {
+    public Page<UserDataDTO> getUserDataDTOs(Pageable pageable) {
+        Page<User> users = userRepository.findAll(pageable);
         List<Admin> admins = Lists.newArrayList(adminRepository.findAll());
         List<Instructor> instructors = Lists.newArrayList(instructorRepository.findAll());
-        Iterable<User> users = userRepository.findAll();
+
         List<UserDataDTO> userDTOs = new ArrayList<>();
         for(User user : users){
             boolean isAdmin = admins.stream().anyMatch(a -> a.getEmail().equals(user.getEmail()));
             boolean isInstructor = instructors.stream().anyMatch(i -> i.getEmail().equals(user.getEmail()));
             userDTOs.add(UserDataDTO.from(user, isAdmin, isInstructor));
         }
-        return userDTOs;
+        return new PageImpl<UserDataDTO>(userDTOs, pageable, users.getTotalElements());
     }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/UsersControllerTests.java
@@ -16,11 +16,15 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -80,9 +84,11 @@ public class UsersControllerTests extends ControllerTestCase {
     userDTOS.add(UserDataDTO.from(u2, false, true));
     userDTOS.add(UserDataDTO.from(u, false, false));
 
-    String expectedJson = mapper.writeValueAsString(userDTOS);
+    Page<UserDataDTO> page = new PageImpl<>(userDTOS);
 
-    when(mockUserDataDTOService.getUserDataDTOs()).thenReturn(userDTOS);
+    String expectedJson = mapper.writeValueAsString(page);
+
+    when(mockUserDataDTOService.getUserDataDTOs(any(Pageable.class))).thenReturn(page);
 
     
     // act

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/UserDataDTOServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/UserDataDTOServiceTests.java
@@ -12,12 +12,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 public class UserDataDTOServiceTests {
@@ -61,11 +65,15 @@ public class UserDataDTOServiceTests {
         userDTOS.add(UserDataDTO.from(u2, false, true));
         userDTOS.add(UserDataDTO.from(u3, false, false));
 
-        when(userRepository.findAll()).thenReturn(expectedUsers);
+        PageImpl<User> page = new PageImpl<>(expectedUsers);
+
+        Pageable pageable = Pageable.unpaged();
+
+        when(userRepository.findAll(eq(pageable))).thenReturn(page);
         when(adminRepository.findAll()).thenReturn(expectedAdmins);
         when(instructorRepository.findAll()).thenReturn(expectedInstructors);
 
-        assertEquals(userDTOS, userDataService.getUserDataDTOs());
+        assertEquals(userDTOS, userDataService.getUserDataDTOs(pageable).getContent());
 
     }
 }


### PR DESCRIPTION
In this PR, I paginate the Users table, bringing over [proj-courses' OurPagination Component](https://github.com/ucsb-cs156/proj-courses/blob/main/frontend/src/main/components/Utils/OurPagination.js), with some tweaks to align with React principles. 

It is deployed in a div that is centered in the middle of the Users page. Currently has a static size of 50 and is sorted by ID. (Adding sort/size may be good for a student?)

<img width="1383" height="587" alt="image" src="https://github.com/user-attachments/assets/f4c2f348-a6fb-4b8f-9087-eed01031a807" />

Notably, I add the `@EnableSpringDataWebSupport(pageSerializationMode=VIA_DTO)` annotation to the application, to comply with Spring Data's notes on using `PageImpl<>`. They are automatically converted to `PagedModel`, rather than having to manually apply the conversion.

If the request does not request pagination, Spring returns `Pageable.unpaged()` by default.
Storybook: https://67da6ee1a47bfcdda4700814-whwjobcxdy.chromatic.com/?path=/story/pages-admins-adminuserspage--two-items-admin-user
Deployed on https://frontiers-qa2.dokku-00.cs.ucsb.edu/
Closes #159 