### PR TITLE
Version Bump to TanStack Query v5

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -4,7 +4,7 @@ import 'react-toastify/dist/ReactToastify.css';
 
 import { initialize, mswLoader } from 'msw-storybook-addon'
 
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { ToastContainer, toast } from "react-toastify";
 import { useEffect } from "react";

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@jest/core": "^29.7.0",
+        "@tanstack/react-query": "^4.40.1",
         "@tanstack/react-table": "^8.21.3",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/user-event": "^14.6.1",
@@ -20,7 +21,6 @@
         "react-hook-form": "^7.53.0",
         "react-icons": "^5.5.0",
         "react-inspector": "^6.0.2",
-        "react-query": "^3.39.3",
         "react-router-dom": "^6.26.1",
         "react-scripts": "5.0.1",
         "react-toastify": "^10.0.5",
@@ -5813,6 +5813,43 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.40.0.tgz",
+      "integrity": "sha512-7MJTtZkCSuehMC7IxMOCGsLvHS3jHx4WjveSrGsG1Nc1UQLjaFwwkpLA2LmPfvOAxnH4mszMOBFD6LlZE+aB+Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.40.1.tgz",
+      "integrity": "sha512-mgD07S5N8e5v81CArKDWrHE4LM7HxZ9k/KLeD3+NUD9WimGZgKIqojUZf/rXkfAMYZU9p0Chzj2jOXm7xpgHHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "4.40.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tanstack/react-table": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
@@ -8072,15 +8109,6 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -8201,22 +8229,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "node_modules/browser-assert": {
@@ -18387,12 +18399,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -18926,16 +18932,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/match-sorter": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.4.tgz",
-      "integrity": "sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.8",
-        "remove-accents": "0.5.0"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -19027,12 +19023,6 @@
       "engines": {
         "node": ">=8.6"
       }
-    },
-    "node_modules/microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==",
-      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "1.6.0",
@@ -19369,15 +19359,6 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
-      }
-    },
-    "node_modules/nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "license": "ISC",
-      "dependencies": {
-        "big-integer": "^1.6.16"
       }
     },
     "node_modules/nanoid": {
@@ -19898,12 +19879,6 @@
       "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==",
-      "license": "MIT"
     },
     "node_modules/obuf": {
       "version": "1.1.2",
@@ -22729,32 +22704,6 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
     },
-    "node_modules/react-query": {
-      "version": "3.39.3",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
-      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -23498,12 +23447,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
     },
     "node_modules/renderkid": {
       "version": "3.0.0",
@@ -26417,16 +26360,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -26535,6 +26468,15 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/util": {
       "version": "0.12.5",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@jest/core": "^29.7.0",
-        "@tanstack/react-query": "^4.40.1",
+        "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-table": "^8.21.3",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/user-event": "^14.6.1",
@@ -5814,9 +5814,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.40.0.tgz",
-      "integrity": "sha512-7MJTtZkCSuehMC7IxMOCGsLvHS3jHx4WjveSrGsG1Nc1UQLjaFwwkpLA2LmPfvOAxnH4mszMOBFD6LlZE+aB+Q==",
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.0.tgz",
+      "integrity": "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5824,30 +5824,19 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.40.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.40.1.tgz",
-      "integrity": "sha512-mgD07S5N8e5v81CArKDWrHE4LM7HxZ9k/KLeD3+NUD9WimGZgKIqojUZf/rXkfAMYZU9p0Chzj2jOXm7xpgHHQ==",
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.0.tgz",
+      "integrity": "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "4.40.0",
-        "use-sync-external-store": "^1.2.0"
+        "@tanstack/query-core": "5.83.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -26468,15 +26457,6 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/util": {
       "version": "0.12.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@jest/core": "^29.7.0",
+    "@tanstack/react-query": "^4.40.1",
     "@tanstack/react-table": "^8.21.3",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/user-event": "^14.6.1",
@@ -18,7 +19,6 @@
     "react-hook-form": "^7.53.0",
     "react-icons": "^5.5.0",
     "react-inspector": "^6.0.2",
-    "react-query": "^3.39.3",
     "react-router-dom": "^6.26.1",
     "react-scripts": "5.0.1",
     "react-toastify": "^10.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@jest/core": "^29.7.0",
-    "@tanstack/react-query": "^4.40.1",
+    "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-table": "^8.21.3",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/src/fixtures/ourTableFixtures.js
+++ b/frontend/src/fixtures/ourTableFixtures.js
@@ -114,7 +114,7 @@ const ourTableFixtures = {
         header: "Actions",
         cell: (props) => (
           // You can access the entire row data using props.row.original
-          (<div>
+          <div>
             <button
               onClick={() => alert(`Editing ${props.row.original.firstName}`)}
             >
@@ -125,7 +125,7 @@ const ourTableFixtures = {
             >
               Delete
             </button>
-          </div>)
+          </div>
         ),
       }),
     ],

--- a/frontend/src/fixtures/ourTableFixtures.js
+++ b/frontend/src/fixtures/ourTableFixtures.js
@@ -114,7 +114,7 @@ const ourTableFixtures = {
         header: "Actions",
         cell: (props) => (
           // You can access the entire row data using props.row.original
-          <div>
+          (<div>
             <button
               onClick={() => alert(`Editing ${props.row.original.firstName}`)}
             >
@@ -125,7 +125,7 @@ const ourTableFixtures = {
             >
               Delete
             </button>
-          </div>
+          </div>)
         ),
       }),
     ],

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastContainer } from "react-toastify";
 
 const queryClient = new QueryClient();

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ToastContainer } from "react-toastify";
 
 const queryClient = new QueryClient();

