### PR TITLE
divyanipunj: Added InstructorCoursesTable tooltips.

### DIFF
--- a/frontend/src/main/components/Courses/InstructorCoursesTable.js
+++ b/frontend/src/main/components/Courses/InstructorCoursesTable.js
@@ -1,6 +1,6 @@
 import OurTable from "main/components/OurTable";
 import { hasRole } from "main/utils/currentUser";
-import { Button } from "react-bootstrap";
+import { Tooltip, OverlayTrigger, Button } from "react-bootstrap";
 import { FaGithub } from "react-icons/fa";
 
 const columns = [
@@ -13,12 +13,21 @@ const columns = [
     id: "courseName",
     cell: ({ cell }) => {
       return (
-        <a
-          href={`/instructor/courses/${cell.row.original.id}`}
-          data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-link`}
+        <OverlayTrigger
+          placement="right"
+          overlay={
+            <Tooltip id={`tooltip-coursename-${cell.row.index}`}>
+              View course details
+            </Tooltip>
+          }
         >
-          {cell.row.original.courseName}
-        </a>
+          <a
+            href={`/instructor/courses/${cell.row.original.id}`}
+            data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-link`}
+          >
+            {cell.row.original.courseName}
+          </a>
+        </OverlayTrigger>
       );
     },
   },
@@ -64,6 +73,19 @@ export default function InstructorCoursesTable({
     return false;
   };
 
+  const renderTooltip = (cell) => {
+    let set_message;
+    const result = canInstall(cell.row);
+    if (result) {
+      set_message = `Click to install the GitHub app for the course: ${cell.row.original.courseName}`;
+    } else {
+      set_message = `View Github organization: ${cell.row.original.orgName}`;
+    }
+    return (
+      <Tooltip id={`tooltip-orgname-${cell.row.index}`}>{set_message}</Tooltip>
+    );
+  };
+
   const columnsWithInstall = [
     ...columns,
     {
@@ -73,13 +95,17 @@ export default function InstructorCoursesTable({
         const result = canInstall(cell.row);
         if (result) {
           return (
-            <Button
-              variant={"primary"}
-              onClick={() => installCallback(cell)}
-              data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
-            >
-              Install Github App
-            </Button>
+            <OverlayTrigger placement="right" overlay={renderTooltip(cell)}>
+              <span>
+                <Button
+                  variant={"primary"}
+                  onClick={() => installCallback(cell)}
+                  data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
+                >
+                  Install Github App
+                </Button>
+              </span>
+            </OverlayTrigger>
           );
         } else if (!cell.row.original.orgName) {
           return (
@@ -89,38 +115,40 @@ export default function InstructorCoursesTable({
           );
         } else {
           return (
-            <div
-              style={{
-                display: "flex",
-                justifyContent: "space-between",
-                width: "100%",
-              }}
-              data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-div`}
-            >
-              <span>
-                <a
-                  href={`https://github.com/${cell.row.original.orgName}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-github-link`}
-                >
-                  {cell.row.original.orgName}
-                </a>
-              </span>
-              <span>
-                <a
-                  href={`https://github.com/organizations/${cell.row.original.orgName}/settings/installations/${cell.row.original.installationId}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-github-settings-link`}
-                >
-                  <FaGithub
-                    size={"1.5em"}
-                    data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-github-icon`}
-                  />
-                </a>
-              </span>
-            </div>
+            <OverlayTrigger placement="right" overlay={renderTooltip(cell)}>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  width: "100%",
+                }}
+                data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-div`}
+              >
+                <span>
+                  <a
+                    href={`https://github.com/${cell.row.original.orgName}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-testid={`${testId}-cell-row-${cell.row.index}-col-${cell.column.id}-github-link`}
+                  >
+                    {cell.row.original.orgName}
+                  </a>
+                </span>
+                <span>
+                  <a
+                    href={`https://github.com/organizations/${cell.row.original.orgName}/settings/installations/${cell.row.original.installationId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-github-settings-link`}
+                  >
+                    <FaGithub
+                      size={"1.5em"}
+                      data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-github-icon`}
+                    />
+                  </a>
+                </span>
+              </div>
+            </OverlayTrigger>
           );
         }
       },

--- a/frontend/src/tests/components/Courses/InstructorCoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/InstructorCoursesTable.test.js
@@ -256,4 +256,93 @@ describe("InstructorCoursesTable tests", () => {
 
     expect(window.location.href).toBe("/api/courses/redirect?courseId=3");
   });
+  test("expect the correct tooltip ID for the courseName tooltips", async () => {
+    render(
+      <BrowserRouter>
+        <InstructorCoursesTable
+          courses={coursesFixtures.severalCourses}
+          currentUser={currentUserFixtures.instructorUser}
+          storybook={false}
+        />
+      </BrowserRouter>,
+    );
+
+    fireEvent.mouseOver(screen.getByText("CPTS 489"));
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveAttribute("id", "tooltip-coursename-1");
+  });
+  test("expect the correct tooltip ID for the orgName tooltips", async () => {
+    render(
+      <BrowserRouter>
+        <InstructorCoursesTable
+          courses={coursesFixtures.severalCourses}
+          currentUser={currentUserFixtures.instructorUser}
+          storybook={false}
+        />
+      </BrowserRouter>,
+    );
+
+    fireEvent.mouseOver(screen.getByText("wsu-cpts489-fa20"));
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveAttribute("id", "tooltip-orgname-1");
+  });
+  test("the correct tooltip renders for courseName", async () => {
+    render(
+      <BrowserRouter>
+        <InstructorCoursesTable
+          courses={coursesFixtures.severalCourses}
+          currentUser={currentUserFixtures.instructorUser}
+          storybook={false}
+        />
+      </BrowserRouter>,
+    );
+
+    fireEvent.mouseOver(screen.getByText("CPTS 489"));
+
+    await waitFor(() => {
+      expect(screen.getByText("View course details")).toBeInTheDocument();
+    });
+  });
+  test("the correct tooltip renders for orgName when a GitHub organization exists for the course", async () => {
+    render(
+      <BrowserRouter>
+        <InstructorCoursesTable
+          courses={coursesFixtures.severalCourses}
+          currentUser={currentUserFixtures.instructorUser}
+          storybook={false}
+        />
+      </BrowserRouter>,
+    );
+
+    fireEvent.mouseOver(screen.getByText("wsu-cpts489-fa20"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("View Github organization: wsu-cpts489-fa20"),
+      ).toBeInTheDocument();
+    });
+  });
+  test("the correct tooltip renders for orgName when a GitHub organization does NOT exist for the course", async () => {
+    render(
+      <BrowserRouter>
+        <InstructorCoursesTable
+          courses={coursesFixtures.severalCourses}
+          currentUser={currentUserFixtures.instructorUser}
+          storybook={false}
+        />
+      </BrowserRouter>,
+    );
+
+    fireEvent.mouseOver(screen.getByText("Install Github App"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Click to install the GitHub app for the course: CMPSC 156",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
**This PR:** 
- adds tooltips for the columns _Course Name_ and _GitHub Organization_.
- adds the corresponding tests. 

Storybook: 
Dokku: 

# Test Plan (for interactive testing):
In the InstructorCoursesTable: 
  - Have an instructor create a course and see the tooltip that is displayed for the  _Install GitHub App_ button.
  - Have an instructor hover over an existing organization for a course to display the tooltip.
  - Have an instructor hover a course name to view the tooltip.