### PR TITLE
divyanipunj - Seperated the api/courses/all endpoint for admins and instructors 

### DIFF
--- a/frontend/src/main/pages/Instructors/CoursesIndexPage.js
+++ b/frontend/src/main/pages/Instructors/CoursesIndexPage.js
@@ -1,12 +1,9 @@
 import React from "react";
-import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { useBackend } from "main/utils/useBackend";
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import InstructorCoursesTable from "main/components/Courses/InstructorCoursesTable";
 import { useCurrentUser } from "main/utils/currentUser";
-import { Button } from "react-bootstrap";
-import { toast } from "react-toastify";
-import CourseModal from "main/components/Courses/CourseModal";
 
 export default function CoursesIndexPage() {
   const currentUser = useCurrentUser();
@@ -17,58 +14,16 @@ export default function CoursesIndexPage() {
     status: _status,
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
-    ["/api/courses/all"],
-    { method: "GET", url: "/api/courses/all" },
+    ["/api/courses/allForAdmins"],
+    { method: "GET", url: "/api/courses/allForAdmins" },
     // Stryker disable next-line all : don't test default value of empty list
     [],
   );
-
-  const [viewModal, setViewModal] = React.useState(false);
-
-  const objectToAxiosParams = (course) => ({
-    url: "/api/courses/post",
-    method: "POST",
-    params: {
-      courseName: course.courseName,
-      term: course.term,
-      school: course.school,
-    },
-  });
-
-  const onSuccess = (course) => {
-    toast(`Course ${course.courseName} created`);
-    setViewModal(false);
-  };
-
-  const mutation = useBackendMutation(
-    objectToAxiosParams,
-    { onSuccess },
-    // Stryker disable next-line all : hard to set up test for caching
-    ["/api/courses/all"],
-  );
-
-  const onSubmit = async (data) => {
-    mutation.mutate(data);
-  };
-
-  const createCourse = () => setViewModal(true);
 
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Courses</h1>
-        <Button
-          onClick={createCourse}
-          style={{ float: "right", marginBottom: 10 }}
-          variant="primary"
-        >
-          Create Course
-        </Button>
-        <CourseModal
-          showModal={viewModal}
-          toggleShowModal={setViewModal}
-          onSubmitAction={onSubmit}
-        />
         <InstructorCoursesTable courses={courses} currentUser={currentUser} />
       </div>
     </BasicLayout>

--- a/frontend/src/tests/pages/Instructors/CoursesIndexPage.test.js
+++ b/frontend/src/tests/pages/Instructors/CoursesIndexPage.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import CoursesIndexPage from "main/pages/Instructors/CoursesIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -32,15 +32,6 @@ describe("CoursesIndexPage tests", () => {
     queryClient.clear();
   });
 