--- a/frontend/src/main/pages/HomePageLoggedIn.js
+++ b/frontend/src/main/pages/HomePageLoggedIn.js
@@ -77,14 +77,14 @@ export default function HomePageLoggedIn() {
 
   const isStudentJoining = (cell) => {
     return (
-      studentJoinMutation.isLoading &&
+      studentJoinMutation.isPending &&
       studentJoinMutation.variables.row.index === cell.row.index
     );
   };
 
   const isStaffJoining = (cell) => {
     return (
-      staffJoinMutation.isLoading &&
+      staffJoinMutation.isPending &&
       staffJoinMutation.variables.row.index === cell.row.index
     );
   };

--- a/frontend/src/main/utils/currentUser.js
+++ b/frontend/src/main/utils/currentUser.js
@@ -1,11 +1,11 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 
 export function useCurrentUser() {
   let rolesList = ["ERROR_GETTING_ROLES"];
   const queryResults = useQuery({
-    queryKey: ['current user'],
+    queryKey: ["current user"],
     queryFn: async () => {
       try {
         const response = await axios.get("/api/currentUser");
@@ -28,10 +28,12 @@ export function useCurrentUser() {
 export function useLogout() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const mutation = useMutation(async () => {
-    await axios.post("/logout");
-    await queryClient.resetQueries({queryKey: ['current user']});
-    navigate("/");
+  const mutation = useMutation({
+    mutationFn: async () => {
+      await axios.post("/logout");
+      await queryClient.resetQueries({ queryKey: ["current user"] });
+      navigate("/");
+    },
   });
   return mutation;
 }

--- a/frontend/src/main/utils/currentUser.js
+++ b/frontend/src/main/utils/currentUser.js
@@ -1,12 +1,12 @@
-import { useMutation, useQuery, useQueryClient } from "react-query";
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 
 export function useCurrentUser() {
   let rolesList = ["ERROR_GETTING_ROLES"];
-  const queryResults = useQuery(
-    "current user",
-    async () => {
+  const queryResults = useQuery({
+    queryKey: ['current user'],
+    queryFn: async () => {
       try {
         const response = await axios.get("/api/currentUser");
         try {
@@ -20,10 +20,8 @@ export function useCurrentUser() {
         console.error("Error invoking axios.get: ", e);
       }
     },
-    {
-      initialData: { loggedIn: false, root: null, initialData: true },
-    },
-  );
+    initialData: { loggedIn: false, root: null, initialData: true },
+  });
   return queryResults.data;
 }
 
@@ -32,7 +30,7 @@ export function useLogout() {
   const navigate = useNavigate();
   const mutation = useMutation(async () => {
     await axios.post("/logout");
-    await queryClient.resetQueries("current user", { exact: true });
+    await queryClient.resetQueries({queryKey: ['current user']});
     navigate("/");
   });
   return mutation;

--- a/frontend/src/main/utils/systemInfo.js
+++ b/frontend/src/main/utils/systemInfo.js
@@ -1,10 +1,10 @@
-import { useQuery } from "react-query";
+import { useQuery } from '@tanstack/react-query';
 import axios from "axios";
 
 export function useSystemInfo() {
-  return useQuery(
-    "systemInfo",
-    async () => {
+  return useQuery({
+    queryKey: ["systemInfo"],
+    queryFn: async () => {
       try {
         const response = await axios.get("/api/systemInfo");
         return response.data;
@@ -13,12 +13,10 @@ export function useSystemInfo() {
         return {};
       }
     },
-    {
-      initialData: {
-        initialData: true,
-        springH2ConsoleEnabled: false,
-        showSwaggerUILink: false,
-      },
+    initialData: {
+      initialData: true,
+      springH2ConsoleEnabled: false,
+      showSwaggerUILink: false,
     },
-  );
+  });
 }

--- a/frontend/src/main/utils/systemInfo.js
+++ b/frontend/src/main/utils/systemInfo.js
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 
 export function useSystemInfo() {

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from "react-query";
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from "axios";
 import { toast } from "react-toastify";
 
@@ -31,25 +31,24 @@ export function useBackend(
   initialData,
   suppressToasts = false,
 ) {
-  return useQuery(
-    queryKey,
-    async () => {
-      try {
-        const response = await axios(axiosParameters);
-        return response.data;
-      } catch (e) {
-        const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
-        if (!suppressToasts) {
-          toast(errorMessage);
-        }
-        console.error(errorMessage, e);
-        throw e;
+  return useQuery({
+    queryKey: queryKey,
+    queryFn: async () =>
+  {
+    try {
+      const response = await axios(axiosParameters);
+      return response.data;
+    } catch (e) {
+      const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
+      if (!suppressToasts) {
+        toast(errorMessage);
       }
-    },
-    {
-      initialData,
-    },
-  );
+      console.error(errorMessage, e);
+      throw e;
+    }
+  },
+  initialData: initialData,
+});
 }
 
 // const wrappedParams = async (params) =>

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import { toast } from "react-toastify";
 
@@ -33,22 +33,21 @@ export function useBackend(
 ) {
   return useQuery({
     queryKey: queryKey,
-    queryFn: async () =>
-  {
-    try {
-      const response = await axios(axiosParameters);
-      return response.data;
-    } catch (e) {
-      const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
-      if (!suppressToasts) {
-        toast(errorMessage);
+    queryFn: async () => {
+      try {
+        const response = await axios(axiosParameters);
+        return response.data;
+      } catch (e) {
+        const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
+        if (!suppressToasts) {
+          toast(errorMessage);
+        }
+        console.error(errorMessage, e);
+        throw e;
       }
-      console.error(errorMessage, e);
-      throw e;
-    }
-  },
-  initialData: initialData,
-});
+    },
+    initialData: initialData,
+  });
 }
 
 // const wrappedParams = async (params) =>
@@ -67,13 +66,15 @@ export function useBackendMutation(
 ) {
   const queryClient = useQueryClient();
 
-  return useMutation((object) => wrappedParams(objectToAxiosParams(object)), {
+  return useMutation({
+    mutationFn: (object) => wrappedParams(objectToAxiosParams(object)),
     onError: (data) => {
       toast(`${data}`);
     },
     // Stryker disable all: Not sure how to set up the complex behavior needed to test this
     onSettled: () => {
-      if (queryKey !== null) queryClient.invalidateQueries(queryKey);
+      if (queryKey !== null)
+        queryClient.invalidateQueries({ queryKey: queryKey });
     },
     // Stryker restore all
     retry: false,

--- a/frontend/src/stories/pages/HomePageLoggedIn.stories.js
+++ b/frontend/src/stories/pages/HomePageLoggedIn.stories.js
@@ -1,7 +1,7 @@
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { http, HttpResponse } from "msw";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import HomePageLoggedIn from "main/pages/HomePageLoggedIn";
 import coursesFixtures from "fixtures/coursesFixtures";

--- a/frontend/src/stories/pages/HomePageLoggedIn.stories.js
+++ b/frontend/src/stories/pages/HomePageLoggedIn.stories.js
@@ -1,7 +1,7 @@
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { http, HttpResponse } from "msw";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import HomePageLoggedIn from "main/pages/HomePageLoggedIn";
 import coursesFixtures from "fixtures/coursesFixtures";

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 import {
   currentUserFixtures,

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import {
   currentUserFixtures,

--- a/frontend/src/tests/components/Nav/GithubLogin.test.js
+++ b/frontend/src/tests/components/Nav/GithubLogin.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 import {
   currentUserFixtures,

--- a/frontend/src/tests/components/Nav/GithubLogin.test.js
+++ b/frontend/src/tests/components/Nav/GithubLogin.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import {
   currentUserFixtures,

--- a/frontend/src/tests/components/Nav/GoogleLogin.test.js
+++ b/frontend/src/tests/components/Nav/GoogleLogin.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 

--- a/frontend/src/tests/components/Nav/GoogleLogin.test.js
+++ b/frontend/src/tests/components/Nav/GoogleLogin.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 

--- a/frontend/src/tests/components/RosterStudent/RosterStudentForm.test.js
+++ b/frontend/src/tests/components/RosterStudent/RosterStudentForm.test.js
@@ -4,7 +4,7 @@ import { BrowserRouter as Router } from "react-router-dom";
 import RosterStudentForm from "main/components/RosterStudent/RosterStudentForm";
 import { rosterStudentFixtures } from "fixtures/rosterStudentFixtures";
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const mockedNavigate = jest.fn();
 

--- a/frontend/src/tests/components/RosterStudent/RosterStudentForm.test.js
+++ b/frontend/src/tests/components/RosterStudent/RosterStudentForm.test.js
@@ -4,7 +4,7 @@ import { BrowserRouter as Router } from "react-router-dom";
 import RosterStudentForm from "main/components/RosterStudent/RosterStudentForm";
 import { rosterStudentFixtures } from "fixtures/rosterStudentFixtures";
 
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const mockedNavigate = jest.fn();
 

--- a/frontend/src/tests/components/RosterStudent/RosterStudentTable.test.js
+++ b/frontend/src/tests/components/RosterStudent/RosterStudentTable.test.js
@@ -1,7 +1,7 @@
 import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { rosterStudentFixtures } from "fixtures/rosterStudentFixtures";
 import RosterStudentTable from "main/components/RosterStudent/RosterStudentTable";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import axios from "axios";

--- a/frontend/src/tests/components/RosterStudent/RosterStudentTable.test.js
+++ b/frontend/src/tests/components/RosterStudent/RosterStudentTable.test.js
@@ -1,7 +1,7 @@
 import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { rosterStudentFixtures } from "fixtures/rosterStudentFixtures";
 import RosterStudentTable from "main/components/RosterStudent/RosterStudentTable";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import axios from "axios";

--- a/frontend/src/tests/components/Users/RoleEmailForm.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailForm.test.js
@@ -3,7 +3,7 @@ import { BrowserRouter as Router } from "react-router-dom";
 
 import RoleEmailForm from "main/components/Users/RoleEmailForm";
 
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const mockedNavigate = jest.fn();
 

--- a/frontend/src/tests/components/Users/RoleEmailForm.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailForm.test.js
@@ -3,7 +3,7 @@ import { BrowserRouter as Router } from "react-router-dom";
 
 import RoleEmailForm from "main/components/Users/RoleEmailForm";
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const mockedNavigate = jest.fn();
 

--- a/frontend/src/tests/components/Users/RoleEmailTable.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailTable.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import RoleEmailTable from "main/components/Users/RoleEmailTable";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
@@ -203,7 +203,9 @@ describe("RoleEmailTable", () => {
       email: "user1@example.org",
     });
     expect(invalidateQueriesSpy).toHaveBeenCalledTimes(1);
-    expect(invalidateQueriesSpy).toHaveBeenCalledWith(["/api/admin/all"]);
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["/api/admin/all"],
+    });
   });
 
   test("Check that api endpoint overrides work", async () => {
@@ -239,8 +241,8 @@ describe("RoleEmailTable", () => {
     });
 
     expect(invalidateQueriesSpy).toHaveBeenCalledTimes(1);
-    expect(invalidateQueriesSpy).toHaveBeenCalledWith([
-      "/api/admin/instructor/all",
-    ]);
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["/api/admin/instructor/all"],
+    });
   });
 });

--- a/frontend/src/tests/components/Users/RoleEmailTable.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailTable.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import RoleEmailTable from "main/components/Users/RoleEmailTable";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";

--- a/frontend/src/tests/pages/Admin/AdminUsersPage.test.js
+++ b/frontend/src/tests/pages/Admin/AdminUsersPage.test.js
@@ -1,5 +1,5 @@
 import { render, waitFor, screen } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import AdminUsersPage from "main/pages/Admin/AdminUsersPage";
 import usersFixtures from "fixtures/usersFixtures";

--- a/frontend/src/tests/pages/Admin/AdminUsersPage.test.js
+++ b/frontend/src/tests/pages/Admin/AdminUsersPage.test.js
@@ -1,5 +1,5 @@
 import { render, waitFor, screen } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 import AdminUsersPage from "main/pages/Admin/AdminUsersPage";
 import usersFixtures from "fixtures/usersFixtures";

--- a/frontend/src/tests/pages/Admin/AdminsCreatePage.test.js
+++ b/frontend/src/tests/pages/Admin/AdminsCreatePage.test.js
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import AdminsCreatePage from "main/pages/Admin/AdminsCreatePage";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/Admin/AdminsCreatePage.test.js
+++ b/frontend/src/tests/pages/Admin/AdminsCreatePage.test.js
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import AdminsCreatePage from "main/pages/Admin/AdminsCreatePage";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/Admin/AdminsIndexPage.test.js
+++ b/frontend/src/tests/pages/Admin/AdminsIndexPage.test.js
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import AdminsIndexPage from "main/pages/Admin/AdminsIndexPage";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import mockConsole from "jest-mock-console";
 import { roleEmailFixtures } from "fixtures/roleEmailFixtures";

--- a/frontend/src/tests/pages/Admin/AdminsIndexPage.test.js
+++ b/frontend/src/tests/pages/Admin/AdminsIndexPage.test.js
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import AdminsIndexPage from "main/pages/Admin/AdminsIndexPage";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 import mockConsole from "jest-mock-console";
 import { roleEmailFixtures } from "fixtures/roleEmailFixtures";

--- a/frontend/src/tests/pages/Admin/InstructorsCreatePage.test.js
+++ b/frontend/src/tests/pages/Admin/InstructorsCreatePage.test.js
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import InstructorsCreatePage from "main/pages/Admin/InstructorsCreatePage";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/Admin/InstructorsCreatePage.test.js
+++ b/frontend/src/tests/pages/Admin/InstructorsCreatePage.test.js
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import InstructorsCreatePage from "main/pages/Admin/InstructorsCreatePage";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/Admin/InstructorsIndexPage.test.js
+++ b/frontend/src/tests/pages/Admin/InstructorsIndexPage.test.js
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import InstructorsIndexPage from "main/pages/Admin/InstructorsIndexPage";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import mockConsole from "jest-mock-console";
 import { roleEmailFixtures } from "fixtures/roleEmailFixtures";

--- a/frontend/src/tests/pages/Admin/InstructorsIndexPage.test.js
+++ b/frontend/src/tests/pages/Admin/InstructorsIndexPage.test.js
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import InstructorsIndexPage from "main/pages/Admin/InstructorsIndexPage";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 import mockConsole from "jest-mock-console";
 import { roleEmailFixtures } from "fixtures/roleEmailFixtures";

--- a/frontend/src/tests/pages/Admin/LoadingPage.test.js
+++ b/frontend/src/tests/pages/Admin/LoadingPage.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";

--- a/frontend/src/tests/pages/Admin/LoadingPage.test.js
+++ b/frontend/src/tests/pages/Admin/LoadingPage.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";

--- a/frontend/src/tests/pages/Auth/SignInPage.test.js
+++ b/frontend/src/tests/pages/Auth/SignInPage.test.js
@@ -3,7 +3,7 @@ import axios from "axios";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { render, screen, within } from "@testing-library/react";
 import SignInPage from "main/pages/Auth/SignInPage";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 

--- a/frontend/src/tests/pages/Auth/SignInPage.test.js
+++ b/frontend/src/tests/pages/Auth/SignInPage.test.js
@@ -3,7 +3,7 @@ import axios from "axios";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { render, screen, within } from "@testing-library/react";
 import SignInPage from "main/pages/Auth/SignInPage";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 

--- a/frontend/src/tests/pages/Auth/SignInSuccessPage.test.js
+++ b/frontend/src/tests/pages/Auth/SignInSuccessPage.test.js
@@ -1,7 +1,7 @@
 import { render, waitFor, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import SignInSuccessPage from "main/pages/Auth/SignInSuccessPage";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import mockConsole from "jest-mock-console";
 
 const mockedNavigate = jest.fn();

--- a/frontend/src/tests/pages/Auth/SignInSuccessPage.test.js
+++ b/frontend/src/tests/pages/Auth/SignInSuccessPage.test.js
@@ -1,7 +1,7 @@
 import { render, waitFor, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import SignInSuccessPage from "main/pages/Auth/SignInSuccessPage";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import mockConsole from "jest-mock-console";
 
 const mockedNavigate = jest.fn();

--- a/frontend/src/tests/pages/HomePageConnectGithub.test.js
+++ b/frontend/src/tests/pages/HomePageConnectGithub.test.js
@@ -6,7 +6,7 @@ import {
   within,
 } from "@testing-library/react";
 import HomePageConnectGithub from "main/pages/HomePageConnectGithub";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/HomePageConnectGithub.test.js
+++ b/frontend/src/tests/pages/HomePageConnectGithub.test.js
@@ -65,7 +65,7 @@ describe("HomePageConnectGithub tests", () => {
     );
   });
   test("If systemInfo is not available, use the default githubOauthLogin", async () => {
-    axiosMock.onGet("/api/systemInfo").reply(200, undefined);
+    axiosMock.onGet("/api/systemInfo").reply(200, null);
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>

--- a/frontend/src/tests/pages/HomePageConnectGithub.test.js
+++ b/frontend/src/tests/pages/HomePageConnectGithub.test.js
@@ -6,7 +6,7 @@ import {
   within,
 } from "@testing-library/react";
 import HomePageConnectGithub from "main/pages/HomePageConnectGithub";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/HomePageLoggedIn.test.js
+++ b/frontend/src/tests/pages/HomePageLoggedIn.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 
 import axios from "axios";
@@ -157,11 +157,11 @@ describe("HomePageLoggedIn tests", () => {
       );
     });
 
-    expect(queryClient.getQueryState("/api/courses/list").dataUpdateCount).toBe(
+    expect(queryClient.getQueryState(['/api/courses/list']).dataUpdateCount).toBe(
       2,
     );
     expect(
-      queryClient.getQueryState("/api/courses/staffCourses").dataUpdateCount,
+      queryClient.getQueryState(['/api/courses/staffCourses']).dataUpdateCount,
     ).toBe(2);
   });
 

--- a/frontend/src/tests/pages/HomePageLoggedIn.test.js
+++ b/frontend/src/tests/pages/HomePageLoggedIn.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import axios from "axios";
@@ -157,11 +157,11 @@ describe("HomePageLoggedIn tests", () => {
       );
     });
 
-    expect(queryClient.getQueryState(['/api/courses/list']).dataUpdateCount).toBe(
-      2,
-    );
     expect(
-      queryClient.getQueryState(['/api/courses/staffCourses']).dataUpdateCount,
+      queryClient.getQueryState(["/api/courses/list"]).dataUpdateCount,
+    ).toBe(2);
+    expect(
+      queryClient.getQueryState(["/api/courses/staffCourses"]).dataUpdateCount,
     ).toBe(2);
   });
 

--- a/frontend/src/tests/pages/HomePageLoggedOut.test.js
+++ b/frontend/src/tests/pages/HomePageLoggedOut.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import HomePageLoggedOut from "main/pages/HomePageLoggedOut";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/HomePageLoggedOut.test.js
+++ b/frontend/src/tests/pages/HomePageLoggedOut.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import HomePageLoggedOut from "main/pages/HomePageLoggedOut";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
+++ b/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
@@ -7,7 +7,7 @@ import {
   within,
 } from "@testing-library/react";
 import InstructorCourseShowPage from "main/pages/Instructor/InstructorCourseShowPage";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import coursesFixtures from "fixtures/coursesFixtures";
 
@@ -266,8 +266,10 @@ describe("InstructorCourseShowPage tests", () => {
       </QueryClientProvider>,
     );
     //Great time to also check initial values
-    expect(queryClient.getQueryData(['/api/courses/7'])).toBe(null);
-    expect(queryClient.getQueryData(['/api/rosterstudents/course/7'])).toBe(null);
+    expect(queryClient.getQueryData(["/api/courses/7"])).toBe(null);
+    expect(queryClient.getQueryData(["/api/rosterstudents/course/7"])).toBe(
+      null,
+    );
 
     await screen.findByText(
       "Course not found. You will be returned to the course list in 3 seconds.",
@@ -420,9 +422,12 @@ describe("InstructorCourseShowPage tests", () => {
     );
     await screen.findByTestId("RosterStudentCSVUploadForm-upload");
 
-    const alternateUpdateCount =
-      queryClientSpecific.getQueryState(['/api/courses/7']).dataUpdateCount;
-    const updateCountStudent = queryClientSpecific.getQueryState(['/api/rosterstudents/course/7']).dataUpdateCount;
+    const alternateUpdateCount = queryClientSpecific.getQueryState([
+      "/api/courses/7",
+    ]).dataUpdateCount;
+    const updateCountStudent = queryClientSpecific.getQueryState([
+      "/api/rosterstudents/course/7",
+    ]).dataUpdateCount;
     const upload = screen.getByTestId("RosterStudentCSVUploadForm-upload");
     const submitButton = screen.getByTestId(
       "RosterStudentCSVUploadForm-submit",
@@ -437,10 +442,10 @@ describe("InstructorCourseShowPage tests", () => {
     expect(axiosMock.history.post[0].data.get("file")).toEqual(file);
     expect(mockToast).toBeCalledWith("Roster successfully updated.");
     expect(
-      queryClientSpecific.getQueryState(['/api/courses/7']).dataUpdateCount,
+      queryClientSpecific.getQueryState(["/api/courses/7"]).dataUpdateCount,
     ).toEqual(alternateUpdateCount);
     expect(
-      queryClientSpecific.getQueryState(['/api/rosterstudents/course/7'])
+      queryClientSpecific.getQueryState(["/api/rosterstudents/course/7"])
         .dataUpdateCount,
     ).toEqual(updateCountStudent + 1);
   });
@@ -482,9 +487,12 @@ describe("InstructorCourseShowPage tests", () => {
     );
 
     await screen.findAllByText("Student Id");
-    const alternateUpdateCount =
-      queryClientSpecific.getQueryState(['/api/courses/7']).dataUpdateCount;
-    const updateCountStudent = queryClientSpecific.getQueryState(['/api/rosterstudents/course/7']).dataUpdateCount;
+    const alternateUpdateCount = queryClientSpecific.getQueryState([
+      "/api/courses/7",
+    ]).dataUpdateCount;
+    const updateCountStudent = queryClientSpecific.getQueryState([
+      "/api/rosterstudents/course/7",
+    ]).dataUpdateCount;
     expect(screen.queryByText("Cancel")).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Student Id"), {
       target: { value: "123456789" },
@@ -510,10 +518,10 @@ describe("InstructorCourseShowPage tests", () => {
     await waitFor(() => expect(mockToast).toBeCalled());
     expect(mockToast).toBeCalledWith("Roster successfully updated.");
     expect(
-      queryClientSpecific.getQueryState(['/api/courses/7']).dataUpdateCount,
+      queryClientSpecific.getQueryState(["/api/courses/7"]).dataUpdateCount,
     ).toEqual(alternateUpdateCount);
     expect(
-      queryClientSpecific.getQueryState(['/api/rosterstudents/course/7'])
+      queryClientSpecific.getQueryState(["/api/rosterstudents/course/7"])
         .dataUpdateCount,
     ).toEqual(updateCountStudent + 1);
   });

--- a/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
+++ b/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
@@ -7,7 +7,7 @@ import {
   within,
 } from "@testing-library/react";
 import InstructorCourseShowPage from "main/pages/Instructor/InstructorCourseShowPage";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import coursesFixtures from "fixtures/coursesFixtures";
 
@@ -266,8 +266,8 @@ describe("InstructorCourseShowPage tests", () => {
       </QueryClientProvider>,
     );
     //Great time to also check initial values
-    expect(queryClient.getQueryData("/api/courses/7")).toBe(null);
-    expect(queryClient.getQueryData("/api/rosterstudents/course/7")).toBe(null);
+    expect(queryClient.getQueryData(['/api/courses/7'])).toBe(null);
+    expect(queryClient.getQueryData(['/api/rosterstudents/course/7'])).toBe(null);
 
     await screen.findByText(
       "Course not found. You will be returned to the course list in 3 seconds.",
@@ -421,10 +421,8 @@ describe("InstructorCourseShowPage tests", () => {
     await screen.findByTestId("RosterStudentCSVUploadForm-upload");
 
     const alternateUpdateCount =
-      queryClientSpecific.getQueryState("/api/courses/7").dataUpdateCount;
-    const updateCountStudent = queryClientSpecific.getQueryState(
-      "/api/rosterstudents/course/7",
-    ).dataUpdateCount;
+      queryClientSpecific.getQueryState(['/api/courses/7']).dataUpdateCount;
+    const updateCountStudent = queryClientSpecific.getQueryState(['/api/rosterstudents/course/7']).dataUpdateCount;
     const upload = screen.getByTestId("RosterStudentCSVUploadForm-upload");
     const submitButton = screen.getByTestId(
       "RosterStudentCSVUploadForm-submit",
@@ -439,10 +437,10 @@ describe("InstructorCourseShowPage tests", () => {
     expect(axiosMock.history.post[0].data.get("file")).toEqual(file);
     expect(mockToast).toBeCalledWith("Roster successfully updated.");
     expect(
-      queryClientSpecific.getQueryState("/api/courses/7").dataUpdateCount,
+      queryClientSpecific.getQueryState(['/api/courses/7']).dataUpdateCount,
     ).toEqual(alternateUpdateCount);
     expect(
-      queryClientSpecific.getQueryState("/api/rosterstudents/course/7")
+      queryClientSpecific.getQueryState(['/api/rosterstudents/course/7'])
         .dataUpdateCount,
     ).toEqual(updateCountStudent + 1);
   });
@@ -485,10 +483,8 @@ describe("InstructorCourseShowPage tests", () => {
 
     await screen.findAllByText("Student Id");
     const alternateUpdateCount =
-      queryClientSpecific.getQueryState("/api/courses/7").dataUpdateCount;
-    const updateCountStudent = queryClientSpecific.getQueryState(
-      "/api/rosterstudents/course/7",
-    ).dataUpdateCount;
+      queryClientSpecific.getQueryState(['/api/courses/7']).dataUpdateCount;
+    const updateCountStudent = queryClientSpecific.getQueryState(['/api/rosterstudents/course/7']).dataUpdateCount;
     expect(screen.queryByText("Cancel")).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Student Id"), {
       target: { value: "123456789" },
@@ -514,10 +510,10 @@ describe("InstructorCourseShowPage tests", () => {
     await waitFor(() => expect(mockToast).toBeCalled());
     expect(mockToast).toBeCalledWith("Roster successfully updated.");
     expect(
-      queryClientSpecific.getQueryState("/api/courses/7").dataUpdateCount,
+      queryClientSpecific.getQueryState(['/api/courses/7']).dataUpdateCount,
     ).toEqual(alternateUpdateCount);
     expect(
-      queryClientSpecific.getQueryState("/api/rosterstudents/course/7")
+      queryClientSpecific.getQueryState(['/api/rosterstudents/course/7'])
         .dataUpdateCount,
     ).toEqual(updateCountStudent + 1);
   });

--- a/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
+++ b/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
@@ -297,10 +297,17 @@ describe("InstructorCourseShowPage tests", () => {
     jest.useFakeTimers({
       advanceTimers: false,
     });
+    const specificQueryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
     const setTimeoutSpy = jest.spyOn(global, "setTimeout");
     const clearTimeoutSpy = jest.spyOn(global, "clearTimeout");
     render(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={specificQueryClient}>
         <MemoryRouter initialEntries={["/instructor/courses/7"]}>
           <Routes>
             <Route
@@ -324,11 +331,12 @@ describe("InstructorCourseShowPage tests", () => {
       within(screen.getByRole("navigation")).getByText("Frontiers"),
     );
     await waitFor(() =>
-      expect(clearTimeoutSpy.mock.results.length).toBeGreaterThanOrEqual(8),
+      expect(clearTimeoutSpy.mock.results.length).toBeGreaterThanOrEqual(12),
     );
     setTimeoutSpy.mockRestore();
     clearTimeoutSpy.mockRestore();
     jest.useRealTimers();
+    specificQueryClient.clear();
   });
 
   test("Tab assertions", () => {

--- a/frontend/src/tests/pages/Instructors/CoursesIndexPage.test.js
+++ b/frontend/src/tests/pages/Instructors/CoursesIndexPage.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import CoursesIndexPage from "main/pages/Instructors/CoursesIndexPage";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 import mockConsole from "jest-mock-console";
 import coursesFixtures from "fixtures/coursesFixtures";
@@ -222,7 +222,7 @@ describe("CoursesIndexPage tests", () => {
     await waitFor(() =>
       expect(mockToast).toBeCalledWith("Course CMPSC 156 created"),
     );
-    expect(queryClient.getQueryState("/api/courses/all")).toBeTruthy();
+    expect(queryClient.getQueryState(['/api/courses/all'])).toBeTruthy();
     expect(screen.queryByTestId("CourseModal-base")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/Instructors/CoursesIndexPage.test.js
+++ b/frontend/src/tests/pages/Instructors/CoursesIndexPage.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import CoursesIndexPage from "main/pages/Instructors/CoursesIndexPage";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import mockConsole from "jest-mock-console";
 import coursesFixtures from "fixtures/coursesFixtures";
@@ -222,7 +222,7 @@ describe("CoursesIndexPage tests", () => {
     await waitFor(() =>
       expect(mockToast).toBeCalledWith("Course CMPSC 156 created"),
     );
-    expect(queryClient.getQueryState(['/api/courses/all'])).toBeTruthy();
+    expect(queryClient.getQueryState(["/api/courses/all"])).toBeTruthy();
     expect(screen.queryByTestId("CourseModal-base")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import {
   apiCurrentUserFixtures,
@@ -118,10 +118,12 @@ describe("ProfilePage tests", () => {
       screen.getByText("Please only do so if you know what you're doing."),
     ).toBeInTheDocument();
     const fire = screen.getByText("Yes, I'd like to do this");
-    const updateCount =
-      queryClient.getQueryState(['current user']).dataUpdateCount;
-    const systemInfoCount =
-      queryClient.getQueryState(['systemInfo']).dataUpdateCount;
+    const updateCount = queryClient.getQueryState([
+      "current user",
+    ]).dataUpdateCount;
+    const systemInfoCount = queryClient.getQueryState([
+      "systemInfo",
+    ]).dataUpdateCount;
     fireEvent.click(fire);
     await waitFor(() =>
       expect(
@@ -133,10 +135,10 @@ describe("ProfilePage tests", () => {
     expect(mockToast).toBeCalledWith(
       "Disconnected from GitHub. You may now log in with a different account.",
     );
-    expect(queryClient.getQueryState(['current user']).dataUpdateCount).toBe(
+    expect(queryClient.getQueryState(["current user"]).dataUpdateCount).toBe(
       updateCount + 1,
     );
-    expect(queryClient.getQueryState(['systemInfo']).dataUpdateCount).toBe(
+    expect(queryClient.getQueryState(["systemInfo"]).dataUpdateCount).toBe(
       systemInfoCount,
     );
   });

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from "react-router-dom";
 import {
   apiCurrentUserFixtures,
@@ -119,9 +119,9 @@ describe("ProfilePage tests", () => {
     ).toBeInTheDocument();
     const fire = screen.getByText("Yes, I'd like to do this");
     const updateCount =
-      queryClient.getQueryState("current user").dataUpdateCount;
+      queryClient.getQueryState(['current user']).dataUpdateCount;
     const systemInfoCount =
-      queryClient.getQueryState("systemInfo").dataUpdateCount;
+      queryClient.getQueryState(['systemInfo']).dataUpdateCount;
     fireEvent.click(fire);
     await waitFor(() =>
       expect(
@@ -133,10 +133,10 @@ describe("ProfilePage tests", () => {
     expect(mockToast).toBeCalledWith(
       "Disconnected from GitHub. You may now log in with a different account.",
     );
-    expect(queryClient.getQueryState("current user").dataUpdateCount).toBe(
+    expect(queryClient.getQueryState(['current user']).dataUpdateCount).toBe(
       updateCount + 1,
     );
-    expect(queryClient.getQueryState("systemInfo").dataUpdateCount).toBe(
+    expect(queryClient.getQueryState(['systemInfo']).dataUpdateCount).toBe(
       systemInfoCount,
     );
   });

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useCurrentUser, useLogout, hasRole } from "main/utils/currentUser";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import {
@@ -35,7 +35,7 @@ describe("utils/currentUser tests", () => {
 
       const { result } = renderHook(() => useCurrentUser(), { wrapper });
       await waitFor(() =>
-        expect(queryClient.getQueryState("current user").status).toBe(
+        expect(queryClient.getQueryState(['current user']).status).toBe(
           "success",
         ),
       );
@@ -46,7 +46,7 @@ describe("utils/currentUser tests", () => {
         initialData: true,
       });
 
-      const queryState = queryClient.getQueryState("current user");
+      const queryState = queryClient.getQueryState(['current user']);
       expect(queryState).toBeDefined();
 
       queryClient.clear();
@@ -76,8 +76,8 @@ describe("utils/currentUser tests", () => {
       const { result } = renderHook(() => useCurrentUser(), { wrapper });
 
       await waitFor(() =>
-        expect(queryClient.getQueryState("current user").status).toBe(
-          "success",
+        expect(queryClient.getQueryState(['current user']).dataUpdateCount).toBe(
+          1,
         ),
       );
 
@@ -100,7 +100,7 @@ describe("utils/currentUser tests", () => {
       const { result } = renderHook(() => useCurrentUser(), { wrapper });
 
       await waitFor(() =>
-        expect(queryClient.getQueryState("current user").status).toBe(
+        expect(queryClient.getQueryState(['current user']).status).toBe(
           "success",
         ),
       );
@@ -133,8 +133,8 @@ describe("utils/currentUser tests", () => {
       const { result } = renderHook(() => useCurrentUser(), { wrapper });
 
       await waitFor(() =>
-        expect(queryClient.getQueryState("current user").status).toBe(
-          "success",
+        expect(queryClient.getQueryState(['current user']).dataUpdateCount).toBe(
+          1,
         ),
       );
       expect(console.error).toHaveBeenCalled();
@@ -176,9 +176,7 @@ describe("utils/currentUser tests", () => {
       await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith("/"));
 
       await waitFor(() =>
-        expect(resetQueriesSpy).toHaveBeenCalledWith("current user", {
-          exact: true,
-        }),
+        expect(resetQueriesSpy).toHaveBeenCalledWith({"queryKey": ["current user"]}),
       );
 
       queryClient.clear();

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useCurrentUser, useLogout, hasRole } from "main/utils/currentUser";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import {
@@ -35,7 +35,7 @@ describe("utils/currentUser tests", () => {
 
       const { result } = renderHook(() => useCurrentUser(), { wrapper });
       await waitFor(() =>
-        expect(queryClient.getQueryState(['current user']).status).toBe(
+        expect(queryClient.getQueryState(["current user"]).status).toBe(
           "success",
         ),
       );
@@ -46,7 +46,7 @@ describe("utils/currentUser tests", () => {
         initialData: true,
       });
 
-      const queryState = queryClient.getQueryState(['current user']);
+      const queryState = queryClient.getQueryState(["current user"]);
       expect(queryState).toBeDefined();
 
       queryClient.clear();
@@ -76,9 +76,9 @@ describe("utils/currentUser tests", () => {
       const { result } = renderHook(() => useCurrentUser(), { wrapper });
 
       await waitFor(() =>
-        expect(queryClient.getQueryState(['current user']).dataUpdateCount).toBe(
-          1,
-        ),
+        expect(
+          queryClient.getQueryState(["current user"]).dataUpdateCount,
+        ).toBe(1),
       );
 
       expect(result.current).toEqual(currentUserFixtures.userOnly);
@@ -100,7 +100,7 @@ describe("utils/currentUser tests", () => {
       const { result } = renderHook(() => useCurrentUser(), { wrapper });
 
       await waitFor(() =>
-        expect(queryClient.getQueryState(['current user']).status).toBe(
+        expect(queryClient.getQueryState(["current user"]).status).toBe(
           "success",
         ),
       );
@@ -133,9 +133,9 @@ describe("utils/currentUser tests", () => {
       const { result } = renderHook(() => useCurrentUser(), { wrapper });
 
       await waitFor(() =>
-        expect(queryClient.getQueryState(['current user']).dataUpdateCount).toBe(
-          1,
-        ),
+        expect(
+          queryClient.getQueryState(["current user"]).dataUpdateCount,
+        ).toBe(1),
       );
       expect(console.error).toHaveBeenCalled();
       const errorMessage = console.error.mock.calls[0][0];
@@ -176,7 +176,9 @@ describe("utils/currentUser tests", () => {
       await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith("/"));
 
       await waitFor(() =>
-        expect(resetQueriesSpy).toHaveBeenCalledWith({"queryKey": ["current user"]}),
+        expect(resetQueriesSpy).toHaveBeenCalledWith({
+          queryKey: ["current user"],
+        }),
       );
 
       queryClient.clear();

--- a/frontend/src/tests/utils/systemInfo.test.js
+++ b/frontend/src/tests/utils/systemInfo.test.js
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useSystemInfo } from "main/utils/systemInfo";
 import { renderHook } from "@testing-library/react";
 import mockConsole from "jest-mock-console";
@@ -39,7 +39,7 @@ describe("utils/systemInfo tests", () => {
         showSwaggerUILink: false,
       });
 
-      const queryState = queryClient.getQueryState(['systemInfo']);
+      const queryState = queryClient.getQueryState(["systemInfo"]);
       expect(queryState).toBeDefined();
 
       queryClient.clear();
@@ -65,7 +65,9 @@ describe("utils/systemInfo tests", () => {
 
       const { result } = renderHook(() => useSystemInfo(), { wrapper });
 
-      await waitFor(() => expect(result.current.isFetchedAfterMount).toBe(true));
+      await waitFor(() =>
+        expect(result.current.isFetchedAfterMount).toBe(true),
+      );
 
       expect(result.current.data).toEqual(systemInfoFixtures.showingBoth);
       queryClient.clear();

--- a/frontend/src/tests/utils/systemInfo.test.js
+++ b/frontend/src/tests/utils/systemInfo.test.js
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useSystemInfo } from "main/utils/systemInfo";
 import { renderHook } from "@testing-library/react";
 import mockConsole from "jest-mock-console";
@@ -39,7 +39,7 @@ describe("utils/systemInfo tests", () => {
         showSwaggerUILink: false,
       });
 
-      const queryState = queryClient.getQueryState("systemInfo");
+      const queryState = queryClient.getQueryState(['systemInfo']);
       expect(queryState).toBeDefined();
 
       queryClient.clear();
@@ -65,7 +65,7 @@ describe("utils/systemInfo tests", () => {
 
       const { result } = renderHook(() => useSystemInfo(), { wrapper });
 
-      await waitFor(() => result.current.isFetched);
+      await waitFor(() => expect(result.current.isFetchedAfterMount).toBe(true));
 
       expect(result.current.data).toEqual(systemInfoFixtures.showingBoth);
       queryClient.clear();

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor, act } from "@testing-library/react";
 
 import axios from "axios";
@@ -239,12 +239,11 @@ describe("utils/useBackend tests", () => {
         "Error: Request failed with status code 404",
       );
 
-      expect(console.error).toHaveBeenCalledTimes(2);
-      const errorMessage1 = console.error.mock.calls[0][0];
-      expect(errorMessage1.message).toMatch(
-        /Request failed with status code 404/,
-      );
-      const errorMessage2 = console.error.mock.calls[1][0];
+      console.log(console.error.mock.calls);
+      expect(console.error).toHaveBeenCalledTimes(1);
+      const errorMessage1 = console.error.mock.calls[0][1];
+      expect(errorMessage1).toMatch(/Request failed with status code 404/);
+      const errorMessage2 = console.error.mock.calls[0][0];
       expect(errorMessage2).toMatch(/onError from mutation.mutate called!/);
     });
   });

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor, act } from "@testing-library/react";
 
 import axios from "axios";


### PR DESCRIPTION
In this PR, I progressively jump our TanStack query version from v3 to v4, and then v4 to v5. This started as work on #242 , but along the way I think I discovered the cause of the actual development problems I was having.

Major changes:
Query keys must now be arrays, so "current user" has become `["current user"].
Query methods no longer are broken out as queryKey, queryFn, options, and are now {queryKey, queryFn, ...options}. useBackend, useCurrentUser, and useSystemInfo has been updated to match.

Additionally, the package is now `@tanstack/react-query` rather than `react-query`

Deployed to https://frontiers-qa2.dokku-00.cs.ucsb.edu/

# Guide for migration

If you are using this PR as a guide to migrate other CS156 Spring Boot projects that use the older version of react-query to the new version, here are some things to look for:

1. `npm uninstall react-query; npm install @tanstack/react-query`
2. Change `import { QueryClient, QueryClientProvider } from "react-query";` to `import { QueryClient, QueryClientProvider } from "@tanstack/react-query";` in every file where it occurs.
3. Change occurrences of `is_loading` to `is_pending`
4. Find every occurence of useQuery, and modify it as shown in this PR.  This will probably be limited to `useCurrentUser`, `useSysteminfo`, `useBackend`,  and `useBackendMutation`, but also, maybe not?
5. In tests where we are spying on the queryClient in order to test the invalidation of react query keys (replacing the old stryker mutations that we used to put in for these), you'll have to change the parameter passing format.  Look for code such as:
    ```
    invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries");
    ```
    Then change code like this:
    ```
    expect(invalidateQueriesSpy).toHaveBeenCalledWith(["/api/admin/all"]);
    ```

    to code like this:
    ```
    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
      queryKey: ["/api/admin/all"],
    });
    ```
    
6. If there are places where we are mocking the backend to produce `undefined`, we may instead want to mock the backend to return `null`; the new behavior is slightly different, and on `undefined` it may return the "initial data", rather than actually returning an undefined result.   
     
    Example:
    ```
    axiosMock.onGet("/api/systemInfo").reply(200, undefined);
    ```
    becomes:
    ```
    axiosMock.onGet("/api/systemInfo").reply(200, null);
    ```