### PR TITLE
pc - update workflows 13 and 14 to tolerate slashes in the branch name by changing them to hyphens

### DIFF
--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -35,13 +35,16 @@ jobs:
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_CLEANED}}"
           echo "branch_name=${BRANCH}"
           echo "branch_name=${BRANCH}" >> "$GITHUB_ENV"    
+          BRANCH_CLEANED=${BRANCH//\//-}
+          echo "branch_name_cleaned=${BRANCH_CLEANED}"
+          echo "branch_name_cleaned=${BRANCH_CLEANED}" >> "$GITHUB_ENV
     - name: Download artifact
       id: download-artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
         github_token: ${{secrets.GITHUB_TOKEN}}
         branch: ${{ env.branch_name }}
-        name: pitest-${{env.branch_name}}-history.bin
+        name: pitest-${{env.branch_name_cleaned}}-history.bin
         path: target/pit-history
         check_artifacts: true
         if_no_artifact_found: warn
@@ -59,7 +62,7 @@ jobs:
       if: always() # always upload artifacts, even if tests fail
       uses: actions/upload-artifact@v4
       with:
-        name: pitest-${{env.branch_name}}-history.bin
+        name: pitest-${{env.branch_name_cleaned}}-history.bin
         path: target/pit-history/history.bin
     - name: Upload Pitest Report to Artifacts
       if: always() # always upload artifacts, even if tests fail

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -35,9 +35,9 @@ jobs:
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_CLEANED}}"
           echo "branch_name=${BRANCH}"
           echo "branch_name=${BRANCH}" >> "$GITHUB_ENV"    
-          BRANCH_CLEANED=${BRANCH//\//-}
+          BRANCH_CLEANED="${BRANCH//\//-}"
           echo "branch_name_cleaned=${BRANCH_CLEANED}"
-          echo "branch_name_cleaned=${BRANCH_CLEANED}" >> "$GITHUB_ENV
+          echo "branch_name_cleaned=${BRANCH_CLEANED}" >> "$GITHUB_ENV"  
     - name: Download artifact
       id: download-artifact
       uses: dawidd6/action-download-artifact@v2.27.0

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -29,7 +29,10 @@ jobs:
           echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_CLEANED}}"
           echo "branch_name=${BRANCH}"
-          echo "branch_name=${BRANCH}" >> "$GITHUB_ENV"    
+          echo "branch_name=${BRANCH}" >> "$GITHUB_ENV"  
+          BRANCH_CLEANED=${BRANCH//\//-}
+          echo "branch_name_cleaned=${BRANCH_CLEANED}"
+          echo "branch_name_cleaned=${BRANCH_CLEANED}" >> "$GITHUB_ENV  
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v4
       with:
@@ -48,7 +51,7 @@ jobs:
       if: always() # always upload artifacts, even if tests fail
       uses: actions/upload-artifact@v4
       with:
-        name: pitest-${{env.branch_name}}-history.bin
+        name: pitest-${{env.branch_name_cleaned}}-history.bin
         path: target/pit-history/history.bin
     - name: Upload Pitest to Artifacts
       if: always() # always upload artifacts, even if tests fail

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -30,9 +30,9 @@ jobs:
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_CLEANED}}"
           echo "branch_name=${BRANCH}"
           echo "branch_name=${BRANCH}" >> "$GITHUB_ENV"  
-          BRANCH_CLEANED=${BRANCH//\//-}
+          BRANCH_CLEANED="${BRANCH//\//-}"
           echo "branch_name_cleaned=${BRANCH_CLEANED}"
-          echo "branch_name_cleaned=${BRANCH_CLEANED}" >> "$GITHUB_ENV  
+          echo "branch_name_cleaned=${BRANCH_CLEANED}" >> "$GITHUB_ENV"  
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
In this PR, we change two of the CI/CD workflows so that slashes in the branch name won't cause them to fail.

This is necessary to support the AI assistant Junie.