-  const setupInstructorUser = () => {
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.instructorUser);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  };
-
   const setupAdminUser = () => {
     axiosMock
       .onGet("/api/currentUser")
@@ -52,53 +43,9 @@ describe("CoursesIndexPage tests", () => {
 
   const queryClient = new QueryClient();
 
-  test("renders correctly for instructor user", async () => {
-    setupInstructorUser();
-    axiosMock
-      .onGet("/api/courses/all")
-      .reply(200, coursesFixtures.severalCourses);
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <CoursesIndexPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId(`${testId}-cell-row-0-col-id`),
-      ).toHaveTextContent("1");
-    });
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
-      "2",
-    );
-    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
-      "3",
-    );
-
-    const orgName = screen.getByText("wsu-cpts489-fa20");
-    expect(orgName).toBeInTheDocument();
-
-    const button3 = screen.queryByTestId(
-      "InstructorCoursesTable-cell-row-2-col-orgName-button",
-    );
-    expect(button3).toBeInTheDocument();
-    expect(button3).toHaveTextContent("Install GitHub App");
-
-    // This one should not have a button because the instructor is not
-    // the creator of the course
-    const span4 = screen.getByTestId(
-      "InstructorCoursesTable-cell-row-3-col-orgName",
-    );
-    expect(span4).toBeInTheDocument();
-    expect(span4).toHaveTextContent("");
-  });
-
   test("Renders for admin user", async () => {
     setupAdminUser();
-    axiosMock.onGet("/api/courses/all").reply(200, []);
+    axiosMock.onGet("/api/courses/allForAdmins").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -116,7 +63,7 @@ describe("CoursesIndexPage tests", () => {
   test("renders correctly for admin user", async () => {
     setupAdminUser();
     axiosMock
-      .onGet("/api/courses/all")
+      .onGet("/api/courses/allForAdmins")
       .reply(200, coursesFixtures.severalCourses);
 
     render(
@@ -159,7 +106,7 @@ describe("CoursesIndexPage tests", () => {
   test("renders empty table when backend unavailable, admin only", async () => {
     setupAdminUser();
 
-    axiosMock.onGet("/api/courses/all").timeout();
+    axiosMock.onGet("/api/courses/allForAdmins").timeout();
 
     const restoreConsole = mockConsole();
 
@@ -177,52 +124,8 @@ describe("CoursesIndexPage tests", () => {
 
     const errorMessage = console.error.mock.calls[0][0];
     expect(errorMessage).toMatch(
-      "Error communicating with backend via GET on /api/courses/all",
+      "Error communicating with backend via GET on /api/courses/allForAdmins",
     );
     restoreConsole();
-  });
-
-  test("Can submit new course", async () => {
-    setupAdminUser();
-    axiosMock
-      .onPost("/api/courses/post")
-      .reply(200, coursesFixtures.severalCourses[0]);
-    axiosMock
-      .onGet("/api/courses/all")
-      .reply(200, coursesFixtures.severalCourses);
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <CoursesIndexPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-
-    const createCourse = screen.getByText("Create Course");
-    expect(createCourse).toHaveClass("btn btn-primary");
-    expect(createCourse).toHaveStyle("float: right; margin-bottom: 10px;");
-    fireEvent.click(createCourse);
-
-    await screen.findByLabelText("Course Name");
-    const courseName = screen.getByLabelText("Course Name");
-    const courseTerm = screen.getByLabelText("Term");
-    const school = screen.getByLabelText("School");
-    fireEvent.change(courseName, { target: { value: "CMPSC 156" } });
-    fireEvent.change(courseTerm, { target: { value: "Spring 2025" } });
-    fireEvent.change(school, { target: { value: "UCSB" } });
-    fireEvent.click(screen.getByText("Create"));
-    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
-    expect(axiosMock.history.post[0].url).toBe("/api/courses/post");
-    expect(axiosMock.history.post[0].params).toEqual({
-      courseName: "CMPSC 156",
-      term: "Spring 2025",
-      school: "UCSB",
-    });
-    await waitFor(() =>
-      expect(mockToast).toBeCalledWith("Course CMPSC 156 created"),
-    );
-    expect(queryClient.getQueryState(["/api/courses/all"])).toBeTruthy();
-    expect(screen.queryByTestId("CourseModal-base")).not.toBeInTheDocument();
   });
 });

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -118,27 +118,33 @@ public class CoursesController extends ApiController {
     /**
      * This method returns a list of courses.
      * 
-     * @return a list of all courses.
+     * @return a list of all courses for an instructor.
      */
-    @Operation(summary = "List all courses")
-    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_INSTRUCTOR')")
-    @GetMapping("/all")
-    public Iterable<InstructorCourseView> allCourses() {
-        List<Course> courses = null;
-        if (!isCurrentUserAdmin()) {
-            // if the user is not an admin, return only the courses they created
-            CurrentUser currentUser = getCurrentUser();
-            Long userId = currentUser.getUser().getId();
-            courses = courseRepository.findByCreatorId(userId);
-            // Convert to InstructorCourseView
-            List<InstructorCourseView> courseViews = courses.stream()
-                    .map(InstructorCourseView::new)
-                    .collect(Collectors.toList());
-            // Return as Iterable
-            return courseViews;
-        } else {
-            courses = courseRepository.findAll();
-        }
+    @Operation(summary = "List all courses for an instructor")
+    @PreAuthorize("hasRole('ROLE_INSTRUCTOR')")
+    @GetMapping("/allForInstructors")
+    public Iterable<InstructorCourseView> allForInstructors() {
+        CurrentUser currentUser = getCurrentUser();
+        Long userId = currentUser.getUser().getId();
+        List<Course> courses = courseRepository.findByCreatorId(userId);
+
+        List<InstructorCourseView> courseViews = courses.stream()
+                .map(InstructorCourseView::new)
+                .collect(Collectors.toList());
+        return courseViews;
+    }
+
+    /**
+     * This method returns a list of courses.
+     * 
+     * @return a list of all courses for an admin.
+     */
+    @Operation(summary = "List all courses for an admin")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/allForAdmins")
+    public Iterable<InstructorCourseView> allForAdmins() {
+        List<Course> courses = courseRepository.findAll();
+    
         List<InstructorCourseView> courseViews = courses.stream()
                 .map(InstructorCourseView::new)
                 .collect(Collectors.toList());

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
@@ -151,7 +151,7 @@ public class CoursesControllerTests extends ControllerTestCase {
         }
 
         /**
-         * Test the GET all endpoint for courses
+         * Test the GET all endpoint for courses for admins
          */
 
         @Test
@@ -178,7 +178,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // act
 
-                MvcResult response = mockMvc.perform(get("/api/courses/all"))
+                MvcResult response = mockMvc.perform(get("/api/courses/allForAdmins"))
                                 .andExpect(status().isOk())
                                 .andReturn();
 
@@ -190,7 +190,7 @@ public class CoursesControllerTests extends ControllerTestCase {
         }
 
         /**
-         * Test the GET endpoint
+         * Test the GET endpoint for courses for instructors
          */
 
         @Test
@@ -213,7 +213,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // act
 
-                MvcResult response = mockMvc.perform(get("/api/courses/all"))
+                MvcResult response = mockMvc.perform(get("/api/courses/allForInstructors"))
                                 .andExpect(status().isOk())
                                 .andReturn();
 


### PR DESCRIPTION
Works on #269 

### This PR: 
- Splits the api/courses/all endpoint into api/courses/allForAdmins and api/courses/allForInstructors
- Changes CoursesIndexPage to be an courses page for just admins rather than instructors and admins. The next PR for this issue will continue to refactor this page to be Admin facing and move it under _Admins_ on the NavBar. 

# Testing
Using swagger: 
-  Have two instructors create their own respective courses and then call api/courses/allForInstructors. The instructor should only see the courses they created.
- Login as an admin and return all courses. The admin should see all the courses that have been created. 