### PR TITLE
divyanipunj - Updated RosterStudentTable to include the GitHub login of the student. 

### DIFF
--- a/frontend/src/fixtures/rosterStudentFixtures.js
+++ b/frontend/src/fixtures/rosterStudentFixtures.js
@@ -41,6 +41,7 @@ const rosterStudentFixtures = {
       firstName: "Alice",
       lastName: "Brown",
       email: "alicebrown@ucsb.edu",
+      githubLogin: null,
       orgStatus: "PENDING",
     },
 
@@ -50,6 +51,7 @@ const rosterStudentFixtures = {
       firstName: "Tom",
       lastName: "Hanks",
       email: "tomhanks@ucsb.edu",
+      githubLogin: null,
       orgStatus: "JOINCOURSE",
     },
 
@@ -59,6 +61,7 @@ const rosterStudentFixtures = {
       firstName: "Emma",
       lastName: "Watson",
       email: "emmawatson@ucsb.edu",
+      githubLogin: null,
       orgStatus: "INVITED",
     },
     {
@@ -67,6 +70,7 @@ const rosterStudentFixtures = {
       firstName: "Jon",
       lastName: "Snow",
       email: "jonsnow@ucsb.edu",
+      githubLogin: "jonsnow",
       orgStatus: "OWNER",
     },
     {
@@ -75,6 +79,7 @@ const rosterStudentFixtures = {
       firstName: "Bob",
       lastName: "Smith",
       email: "bobsmith@ucsb.edu",
+      githubLogin: "bobsmith",
       orgStatus: "MEMBER",
     },
     {
@@ -83,6 +88,7 @@ const rosterStudentFixtures = {
       firstName: "Arya",
       lastName: "Sue",
       email: "aryasue@ucsb.edu",
+      githubLogin: "aryasue",
       orgStatus: "Illegal status that will never occur",
     },
   ],

--- a/frontend/src/main/components/RosterStudent/RosterStudentTable.js
+++ b/frontend/src/main/components/RosterStudent/RosterStudentTable.js
@@ -93,6 +93,10 @@ export default function RosterStudentTable({
       header: "Email",
       accessorKey: "email",
     },
+    {
+      header: "GitHub Login",
+      accessorKey: "githubLogin",
+    },
   ];
 
   const renderTooltip = (orgStatus) => (props) => {

--- a/frontend/src/tests/components/RosterStudent/RosterStudentTable.test.js
+++ b/frontend/src/tests/components/RosterStudent/RosterStudentTable.test.js
@@ -26,6 +26,7 @@ describe("RosterStudentTable tests", () => {
     "Last Name",
     "Email",
     "Status",
+    "GitHub Login",
   ];
   const expectedFields = [
     "id",
@@ -34,6 +35,7 @@ describe("RosterStudentTable tests", () => {
     "lastName",
     "email",
     "orgStatus",
+    "githubLogin",
   ];
   const testId = "RosterStudentTable";
 
@@ -124,6 +126,9 @@ describe("RosterStudentTable tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-email`),
     ).toHaveTextContent("alicebrown@ucsb.edu");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-3-col-githubLogin`),
+    ).toHaveTextContent("jonsnow");
 
     const pending = screen.getByText("Pending");
     expect(pending).toBeInTheDocument();


### PR DESCRIPTION
Closes #279.

### This PR: 
- Adds the _GitHub login_ as a column on RosterStudentTable and updates relevant tests (including the fixtures for roster student). 


Storybook: 
Dokku: 

### Test Plan (for interactive testing)
- View the RosterStudentTable with students of each status. Expect that you can view the GitHub IDs of **members** and **owners**.