### PR TITLE
Enforcing Internal React Router Navigation

### DIFF
--- a/frontend/src/main/components/Courses/InstructorCoursesTable.js
+++ b/frontend/src/main/components/Courses/InstructorCoursesTable.js
@@ -2,6 +2,7 @@ import OurTable from "main/components/OurTable";
 import { hasRole } from "main/utils/currentUser";
 import { Tooltip, OverlayTrigger, Button } from "react-bootstrap";
 import { FaGithub } from "react-icons/fa";
+import { Link } from "react-router-dom";
 
 const columns = [
   {
@@ -21,12 +22,12 @@ const columns = [
             </Tooltip>
           }
         >
-          <a
-            href={`/instructor/courses/${cell.row.original.id}`}
+          <Link
+            to={`/instructor/courses/${cell.row.original.id}`}
             data-testid={`CoursesTable-cell-row-${cell.row.index}-col-${cell.column.id}-link`}
           >
             {cell.row.original.courseName}
-          </a>
+          </Link>
         </OverlayTrigger>
       );
     },

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -59,11 +59,13 @@ export default function AppNavbar({
                   id="appnavbar-admin-dropdown"
                   data-testid="appnavbar-admin-dropdown"
                 >
-                  <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
-                  <NavDropdown.Item href="/admin/admins">
+                  <NavDropdown.Item as={Link} to="/admin/users">
+                    Users
+                  </NavDropdown.Item>
+                  <NavDropdown.Item as={Link} to="/admin/admins">
                     Admins
                   </NavDropdown.Item>
-                  <NavDropdown.Item href="/admin/instructors">
+                  <NavDropdown.Item as={Link} to="/admin/instructors">
                     Instructors
                   </NavDropdown.Item>
                 </NavDropdown>
@@ -74,7 +76,7 @@ export default function AppNavbar({
                   id="appnavbar-instructor-dropdown"
                   data-testid="appnavbar-instructor-dropdown"
                 >
-                  <NavDropdown.Item href="/instructor/courses">
+                  <NavDropdown.Item as={Link} to="/instructor/courses">
                     Courses
                   </NavDropdown.Item>
                 </NavDropdown>

--- a/frontend/src/main/pages/Admin/AdminsIndexPage.js
+++ b/frontend/src/main/pages/Admin/AdminsIndexPage.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { useBackend } from "main/utils/useBackend";
-
+import { Link } from "react-router-dom";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import RoleEmailTable from "main/components/Users/RoleEmailTable";
 import { Button } from "react-bootstrap";
@@ -22,7 +22,8 @@ export default function AdminsIndexPage() {
     return (
       <Button
         variant="primary"
-        href="/admin/admins/create"
+        as={Link}
+        to="/admin/admins/create"
         style={{ float: "right" }}
       >
         New Admin

--- a/frontend/src/main/pages/Admin/InstructorsIndexPage.js
+++ b/frontend/src/main/pages/Admin/InstructorsIndexPage.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { useBackend } from "main/utils/useBackend";
-
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import RoleEmailTable from "main/components/Users/RoleEmailTable";
 import { Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
 
 export default function InstructorsIndexPage() {
   const {
@@ -22,7 +22,8 @@ export default function InstructorsIndexPage() {
     return (
       <Button
         variant="primary"
-        href="/admin/instructors/create"
+        as={Link}
+        to="/admin/instructors/create"
         style={{ float: "right" }}
       >
         New Instructor


### PR DESCRIPTION
In this PR, I replace the href attributes in the Navbar and on various buttons with the `React-Router-Dom` `Link` instead to prevent unnecessary full-context reloads.

Since these are internal to the site, they should be navigation calls, rather than hrefs, which will cause the entire application to reload.

Testing Plan:
1. Try the urls on the navbar - make sure they still work.
2. Try out a link in a table and make sure they still work. 

Deployed to https://frontiers-qa3.dokku-00.cs.ucsb.edu/

Prep work for #242 