### PR TITLE
Adding the create-react-app addon to Storybook

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -6,7 +6,8 @@ const config = {
     "@storybook/addon-links",
     "@chromatic-com/storybook",
     "storybook-addon-remix-react-router",
-    "@storybook/addon-docs"
+    "@storybook/addon-docs",
+    "@storybook/preset-create-react-app"
   ],
   framework: {
     name: "@storybook/react-webpack5",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
         "@storybook/addon-docs": "^9.1.0",
         "@storybook/addon-links": "^9.1.0",
         "@storybook/addon-onboarding": "^9.1.0",
+        "@storybook/preset-create-react-app": "^9.1.1",
         "@storybook/react-webpack5": "^9.1.0",
         "@stryker-mutator/jest-runner": "^8.5.0",
         "@testing-library/react": "^16.0.0",
@@ -4745,6 +4746,41 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
+      }
+    },
+    "node_modules/@storybook/preset-create-react-app": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-create-react-app/-/preset-create-react-app-9.1.1.tgz",
+      "integrity": "sha512-ALf2cBV+pKfBjbCUg6a8HHfgXglKw+3dRKAnlwJDAlcF3xwrD/LnTPZnRs6uaXnbNrt4Onche/pbkboYOqzQ5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
+        "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
+        "@types/semver": "^7.5.6",
+        "pnp-webpack-plugin": "^1.7.0",
+        "semver": "^7.5.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react-scripts": ">=5.0.0",
+        "storybook": "^9.1.1"
+      }
+    },
+    "node_modules/@storybook/preset-create-react-app/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
@@ -20652,6 +20688,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/pnp-webpack-plugin": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.7.0.tgz",
+      "integrity": "sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-pnp": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -26092,6 +26141,21 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/ts-pnp": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
+      "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "@storybook/addon-docs": "^9.1.0",
     "@storybook/addon-links": "^9.1.0",
     "@storybook/addon-onboarding": "^9.1.0",
+    "@storybook/preset-create-react-app": "^9.1.1",
     "@storybook/react-webpack5": "^9.1.0",
     "@stryker-mutator/jest-runner": "^8.5.0",
     "@testing-library/react": "^16.0.0",


### PR DESCRIPTION
In this PR, I add the create-react-app storybook addon as instructed in the failing chromatic PR:
```
Command failed with exit code 1: npm run build-storybook -- --output-dir=/tmp/chromatic --webpack-stats-json=/tmp/chromatic
             Storybook support for Create React App is now a separate preset.
             To use the new preset, install `@storybook/preset-create-react-app` and add it to the list of `addons` in your `.storybook/main.js` config file.
             The built-in preset has been disabled in Storybook 6.0.
             No story files found for the specified pattern: src/**/*.mdx
```

Manual Chromatic Run: https://github.com/ucsb-cs156/proj-frontiers/actions/runs/16736389105


