### PR TITLE
Paginating the Users Table in the Backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/FrontiersMain.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/FrontiersMain.java
@@ -15,11 +15,14 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.ClassPathResource;
 
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import edu.ucsb.cs156.frontiers.services.wiremock.WiremockService;
 import lombok.extern.slf4j.Slf4j;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 /**
  * The FrontiersMain class is the main entry point for the application.
@@ -29,6 +32,8 @@ import lombok.extern.slf4j.Slf4j;
 @EnableAsync // for @Async annotation for JobsService
 @EnableScheduling // for @Scheduled annotation for JobsService
 // enables automatic population of @CreatedDate and @LastModifiedDate
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO) //Replaces PageImpl instances with a permanent type PagedModel that is not subject to change
+//See https://docs.spring.io/spring-data/commons/reference/repositories/core-extensions.html#core.web.page
 public class FrontiersMain {
 
   /**

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/UsersController.java
@@ -8,6 +8,8 @@ import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 
 import edu.ucsb.cs156.frontiers.services.UserDataDTOService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +19,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This is a REST controller for getting information about the users.
@@ -40,8 +43,8 @@ public class UsersController extends ApiController {
     @Operation(summary= "Get a list of all users")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("")
-    public List<UserDataDTO> users()
+    public Page<UserDataDTO> users(Pageable pageable)
             throws JsonProcessingException {
-        return userDataDTOService.getUserDataDTOs();
+        return userDataDTOService.getUserDataDTOs(pageable);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/UserRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/UserRepository.java
@@ -1,11 +1,12 @@
 package edu.ucsb.cs156.frontiers.repositories;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import edu.ucsb.cs156.frontiers.entities.User;
 
-import javax.swing.text.html.Option;
 import java.util.Optional;
 
 /**
@@ -19,6 +20,8 @@ public interface UserRepository extends CrudRepository<User, Long> {
    * @return Optional of User (empty if not found)
    */
   Optional<User> findByEmail(String email);
+
+  Page<User> findAll(Pageable pageable);
 
   Optional<User> findByGoogleSub(String googleSub);
 

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/UserDataDTOService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/UserDataDTOService.java
@@ -9,6 +9,9 @@ import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
 import edu.ucsb.cs156.frontiers.repositories.InstructorRepository;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -27,16 +30,17 @@ public class UserDataDTOService {
         this.instructorRepository = instructorRepository;
     }
 
-    public List<UserDataDTO> getUserDataDTOs() {
+    public Page<UserDataDTO> getUserDataDTOs(Pageable pageable) {
+        Page<User> users = userRepository.findAll(pageable);
         List<Admin> admins = Lists.newArrayList(adminRepository.findAll());
         List<Instructor> instructors = Lists.newArrayList(instructorRepository.findAll());
-        Iterable<User> users = userRepository.findAll();
+
         List<UserDataDTO> userDTOs = new ArrayList<>();
         for(User user : users){
             boolean isAdmin = admins.stream().anyMatch(a -> a.getEmail().equals(user.getEmail()));
             boolean isInstructor = instructors.stream().anyMatch(i -> i.getEmail().equals(user.getEmail()));
             userDTOs.add(UserDataDTO.from(user, isAdmin, isInstructor));
         }
-        return userDTOs;
+        return new PageImpl<UserDataDTO>(userDTOs, pageable, users.getTotalElements());
     }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/UsersControllerTests.java
@@ -16,11 +16,15 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -80,9 +84,11 @@ public class UsersControllerTests extends ControllerTestCase {
     userDTOS.add(UserDataDTO.from(u2, false, true));
     userDTOS.add(UserDataDTO.from(u, false, false));
 
-    String expectedJson = mapper.writeValueAsString(userDTOS);
+    Page<UserDataDTO> page = new PageImpl<>(userDTOS);
 
-    when(mockUserDataDTOService.getUserDataDTOs()).thenReturn(userDTOS);
+    String expectedJson = mapper.writeValueAsString(page);
+
+    when(mockUserDataDTOService.getUserDataDTOs(any(Pageable.class))).thenReturn(page);
 
     
     // act

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/UserDataDTOServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/UserDataDTOServiceTests.java
@@ -12,12 +12,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 public class UserDataDTOServiceTests {
@@ -61,11 +65,15 @@ public class UserDataDTOServiceTests {
         userDTOS.add(UserDataDTO.from(u2, false, true));
         userDTOS.add(UserDataDTO.from(u3, false, false));
 
-        when(userRepository.findAll()).thenReturn(expectedUsers);
+        PageImpl<User> page = new PageImpl<>(expectedUsers);
+
+        Pageable pageable = Pageable.unpaged();
+
+        when(userRepository.findAll(eq(pageable))).thenReturn(page);
         when(adminRepository.findAll()).thenReturn(expectedAdmins);
         when(instructorRepository.findAll()).thenReturn(expectedInstructors);
 
-        assertEquals(userDTOS, userDataService.getUserDataDTOs());
+        assertEquals(userDTOS, userDataService.getUserDataDTOs(pageable).getContent());
 
     }
 }


### PR DESCRIPTION
In this PR, I paginate the `/api/admin/users` endpoint, accepting a `Pageable` object that is passed down the to the service and the CRUDRepository

Notably, I add the `@EnableSpringDataWebSupport(pageSerializationMode=VIA_DTO)` annotation to the application, to comply with Spring Data's notes on using `PageImpl<>`. They are automatically converted to `PagedModel`, rather than having to manually apply the conversion.

If the request does not request pagination, Spring returns `Pageable.unpaged()` by default.

Deployed jointly with #261 to https://frontiers-qa2.dokku-00.cs.ucsb.edu/

Notably, I inefficiently request the full list of admins and instructors to compare against on every page, however I was unable to see an autogenerated method that would fulfill this purpose.

Closes #159 
(jointly with #261)