### PR TITLE
Adding Instructors to the Users Table

### DIFF
--- a/frontend/src/fixtures/usersFixtures.js
+++ b/frontend/src/fixtures/usersFixtures.js
@@ -10,6 +10,7 @@ const usersFixtures = {
       givenName: "Phill",
       familyName: "Conrad",
       admin: true,
+      instructor: false,
     },
     {
       id: 2,
@@ -21,6 +22,7 @@ const usersFixtures = {
       givenName: "Phillip",
       familyName: "Conrad",
       admin: false,
+      instructor: false,
     },
     {
       id: 3,
@@ -32,6 +34,7 @@ const usersFixtures = {
       givenName: "Craig",
       familyName: "Zzyxx",
       admin: false,
+      instructor: true,
     },
   ],
 };

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -25,6 +25,14 @@ const columns = [
       return String(cell.getValue());
     }, // convert boolean to string for display
   },
+  {
+    header: "Instructor",
+    id: "instructor",
+    accessorKey: "instructor",
+    cell: ({ cell }) => {
+      return String(cell.getValue());
+    }, // convert boolean to string for display
+  },
 ];
 
 export default function UsersTable({ users }) {

--- a/frontend/src/stories/components/Users/UsersTable.stories.js
+++ b/frontend/src/stories/components/Users/UsersTable.stories.js
@@ -1,0 +1,23 @@
+import React from "react";
+import UsersTable from "main/components/Users/UsersTable";
+import usersFixtures from "fixtures/usersFixtures";
+
+export default {
+  title: "components/Users/UsersTable",
+  component: UsersTable,
+};
+
+const Template = (args) => {
+  return <UsersTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  users: [],
+};
+
+export const ThreeItems = Template.bind({});
+ThreeItems.args = {
+  users: usersFixtures.threeUsers,
+};

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -14,8 +14,22 @@ describe("UserTable tests", () => {
   test("Has the expected colum headers and content", () => {
     render(<UsersTable users={usersFixtures.threeUsers} />);
 
-    const expectedHeaders = ["id", "First Name", "Last Name", "Email", "Admin"];
-    const expectedFields = ["id", "givenName", "familyName", "email", "admin"];
+    const expectedHeaders = [
+      "id",
+      "First Name",
+      "Last Name",
+      "Email",
+      "Admin",
+      "Instructor",
+    ];
+    const expectedFields = [
+      "id",
+      "givenName",
+      "familyName",
+      "email",
+      "admin",
+      "instructor",
+    ];
     const testId = "UsersTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -39,6 +53,13 @@ describe("UserTable tests", () => {
     );
     expect(
       screen.getByTestId(`${testId}-cell-row-1-col-admin`),
+    ).toHaveTextContent("false");
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-instructor`),
+    ).toHaveTextContent("true");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-instructor`),
     ).toHaveTextContent("false");
   });
 });


### PR DESCRIPTION
In this PR, I add the column "Instructor" to the users table, displaying whether or not a user is displayed in the Instructors table. The backend was already present, so I simply added the frontend.

While working with the Users table, I added the appropriate storybook.

<img width="1335" height="340" alt="image" src="https://github.com/user-attachments/assets/ebe71901-6288-4c69-bf51-f486114dfe9b" />


No merge conflicts with #261, #262 - I modified different files.

Storybook: https://67da6ee1a47bfcdda4700814-pnpjwiewvf.chromatic.com/?path=/story/components-users-userstable--three-items

Deployed to https://frontiers-qa3.dokku-00.cs.ucsb.edu/

Closes #173 