### PR TITLE
Pc multiple csv formats

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,3 +1,4 @@
 This folder contains examples of files used as input to proj-frontiers
 
-* egrades.csv is an example (with fake data) of a roster for a course at UCSB, in the format provided to instructors on the `eGrades` web app.
+* `egrades.csv` is an example (with fake data) of a roster for a course at UCSB, in the format provided to instructors on the `eGrades` web app.
+* `chico_canvas.csv` is an example (with fake data) of a roster for a course at Chico State University in the format downloadble from Canvas at Chico State.

--- a/docs/examples/chico_canvas.csv
+++ b/docs/examples/chico_canvas.csv
@@ -1,0 +1,4 @@
+Student Name,Student ID,Student SIS ID,Email,Section Name
+Marge Simpson,88200,013228559,msimpson@csuchico.edu,CSED 500 - 362 Computational Thinking Summer 2025
+Homer Simpson,88001,013205354,hsimpson@csuchico.edu,CSED 500 - 362 Computational Thinking Summer 2025
+Ralph Wiggum,88003,013251642,rwiggum@csuchico.edu,CSED 500 - 362 Computational Thinking Summer 2025

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -8,6 +8,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,6 +80,43 @@ public class RosterStudentsController extends ApiController {
     @Autowired
     private CurrentUserService currentUserService;
 
+
+    public enum RosterSourceType {
+        UCSB_EGRADES,
+        CHICO_CANVAS,
+        UNKNOWN
+    }
+
+    public static final String UCSB_EGRADES_HEADERS = "Enrl Cd,Perm #,Grade,Final Units,Student Last,Student First Middle,Quarter,Course ID,Section,Meeting Time(s) / Location(s),Email,ClassLevel,Major1,Major2,Date/Time,Pronoun";
+    public static final String CHICO_CANVAS_HEADERS = "Student Name,Student ID,Student SIS ID,Email,Section Name";
+
+    public static RosterSourceType getRosterSourceType(String [] headers) {
+
+        Map<RosterSourceType, String[]> sourceTypeToHeaders = new HashMap<RosterSourceType, String[]>();
+        
+        sourceTypeToHeaders.put(RosterSourceType.UCSB_EGRADES, UCSB_EGRADES_HEADERS.split(","));
+        sourceTypeToHeaders.put(RosterSourceType.CHICO_CANVAS, CHICO_CANVAS_HEADERS.split(","));
+
+        for (Map.Entry<RosterSourceType, String[]> entry : sourceTypeToHeaders.entrySet()) {
+            RosterSourceType type = entry.getKey();
+            String[] expectedHeaders = entry.getValue();
+            if (headers.length >= expectedHeaders.length) {
+                boolean matches = true;
+                for (int i = 0; i < expectedHeaders.length; i++) {
+                    if (!expectedHeaders[i].equalsIgnoreCase(headers[i])) {
+                        matches = false;
+                        break;
+                    }
+                }
+                if (matches) {
+                    return type;
+                }
+            }
+        }
+        // If no known type matches, return UNKNOWN
+        return RosterSourceType.UNKNOWN;
+    }
+
     public static record UpsertResponse(InsertStatus insertStatus,RosterStudent rosterStudent){}
 
     /**
@@ -141,7 +179,7 @@ public class RosterStudentsController extends ApiController {
     @Operation(summary = "Upload Roster students for Course in UCSB Egrades Format")
     @PreAuthorize("hasRole('ROLE_INSTRUCTOR')")
     @PostMapping(value = "/upload/egrades", consumes = { "multipart/form-data" })
-    public Map<String, String> uploadRosterStudents(
+    public Map<String, String> uploadRosterStudentsUCSBEgrades(
             @Parameter(name = "courseId") @RequestParam Long courseId,
             @Parameter(name = "file") @RequestParam("file") MultipartFile file)
             throws JsonProcessingException, IOException, CsvException {
@@ -154,10 +192,18 @@ public class RosterStudentsController extends ApiController {
         try (InputStream inputStream = new BufferedInputStream(file.getInputStream());
                 InputStreamReader reader = new InputStreamReader(inputStream);
                 CSVReader csvReader = new CSVReader(reader);) {
-            csvReader.skip(2);
+
+            String [] headers = csvReader.readNext();
+            RosterSourceType sourceType = getRosterSourceType(headers);
+            if (sourceType == RosterSourceType.UNKNOWN) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown Roster Source Type");
+            }
+            if (sourceType == RosterSourceType.UCSB_EGRADES) {    
+                csvReader.skip(1);
+            }
             List<String[]> myEntries = csvReader.readAll();
             for (String[] row : myEntries) {
-                RosterStudent rosterStudent = fromEgradesCSVRow(row);
+                RosterStudent rosterStudent = fromCSVRow(row, sourceType);
                 UpsertResponse upsertResponse = upsertStudent(rosterStudent, course, RosterStatus.ROSTER);
                 InsertStatus s = upsertResponse.insertStatus; 
                 counts[s.ordinal()]++;
@@ -170,7 +216,17 @@ public class RosterStudentsController extends ApiController {
 
     }
 
-    public RosterStudent fromEgradesCSVRow(String[] row) {
+    public RosterStudent fromCSVRow(String[] row, RosterSourceType sourceType) {
+        if (sourceType == RosterSourceType.UCSB_EGRADES) {
+            return fromUCSBEgradesCSVRow(row);
+        } else if (sourceType == RosterSourceType.CHICO_CANVAS) {
+            return fromChicoCanvasCSVRow(row);
+        } else {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown Roster Source Type");
+        }
+    }
+    
+    public RosterStudent fromUCSBEgradesCSVRow(String[] row) {
         return RosterStudent.builder()
                 .firstName(row[5])
                 .lastName(row[4])
@@ -178,6 +234,43 @@ public class RosterStudentsController extends ApiController {
                 .email(row[10])
                 .build();
     }
+
+    /**
+     * Get everything except up to and not including the last space in the full name.  If the string contains no spaces, return an empty string.
+     * @param fullName
+     * @return
+     */
+    public static String getFirstName(String fullName) {
+        int lastSpaceIndex = fullName.lastIndexOf(" ");
+        if (lastSpaceIndex == -1) {
+            return ""; // No spaces found, return empty string
+        }
+        return fullName.substring(0, lastSpaceIndex).trim(); // Return everything before the last space
+    }
+
+    /**
+     * Get everything after the last space in the full name.  If the string contains no spaces, return the entire input string as the result.
+     * @param fullName
+     * @return best estimate of last name
+     */
+    public static String getLastName(String fullName) {
+        int lastSpaceIndex = fullName.lastIndexOf(" ");
+        if (lastSpaceIndex == -1) {
+            return fullName; // No spaces found, return the entire string
+        }
+        return fullName.substring(lastSpaceIndex + 1).trim(); // Return everything after the last space
+    }
+
+
+    public RosterStudent fromChicoCanvasCSVRow(String[] row) {
+        return RosterStudent.builder()
+                .firstName(getFirstName(row[0]))
+                .lastName(getLastName(row[0]))
+                .studentId(row[2])
+                .email(row[3])
+                .build();
+    }
+
 
     public UpsertResponse upsertStudent(RosterStudent student, Course course, RosterStatus rosterStatus) {
         String convertedEmail = CanonicalFormConverter.convertToValidEmail(student.getEmail());

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -178,7 +178,7 @@ public class RosterStudentsController extends ApiController {
      */
     @Operation(summary = "Upload Roster students for Course in UCSB Egrades Format")
     @PreAuthorize("hasRole('ROLE_INSTRUCTOR')")
-    @PostMapping(value = "/upload/egrades", consumes = { "multipart/form-data" })
+    @PostMapping(value = "/upload/csv", consumes = { "multipart/form-data" })
     public Map<String, String> uploadRosterStudentsUCSBEgrades(
             @Parameter(name = "courseId") @RequestParam Long courseId,
             @Parameter(name = "file") @RequestParam("file") MultipartFile file)
@@ -216,17 +216,17 @@ public class RosterStudentsController extends ApiController {
 
     }
 
-    public RosterStudent fromCSVRow(String[] row, RosterSourceType sourceType) {
+    public static RosterStudent fromCSVRow(String[] row, RosterSourceType sourceType) {
         if (sourceType == RosterSourceType.UCSB_EGRADES) {
             return fromUCSBEgradesCSVRow(row);
         } else if (sourceType == RosterSourceType.CHICO_CANVAS) {
             return fromChicoCanvasCSVRow(row);
         } else {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown Roster Source Type");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "CSV format not recognized");
         }
     }
     
-    public RosterStudent fromUCSBEgradesCSVRow(String[] row) {
+    public static RosterStudent fromUCSBEgradesCSVRow(String[] row) {
         return RosterStudent.builder()
                 .firstName(row[5])
                 .lastName(row[4])
@@ -262,7 +262,7 @@ public class RosterStudentsController extends ApiController {
     }
 
 
-    public RosterStudent fromChicoCanvasCSVRow(String[] row) {
+    public static RosterStudent fromChicoCanvasCSVRow(String[] row) {
         return RosterStudent.builder()
                 .firstName(getFirstName(row[0]))
                 .lastName(getLastName(row[0]))

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.frontiers.controllers;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -35,8 +37,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.controllers.RosterStudentsController.RosterSourceType;
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.Job;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
@@ -51,9 +55,11 @@ import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
 import edu.ucsb.cs156.frontiers.services.UpdateUserService;
 import edu.ucsb.cs156.frontiers.services.jobs.JobService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.server.ResponseStatusException;
+
 
 @Slf4j
-@WebMvcTest(controllers = {RosterStudentsController.class})
+@WebMvcTest(controllers = { RosterStudentsController.class })
 public class RosterStudentsControllerTests extends ControllerTestCase {
 
         @MockitoBean
@@ -114,6 +120,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                         .rosterStatus(RosterStatus.ROSTER)
                         .orgStatus(OrgStatus.PENDING)
                         .build();
+
         /**
          * Test the POST endpoint
          */
@@ -143,13 +150,14 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 verify(updateUserService, times(1)).attachUserToRosterStudent(eq(rs1));
 
                 String responseString = response.getResponse().getContentAsString();
-                RosterStudentsController.UpsertResponse upsertResponse = mapper.readValue(responseString, RosterStudentsController.UpsertResponse.class);
+                RosterStudentsController.UpsertResponse upsertResponse = mapper.readValue(responseString,
+                                RosterStudentsController.UpsertResponse.class);
                 assertEquals(RosterStudentsController.InsertStatus.INSERTED, upsertResponse.insertStatus());
                 assertEquals(rs1, upsertResponse.rosterStudent());
         }
 
         /**
-         * Test the POST endpoint when installation ID is null. 
+         * Test the POST endpoint when installation ID is null.
          */
         @Test
         @WithMockUser(roles = { "INSTRUCTOR" })
@@ -159,36 +167,38 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
 
                 ArgumentCaptor<RosterStudent> rosterStudentCaptor = ArgumentCaptor.forClass(RosterStudent.class);
 
-                when(rosterStudentRepository.save(any(RosterStudent.class))).thenAnswer(invocation -> invocation.getArgument(0)); 
+                when(rosterStudentRepository.save(any(RosterStudent.class)))
+                                .thenAnswer(invocation -> invocation.getArgument(0));
 
                 // act
-        
+
                 MvcResult response = mockMvc.perform(post("/api/rosterstudents/post")
-                        .with(csrf())
-                        .param("studentId", "A123456")
-                        .param("firstName", "Chris")
-                        .param("lastName", "Gaucho")
-                        .param("email", "cgaucho@example.org")
-                        .param("courseId", "1"))
-                        .andExpect(status().isOk())
-                        .andReturn();
+                                .with(csrf())
+                                .param("studentId", "A123456")
+                                .param("firstName", "Chris")
+                                .param("lastName", "Gaucho")
+                                .param("email", "cgaucho@example.org")
+                                .param("courseId", "1"))
+                                .andExpect(status().isOk())
+                                .andReturn();
 
                 // assert
                 verify(courseRepository, times(1)).findById(eq(1L));
                 verify(rosterStudentRepository, times(1)).save(rosterStudentCaptor.capture());
 
-                RosterStudent rosterStudentSaved = rosterStudentCaptor.getValue(); 
+                RosterStudent rosterStudentSaved = rosterStudentCaptor.getValue();
                 assertEquals(OrgStatus.PENDING, rosterStudentSaved.getOrgStatus());
 
                 String responseString = response.getResponse().getContentAsString();
-                RosterStudentsController.UpsertResponse upsertResponse = mapper.readValue(responseString, RosterStudentsController.UpsertResponse.class);
+                RosterStudentsController.UpsertResponse upsertResponse = mapper.readValue(responseString,
+                                RosterStudentsController.UpsertResponse.class);
                 assertEquals(RosterStudentsController.InsertStatus.INSERTED, upsertResponse.insertStatus());
                 assertEquals(rs1, upsertResponse.rosterStudent());
                 assertEquals(rosterStudentSaved, upsertResponse.rosterStudent());
         }
 
-         /**
-         * Test the POST endpoint when installation ID exists. 
+        /**
+         * Test the POST endpoint when installation ID exists.
          */
         @Test
         @WithMockUser(roles = { "INSTRUCTOR" })
@@ -198,25 +208,26 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
 
                 ArgumentCaptor<RosterStudent> rosterStudentCaptor = ArgumentCaptor.forClass(RosterStudent.class);
 
-                when(rosterStudentRepository.save(any(RosterStudent.class))).thenAnswer(invocation -> invocation.getArgument(0)); 
+                when(rosterStudentRepository.save(any(RosterStudent.class)))
+                                .thenAnswer(invocation -> invocation.getArgument(0));
 
                 // act
-        
+
                 MvcResult response = mockMvc.perform(post("/api/rosterstudents/post")
-                        .with(csrf())
-                        .param("studentId", "A123456")
-                        .param("firstName", "Chris")
-                        .param("lastName", "Gaucho")
-                        .param("email", "cgaucho@example.org")
-                        .param("courseId", "2"))
-                        .andExpect(status().isOk())
-                        .andReturn();
+                                .with(csrf())
+                                .param("studentId", "A123456")
+                                .param("firstName", "Chris")
+                                .param("lastName", "Gaucho")
+                                .param("email", "cgaucho@example.org")
+                                .param("courseId", "2"))
+                                .andExpect(status().isOk())
+                                .andReturn();
 
                 // assert
                 verify(courseRepository, times(1)).findById(eq(2L));
                 verify(rosterStudentRepository, times(1)).save(rosterStudentCaptor.capture());
 
-                RosterStudent rosterStudentSaved = rosterStudentCaptor.getValue(); 
+                RosterStudent rosterStudentSaved = rosterStudentCaptor.getValue();
                 assertEquals(OrgStatus.JOINCOURSE, rosterStudentSaved.getOrgStatus());
         }
 
@@ -311,7 +322,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
 
         /** Test whether instructor can upload students */
 
-        private final String sampleCSVContents = """
+        private final String sampleCSVContentsUCSB = """
                         Enrl Cd,Perm #,Grade,Final Units,Student Last,Student First Middle,Quarter,Course ID,Section,Meeting Time(s) / Location(s),Email,ClassLevel,Major1,Major2,Date/Time,Pronoun
 
                         08235,A123456,,4.0,GAUCHO,CHRIS FAKE,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,cgaucho@ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,
@@ -319,9 +330,146 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                         08243,1234567,,4.0,TARDE,SABADO,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,sabadotarde@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,He (He/Him/His)
                         """;
 
+        private final String sanmpleCSVContentsChico = """
+                        Student Name,Student ID,Student SIS ID,Email,Section Name
+                        Marge Simpson,88200,013228559,msimpson@csuchico.edu,CSED 500 - 362 Computational Thinking Summer 2025
+                        Homer Simpson,88001,013205354,hsimpson@csuchico.edu,CSED 500 - 362 Computational Thinking Summer 2025
+                        Ralph Wiggum,88003,013251642,rwiggum@csuchico.edu,CSED 500 - 362 Computational Thinking Summer 2025
+                        """;
+
+        private final String sampleUnknownCSVFormat = """
+                        Name,ID,SIS ID,University Email,Invalid Column Name
+                        Marge Simpson,88200,013228559,msimpson@csuchico.edu,CSED 500 - 362 Computational Thinking Summer 2025
+                        """;
+
         @WithMockUser(roles = { "INSTRUCTOR" })
         @Test
-        public void instructor_can_upload_students_for_an_existing_course() throws Exception {
+        public void instructor_can_upload_students_for_an_existing_course_chico() throws Exception {
+
+                // arrange
+
+                RosterStudent rs1BeforeWithId = RosterStudent.builder()
+                                .id(1L)
+                                .firstName("MARGE")
+                                .lastName("SIMPSON")
+                                .studentId("013228559")
+                                .email("msimpson@csuchico.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.MANUAL)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
+
+                RosterStudent rs1AfterWithId = RosterStudent.builder()
+                                .id(1L)
+                                .firstName("Marge")
+                                .lastName("Simpson")
+                                .studentId("013228559")
+                                .email("msimpson@csuchico.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
+
+                RosterStudent rs2BeforeWithId = RosterStudent.builder()
+                                .id(2L)
+                                .firstName("Homer")
+                                .lastName("Simpson")
+                                .studentId("013205354")
+                                .email("hsimpson@csuchico.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
+
+                RosterStudent rs2AfterWithId = RosterStudent.builder()
+                                .id(2L)
+                                .course(course1)
+                                .firstName("Homer")
+                                .lastName("Simpson")
+                                .email("hsimpson@csuchico.edu")
+                                .studentId("013205354")
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
+
+                RosterStudent rs3NoId = RosterStudent.builder()
+                                .course(course1)
+                                .firstName("Ralph")
+                                .lastName("Wiggum")
+                                .email("rwiggum@csuchico.edu")
+                                .studentId("013251642")
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
+
+                RosterStudent rs3WithId = RosterStudent.builder()
+                                .id(3L)
+                                .course(course1)
+                                .firstName("Ralph")
+                                .lastName("Wiggum")
+                                .email("rwiggum@csuchico.edu")
+                                .studentId("013251642")
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
+
+                MockMultipartFile file = new MockMultipartFile(
+                                "file",
+                                "roster.csv",
+                                MediaType.TEXT_PLAIN_VALUE,
+                                sanmpleCSVContentsChico.getBytes());
+
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));
+                when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("013228559")))
+                                .thenReturn(Optional.of(rs1BeforeWithId));
+                when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("013205354")))
+                                .thenReturn(Optional.of(rs2BeforeWithId));
+                when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("013251642")))
+                                .thenReturn(Optional.empty());
+
+                when(rosterStudentRepository.save(eq(rs1AfterWithId))).thenReturn(rs1AfterWithId);
+                when(rosterStudentRepository.save(eq(rs2AfterWithId))).thenReturn(rs2AfterWithId);
+                when(rosterStudentRepository.save(eq(rs3NoId))).thenReturn(rs3WithId);
+
+                doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs1AfterWithId));
+                doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs2AfterWithId));
+                doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs3WithId));
+
+                // act
+
+                MvcResult response = mockMvc
+                                .perform(multipart("/api/rosterstudents/upload/csv")
+                                                .file(file)
+                                                .param("courseId", "1")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(courseRepository, atLeastOnce()).findById(eq(1L));
+                verify(rosterStudentRepository, atLeastOnce()).findByCourseIdAndStudentId(eq(1L), eq("013228559"));
+                verify(rosterStudentRepository, atLeastOnce()).findByCourseIdAndStudentId(eq(1L), eq("013205354"));
+                verify(rosterStudentRepository, atLeastOnce()).findByCourseIdAndStudentId(eq(1L), eq("013251642"));
+                verify(rosterStudentRepository, atLeastOnce()).save(eq(rs1AfterWithId));
+                verify(rosterStudentRepository, atLeastOnce()).save(eq(rs2AfterWithId));
+                verify(rosterStudentRepository, atLeastOnce()).save(eq(rs3NoId));
+
+                verify(updateUserService, times(1)).attachUserToRosterStudent(eq(rs1AfterWithId));
+                verify(updateUserService, times(1)).attachUserToRosterStudent(eq(rs2AfterWithId));
+                verify(updateUserService, times(1)).attachUserToRosterStudent(eq(rs3WithId));
+
+                String responseString = response.getResponse().getContentAsString();
+                Map<String, String> expectedMap = Map.of(
+                                "filename", "roster.csv",
+                                "message", "Inserted 1 new students, Updated 2 students");
+                String expectedJson = mapper.writeValueAsString(expectedMap);
+                assertEquals(expectedJson, responseString);
+
+        }
+
+        @WithMockUser(roles = { "INSTRUCTOR" })
+        @Test
+        public void instructor_can_upload_students_for_an_existing_course_ucsb() throws Exception {
 
                 // arrange
 
@@ -392,9 +540,9 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
 
                 MockMultipartFile file = new MockMultipartFile(
                                 "file",
-                                "egrades.csv",
+                                "roster.csv",
                                 MediaType.TEXT_PLAIN_VALUE,
-                                sampleCSVContents.getBytes());
+                                sampleCSVContentsUCSB.getBytes());
 
                 when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));
                 when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("A123456")))
@@ -408,14 +556,14 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 when(rosterStudentRepository.save(eq(rs2AfterWithId))).thenReturn(rs2AfterWithId);
                 when(rosterStudentRepository.save(eq(rs3NoId))).thenReturn(rs3WithId);
 
-                doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs1AfterWithId));               
+                doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs1AfterWithId));
                 doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs2AfterWithId));
                 doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs3WithId));
 
                 // act
 
                 MvcResult response = mockMvc
-                                .perform(multipart("/api/rosterstudents/upload/egrades")
+                                .perform(multipart("/api/rosterstudents/upload/csv")
                                                 .file(file)
                                                 .param("courseId", "1")
                                                 .with(csrf()))
@@ -437,11 +585,36 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
 
                 String responseString = response.getResponse().getContentAsString();
                 Map<String, String> expectedMap = Map.of(
-                                "filename", "egrades.csv",
+                                "filename", "roster.csv",
                                 "message", "Inserted 1 new students, Updated 2 students");
                 String expectedJson = mapper.writeValueAsString(expectedMap);
                 assertEquals(expectedJson, responseString);
 
+        }
+
+        @WithMockUser(roles = { "INSTRUCTOR" })
+        @Test
+        public void unrecognized_csv_format_throws_an_exception() throws Exception {
+
+                MockMultipartFile file = new MockMultipartFile(
+                                "file",
+                                "roster.csv",
+                                MediaType.TEXT_PLAIN_VALUE,
+                                sampleUnknownCSVFormat.getBytes());
+
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));
+
+                // act
+
+                MvcResult response = mockMvc
+                                .perform(multipart("/api/rosterstudents/upload/csv")
+                                                .file(file)
+                                                .param("courseId", "1")
+                                                .with(csrf()))
+                                .andExpect(status().is4xxClientError()).andReturn();
+
+                String responseString = response.getResponse().getErrorMessage();
+                assertEquals("Unknown Roster Source Type", responseString);
         }
 
         /** Test that you cannot upload a roster for a course that does not exist */
@@ -454,16 +627,16 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
 
                 MockMultipartFile file = new MockMultipartFile(
                                 "file",
-                                "egrades.csv",
+                                "roster.csv",
                                 MediaType.TEXT_PLAIN_VALUE,
-                                sampleCSVContents.getBytes());
+                                sampleCSVContentsUCSB.getBytes());
 
                 when(courseRepository.findById(eq(1L))).thenReturn(Optional.empty());
 
                 // act
 
                 MvcResult response = mockMvc
-                                .perform(multipart("/api/rosterstudents/upload/egrades")
+                                .perform(multipart("/api/rosterstudents/upload/csv")
                                                 .file(file)
                                                 .param("courseId", "1")
                                                 .with(csrf()))
@@ -481,47 +654,49 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         }
 
         @Test
-        @WithMockUser(roles = {"INSTRUCTOR"})
+        @WithMockUser(roles = { "INSTRUCTOR" })
         public void just_no_org_name() throws Exception {
-                Course course = Course.builder().courseName("course").installationId("1234").creator(currentUserService.getUser()).build();
+                Course course = Course.builder().courseName("course").installationId("1234")
+                                .creator(currentUserService.getUser()).build();
                 doReturn(Optional.of(course)).when(courseRepository).findById(eq(2L));
                 MvcResult response = mockMvc.perform(post("/api/rosterstudents/updateCourseMembership")
                                 .with(csrf())
-                                .param("courseId", "2")
-                        ).andExpect(status().isBadRequest())
-                        .andReturn();
+                                .param("courseId", "2")).andExpect(status().isBadRequest())
+                                .andReturn();
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("NoLinkedOrganizationException", json.get("type"));
-                assertEquals("No linked GitHub Organization to course. Please link a GitHub Organization first.", json.get("message"));
+                assertEquals("No linked GitHub Organization to course. Please link a GitHub Organization first.",
+                                json.get("message"));
         }
 
         @Test
-        @WithMockUser(roles = {"INSTRUCTOR"})
+        @WithMockUser(roles = { "INSTRUCTOR" })
         public void not_registered_org() throws Exception {
-                Course course = Course.builder().courseName("course").orgName("ucsb-cs156").creator(currentUserService.getUser()).build();
+                Course course = Course.builder().courseName("course").orgName("ucsb-cs156")
+                                .creator(currentUserService.getUser()).build();
                 doReturn(Optional.of(course)).when(courseRepository).findById(eq(2L));
                 MvcResult response = mockMvc.perform(post("/api/rosterstudents/updateCourseMembership")
                                 .with(csrf())
-                                .param("courseId", "2")
-                        ).andExpect(status().isBadRequest())
-                        .andReturn();
+                                .param("courseId", "2")).andExpect(status().isBadRequest())
+                                .andReturn();
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("NoLinkedOrganizationException", json.get("type"));
-                assertEquals("No linked GitHub Organization to course. Please link a GitHub Organization first.", json.get("message"));
+                assertEquals("No linked GitHub Organization to course. Please link a GitHub Organization first.",
+                                json.get("message"));
         }
 
         @Test
-        @WithMockUser(roles = {"INSTRUCTOR"})
+        @WithMockUser(roles = { "INSTRUCTOR" })
         public void job_actually_fires() throws Exception {
-                Course course = Course.builder().id(2L).orgName("ucsb-cs156").installationId("1234").courseName("course").creator(currentUserService.getUser()).build();
+                Course course = Course.builder().id(2L).orgName("ucsb-cs156").installationId("1234")
+                                .courseName("course").creator(currentUserService.getUser()).build();
                 doReturn(Optional.of(course)).when(courseRepository).findById(eq(2L));
                 Job job = Job.builder().status("processing").build();
                 doReturn(job).when(service).runAsJob(any(UpdateOrgMembershipJob.class));
                 MvcResult response = mockMvc.perform(post("/api/rosterstudents/updateCourseMembership")
                                 .with(csrf())
-                                .param("courseId", "2")
-                        ).andExpect(status().isOk())
-                        .andReturn();
+                                .param("courseId", "2")).andExpect(status().isOk())
+                                .andReturn();
 
                 String expectedJson = objectMapper.writeValueAsString(job);
                 String actualJson = response.getResponse().getContentAsString();
@@ -529,14 +704,13 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         }
 
         @Test
-        @WithMockUser(roles = {"INSTRUCTOR"})
+        @WithMockUser(roles = { "INSTRUCTOR" })
         public void notFound() throws Exception {
                 doReturn(Optional.empty()).when(courseRepository).findById(eq(2L));
                 MvcResult response = mockMvc.perform(post("/api/rosterstudents/updateCourseMembership")
                                 .with(csrf())
-                                .param("courseId", "2")
-                        ).andExpect(status().isNotFound())
-                        .andReturn();
+                                .param("courseId", "2")).andExpect(status().isNotFound())
+                                .andReturn();
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("EntityNotFoundException", json.get("type"));
                 assertEquals("Course with id 2 not found", json.get("message"));
@@ -546,7 +720,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
          * Tests for the joinCourseOnGitHub endpoint
          */
         @Test
-        @WithMockUser(roles = { "USER", "GITHUB"})
+        @WithMockUser(roles = { "USER", "GITHUB" })
         public void testLinkGitHub_notFound() throws Exception {
                 // Arrange
                 when(rosterStudentRepository.findById(eq(99L))).thenReturn(Optional.empty());
@@ -555,8 +729,8 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/joinCourse")
                                 .with(csrf())
                                 .param("rosterStudentId", "99"))
-                        .andExpect(status().isNotFound())
-                        .andReturn();
+                                .andExpect(status().isNotFound())
+                                .andReturn();
 
                 // Assert
                 verify(rosterStudentRepository).findById(eq(99L));
@@ -564,33 +738,33 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 // Verify correct error response
                 String responseString = response.getResponse().getContentAsString();
                 Map<String, String> expectedMap = Map.of(
-                        "type", "EntityNotFoundException",
-                        "message", "RosterStudent with id 99 not found");
+                                "type", "EntityNotFoundException",
+                                "message", "RosterStudent with id 99 not found");
                 String expectedJson = mapper.writeValueAsString(expectedMap);
                 assertEquals(expectedJson, responseString);
         }
 
         @Test
-        @WithMockUser(roles = { "USER", "GITHUB"})
+        @WithMockUser(roles = { "USER", "GITHUB" })
         public void testJoinCourseOnGitHub_unauthorized() throws Exception {
                 // Arrange
                 User currentUser = currentUserService.getUser();
 
                 User differentUser = User.builder()
-                        .id(-1L)  // Different from current user
-                        .build();
+                                .id(-1L) // Different from current user
+                                .build();
 
                 RosterStudent rosterStudent = RosterStudent.builder()
-                        .id(4L)
-                        .firstName("Other")
-                        .lastName("Student")
-                        .studentId("A666666")
-                        .email("otherstudent@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .user(differentUser)  // Belongs to a different user
-                        .build();
+                                .id(4L)
+                                .firstName("Other")
+                                .lastName("Student")
+                                .studentId("A666666")
+                                .email("otherstudent@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .user(differentUser) // Belongs to a different user
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(4L))).thenReturn(Optional.of(rosterStudent));
 
@@ -598,31 +772,31 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 mockMvc.perform(put("/api/rosterstudents/joinCourse")
                                 .with(csrf())
                                 .param("rosterStudentId", "4"))
-                        .andExpect(status().isForbidden());
+                                .andExpect(status().isForbidden());
 
                 // Verify nothing was saved
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
         }
 
         @Test
-        @WithMockUser(roles = { "USER", "GITHUB"})
+        @WithMockUser(roles = { "USER", "GITHUB" })
         public void testJoinCourseOnGitHub_alreadyJoined() throws Exception {
                 // Arrange
                 User currentUser = currentUserService.getUser();
 
                 RosterStudent rosterStudent = RosterStudent.builder()
-                        .id(5L)
-                        .firstName("Already")
-                        .lastName("Linked")
-                        .studentId("A777777")
-                        .email("alreadylinked@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.MEMBER)
-                        .githubId(98765)  // Already has a GitHub ID
-                        .githubLogin("existinguser")  // Already has a GitHub login
-                        .user(currentUser)  // Current user owns this roster entry
-                        .build();
+                                .id(5L)
+                                .firstName("Already")
+                                .lastName("Linked")
+                                .studentId("A777777")
+                                .email("alreadylinked@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.MEMBER)
+                                .githubId(98765) // Already has a GitHub ID
+                                .githubLogin("existinguser") // Already has a GitHub login
+                                .user(currentUser) // Current user owns this roster entry
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(5L))).thenReturn(Optional.of(rosterStudent));
 
@@ -630,36 +804,37 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/joinCourse")
                                 .with(csrf())
                                 .param("rosterStudentId", "5"))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 // Assert
                 verify(rosterStudentRepository).findById(eq(5L));
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
                 verify(organizationMemberService, times(0)).inviteOrganizationMember(any(RosterStudent.class));
 
-                assertEquals("This user has already linked a Github account to this course.", response.getResponse().getContentAsString());
+                assertEquals("This user has already linked a Github account to this course.",
+                                response.getResponse().getContentAsString());
         }
 
         @Test
-        @WithMockUser(roles = { "USER", "GITHUB"})
+        @WithMockUser(roles = { "USER", "GITHUB" })
         public void testJoinCourseOnGitHub_alreadyJoined_Owner() throws Exception {
                 // Arrange
                 User currentUser = currentUserService.getUser();
 
                 RosterStudent rosterStudent = RosterStudent.builder()
-                        .id(5L)
-                        .firstName("Already")
-                        .lastName("Linked")
-                        .studentId("A777777")
-                        .email("alreadylinked@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.OWNER)
-                        .githubId(98765)  // Already has a GitHub ID
-                        .githubLogin("existinguser")  // Already has a GitHub login
-                        .user(currentUser)  // Current user owns this roster entry
-                        .build();
+                                .id(5L)
+                                .firstName("Already")
+                                .lastName("Linked")
+                                .studentId("A777777")
+                                .email("alreadylinked@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.OWNER)
+                                .githubId(98765) // Already has a GitHub ID
+                                .githubLogin("existinguser") // Already has a GitHub login
+                                .user(currentUser) // Current user owns this roster entry
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(5L))).thenReturn(Optional.of(rosterStudent));
 
@@ -667,53 +842,53 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/joinCourse")
                                 .with(csrf())
                                 .param("rosterStudentId", "5"))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 // Assert
                 verify(rosterStudentRepository).findById(eq(5L));
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
                 verify(organizationMemberService, times(0)).inviteOrganizationMember(any(RosterStudent.class));
 
-                assertEquals("This user has already linked a Github account to this course.", response.getResponse().getContentAsString());
+                assertEquals("This user has already linked a Github account to this course.",
+                                response.getResponse().getContentAsString());
         }
 
-
-
         @Test
-        @WithMockUser(roles = { "USER", "GITHUB"})
+        @WithMockUser(roles = { "USER", "GITHUB" })
         public void no_fire_on_no_org_name() throws Exception {
                 User currentUser = currentUserService.getUser();
 
-                Course course2 = Course.builder().id(2L).installationId("1234").courseName("course").creator(currentUser).build();
+                Course course2 = Course.builder().id(2L).installationId("1234").courseName("course")
+                                .creator(currentUser).build();
 
                 RosterStudent rosterStudent = RosterStudent.builder()
-                        .id(3L)
-                        .firstName("Test")
-                        .lastName("User")
-                        .studentId("A555555")
-                        .email("testuser@ucsb.edu")
-                        .course(course2)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .githubId(0)  // Not linked yet
-                        .githubLogin("login")  // Not linked yet
-                        .user(currentUser)  // Current user owns this roster entry
-                        .build();
+                                .id(3L)
+                                .firstName("Test")
+                                .lastName("User")
+                                .studentId("A555555")
+                                .email("testuser@ucsb.edu")
+                                .course(course2)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .githubId(0) // Not linked yet
+                                .githubLogin("login") // Not linked yet
+                                .user(currentUser) // Current user owns this roster entry
+                                .build();
 
                 RosterStudent rosterStudentUpdated = RosterStudent.builder()
-                        .id(3L)
-                        .firstName("Test")
-                        .lastName("User")
-                        .studentId("A555555")
-                        .email("testuser@ucsb.edu")
-                        .course(course2)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .githubId(currentUser.getGithubId())
-                        .githubLogin(currentUser.getGithubLogin())
-                        .user(currentUser)
-                        .build();
+                                .id(3L)
+                                .firstName("Test")
+                                .lastName("User")
+                                .studentId("A555555")
+                                .email("testuser@ucsb.edu")
+                                .course(course2)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .githubId(currentUser.getGithubId())
+                                .githubLogin(currentUser.getGithubLogin())
+                                .user(currentUser)
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(3L))).thenReturn(Optional.of(rosterStudent));
 
@@ -721,8 +896,8 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/joinCourse")
                                 .with(csrf())
                                 .param("rosterStudentId", "3"))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 // Assert
                 verify(rosterStudentRepository).findById(eq(3L));
@@ -731,41 +906,42 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 verify(rosterStudentRepository, times(0)).save(eq(rosterStudentUpdated));
                 verify(organizationMemberService, times(0)).inviteOrganizationMember(any(RosterStudent.class));
 
-                assertEquals("Course has not been set up. Please ask your instructor for help.", response.getResponse().getContentAsString());
+                assertEquals("Course has not been set up. Please ask your instructor for help.",
+                                response.getResponse().getContentAsString());
         }
 
         @Test
-        @WithMockUser(roles = { "USER", "GITHUB"})
+        @WithMockUser(roles = { "USER", "GITHUB" })
         public void no_fire_on_no_installation_id() throws Exception {
                 User currentUser = currentUserService.getUser();
 
                 RosterStudent rosterStudent = RosterStudent.builder()
-                        .id(3L)
-                        .firstName("Test")
-                        .lastName("User")
-                        .studentId("A555555")
-                        .email("testuser@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .githubId(123456789)  
-                        .githubLogin(null) 
-                        .user(currentUser) 
-                        .build();
+                                .id(3L)
+                                .firstName("Test")
+                                .lastName("User")
+                                .studentId("A555555")
+                                .email("testuser@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .githubId(123456789)
+                                .githubLogin(null)
+                                .user(currentUser)
+                                .build();
 
                 RosterStudent rosterStudentUpdated = RosterStudent.builder()
-                        .id(3L)
-                        .firstName("Test")
-                        .lastName("User")
-                        .studentId("A555555")
-                        .email("testuser@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .githubId(currentUser.getGithubId())
-                        .githubLogin(currentUser.getGithubLogin())
-                        .user(currentUser)
-                        .build();
+                                .id(3L)
+                                .firstName("Test")
+                                .lastName("User")
+                                .studentId("A555555")
+                                .email("testuser@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .githubId(currentUser.getGithubId())
+                                .githubLogin(currentUser.getGithubLogin())
+                                .user(currentUser)
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(3L))).thenReturn(Optional.of(rosterStudent));
 
@@ -773,8 +949,8 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/joinCourse")
                                 .with(csrf())
                                 .param("rosterStudentId", "3"))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 // Assert
                 verify(rosterStudentRepository).findById(eq(3L));
@@ -783,220 +959,228 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 verify(rosterStudentRepository, times(0)).save(eq(rosterStudentUpdated));
                 verify(organizationMemberService, times(0)).inviteOrganizationMember(any(RosterStudent.class));
 
-                assertEquals("Course has not been set up. Please ask your instructor for help.", response.getResponse().getContentAsString());
+                assertEquals("Course has not been set up. Please ask your instructor for help.",
+                                response.getResponse().getContentAsString());
         }
 
         @Test
-        @WithMockUser(roles = { "USER", "GITHUB"})
+        @WithMockUser(roles = { "USER", "GITHUB" })
         public void test_fires_invite() throws Exception {
                 User currentUser = currentUserService.getUser();
 
-                Course course2 = Course.builder().id(2L).installationId("1234").orgName("ucsb-cs156").courseName("course").creator(currentUser).build();
+                Course course2 = Course.builder().id(2L).installationId("1234").orgName("ucsb-cs156")
+                                .courseName("course").creator(currentUser).build();
 
                 RosterStudent rosterStudent = RosterStudent.builder()
-                        .id(3L)
-                        .firstName("Test")
-                        .lastName("User")
-                        .studentId("A555555")
-                        .email("testuser@ucsb.edu")
-                        .course(course2)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.JOINCOURSE)
-                        .githubId(null)  // Not linked yet
-                        .githubLogin(null)  // Not linked yet
-                        .user(currentUser)  // Current user owns this roster entry
-                        .build();
+                                .id(3L)
+                                .firstName("Test")
+                                .lastName("User")
+                                .studentId("A555555")
+                                .email("testuser@ucsb.edu")
+                                .course(course2)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.JOINCOURSE)
+                                .githubId(null) // Not linked yet
+                                .githubLogin(null) // Not linked yet
+                                .user(currentUser) // Current user owns this roster entry
+                                .build();
 
                 RosterStudent rosterStudentUpdated = RosterStudent.builder()
-                        .id(3L)
-                        .firstName("Test")
-                        .lastName("User")
-                        .studentId("A555555")
-                        .email("testuser@ucsb.edu")
-                        .course(course2)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.INVITED)
-                        .githubId(currentUser.getGithubId())
-                        .githubLogin(currentUser.getGithubLogin())
-                        .user(currentUser)
-                        .build();
+                                .id(3L)
+                                .firstName("Test")
+                                .lastName("User")
+                                .studentId("A555555")
+                                .email("testuser@ucsb.edu")
+                                .course(course2)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.INVITED)
+                                .githubId(currentUser.getGithubId())
+                                .githubLogin(currentUser.getGithubLogin())
+                                .user(currentUser)
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(3L))).thenReturn(Optional.of(rosterStudent));
                 when(rosterStudentRepository.save(eq(rosterStudentUpdated))).thenReturn(rosterStudentUpdated);
-                when(organizationMemberService.inviteOrganizationMember(any(RosterStudent.class))).thenReturn(OrgStatus.INVITED);
+                when(organizationMemberService.inviteOrganizationMember(any(RosterStudent.class)))
+                                .thenReturn(OrgStatus.INVITED);
 
                 // Act
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/joinCourse")
                                 .with(csrf())
                                 .param("rosterStudentId", "3"))
-                        .andExpect(status().isAccepted())
-                        .andReturn();
-
+                                .andExpect(status().isAccepted())
+                                .andReturn();
 
                 // Assert
                 verify(rosterStudentRepository).findById(eq(3L));
 
                 // Verify the GitHub ID and login were set
                 verify(rosterStudentRepository, times(1)).save(eq(rosterStudentUpdated));
-                assertEquals("Successfully invited student to Organization", response.getResponse().getContentAsString());
+                assertEquals("Successfully invited student to Organization",
+                                response.getResponse().getContentAsString());
         }
 
         @Test
-        @WithMockUser(roles = { "USER", "GITHUB"})
+        @WithMockUser(roles = { "USER", "GITHUB" })
         public void test_already_part_is_member() throws Exception {
                 User currentUser = currentUserService.getUser();
 
-                Course course2 = Course.builder().id(2L).installationId("1234").orgName("ucsb-cs156").courseName("course").creator(currentUser).build();
+                Course course2 = Course.builder().id(2L).installationId("1234").orgName("ucsb-cs156")
+                                .courseName("course").creator(currentUser).build();
 
                 RosterStudent rosterStudent = RosterStudent.builder()
-                        .id(3L)
-                        .firstName("Test")
-                        .lastName("User")
-                        .studentId("A555555")
-                        .email("testuser@ucsb.edu")
-                        .course(course2)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.JOINCOURSE)
-                        .githubId(null)  // Not linked yet
-                        .githubLogin(null)  // Not linked yet
-                        .user(currentUser)  // Current user owns this roster entry
-                        .build();
+                                .id(3L)
+                                .firstName("Test")
+                                .lastName("User")
+                                .studentId("A555555")
+                                .email("testuser@ucsb.edu")
+                                .course(course2)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.JOINCOURSE)
+                                .githubId(null) // Not linked yet
+                                .githubLogin(null) // Not linked yet
+                                .user(currentUser) // Current user owns this roster entry
+                                .build();
 
                 RosterStudent rosterStudentUpdated = RosterStudent.builder()
-                        .id(3L)
-                        .firstName("Test")
-                        .lastName("User")
-                        .studentId("A555555")
-                        .email("testuser@ucsb.edu")
-                        .course(course2)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.MEMBER)
-                        .githubId(currentUser.getGithubId())
-                        .githubLogin(currentUser.getGithubLogin())
-                        .user(currentUser)
-                        .build();
+                                .id(3L)
+                                .firstName("Test")
+                                .lastName("User")
+                                .studentId("A555555")
+                                .email("testuser@ucsb.edu")
+                                .course(course2)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.MEMBER)
+                                .githubId(currentUser.getGithubId())
+                                .githubLogin(currentUser.getGithubLogin())
+                                .user(currentUser)
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(3L))).thenReturn(Optional.of(rosterStudent));
                 when(rosterStudentRepository.save(eq(rosterStudentUpdated))).thenReturn(rosterStudentUpdated);
-                when(organizationMemberService.inviteOrganizationMember(any(RosterStudent.class))).thenReturn(OrgStatus.MEMBER);
+                when(organizationMemberService.inviteOrganizationMember(any(RosterStudent.class)))
+                                .thenReturn(OrgStatus.MEMBER);
 
                 // Act
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/joinCourse")
                                 .with(csrf())
                                 .param("rosterStudentId", "3"))
-                        .andExpect(status().isAccepted())
-                        .andReturn();
-
+                                .andExpect(status().isAccepted())
+                                .andReturn();
 
                 // Assert
                 verify(rosterStudentRepository).findById(eq(3L));
 
                 // Verify the GitHub ID and login were set
                 verify(rosterStudentRepository, times(1)).save(eq(rosterStudentUpdated));
-                assertEquals("Already in organization - set status to MEMBER", response.getResponse().getContentAsString());
+                assertEquals("Already in organization - set status to MEMBER",
+                                response.getResponse().getContentAsString());
         }
 
         @Test
-        @WithMockUser(roles = { "USER", "GITHUB"})
+        @WithMockUser(roles = { "USER", "GITHUB" })
         public void test_already_part_is_owner() throws Exception {
                 User currentUser = currentUserService.getUser();
 
-                Course course2 = Course.builder().id(2L).installationId("1234").orgName("ucsb-cs156").courseName("course").creator(currentUser).build();
+                Course course2 = Course.builder().id(2L).installationId("1234").orgName("ucsb-cs156")
+                                .courseName("course").creator(currentUser).build();
 
                 RosterStudent rosterStudent = RosterStudent.builder()
-                        .id(3L)
-                        .firstName("Test")
-                        .lastName("User")
-                        .studentId("A555555")
-                        .email("testuser@ucsb.edu")
-                        .course(course2)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.JOINCOURSE)
-                        .githubId(null)  // Not linked yet
-                        .githubLogin(null)  // Not linked yet
-                        .user(currentUser)  // Current user owns this roster entry
-                        .build();
+                                .id(3L)
+                                .firstName("Test")
+                                .lastName("User")
+                                .studentId("A555555")
+                                .email("testuser@ucsb.edu")
+                                .course(course2)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.JOINCOURSE)
+                                .githubId(null) // Not linked yet
+                                .githubLogin(null) // Not linked yet
+                                .user(currentUser) // Current user owns this roster entry
+                                .build();
 
                 RosterStudent rosterStudentUpdated = RosterStudent.builder()
-                        .id(3L)
-                        .firstName("Test")
-                        .lastName("User")
-                        .studentId("A555555")
-                        .email("testuser@ucsb.edu")
-                        .course(course2)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.OWNER)
-                        .githubId(currentUser.getGithubId())
-                        .githubLogin(currentUser.getGithubLogin())
-                        .user(currentUser)
-                        .build();
+                                .id(3L)
+                                .firstName("Test")
+                                .lastName("User")
+                                .studentId("A555555")
+                                .email("testuser@ucsb.edu")
+                                .course(course2)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.OWNER)
+                                .githubId(currentUser.getGithubId())
+                                .githubLogin(currentUser.getGithubLogin())
+                                .user(currentUser)
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(3L))).thenReturn(Optional.of(rosterStudent));
                 when(rosterStudentRepository.save(eq(rosterStudentUpdated))).thenReturn(rosterStudentUpdated);
-                when(organizationMemberService.inviteOrganizationMember(any(RosterStudent.class))).thenReturn(OrgStatus.OWNER);
+                when(organizationMemberService.inviteOrganizationMember(any(RosterStudent.class)))
+                                .thenReturn(OrgStatus.OWNER);
 
                 // Act
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/joinCourse")
                                 .with(csrf())
                                 .param("rosterStudentId", "3"))
-                        .andExpect(status().isAccepted())
-                        .andReturn();
-
+                                .andExpect(status().isAccepted())
+                                .andReturn();
 
                 // Assert
                 verify(rosterStudentRepository).findById(eq(3L));
 
                 // Verify the GitHub ID and login were set
                 verify(rosterStudentRepository, times(1)).save(eq(rosterStudentUpdated));
-                assertEquals("Already in organization - set status to OWNER", response.getResponse().getContentAsString());
+                assertEquals("Already in organization - set status to OWNER",
+                                response.getResponse().getContentAsString());
         }
 
         @Test
-        @WithMockUser(roles = { "USER", "GITHUB"})
+        @WithMockUser(roles = { "USER", "GITHUB" })
         public void cant_invite() throws Exception {
                 User currentUser = currentUserService.getUser();
 
-                Course course2 = Course.builder().id(2L).installationId("1234").orgName("ucsb-cs156").courseName("course").creator(currentUser).build();
+                Course course2 = Course.builder().id(2L).installationId("1234").orgName("ucsb-cs156")
+                                .courseName("course").creator(currentUser).build();
 
                 RosterStudent rosterStudent = RosterStudent.builder()
-                        .id(3L)
-                        .firstName("Test")
-                        .lastName("User")
-                        .studentId("A555555")
-                        .email("testuser@ucsb.edu")
-                        .course(course2)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .githubId(123456789)  // Not linked yet
-                        .githubLogin(null)  // Not linked yet
-                        .user(currentUser)  // Current user owns this roster entry
-                        .build();
+                                .id(3L)
+                                .firstName("Test")
+                                .lastName("User")
+                                .studentId("A555555")
+                                .email("testuser@ucsb.edu")
+                                .course(course2)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .githubId(123456789) // Not linked yet
+                                .githubLogin(null) // Not linked yet
+                                .user(currentUser) // Current user owns this roster entry
+                                .build();
 
                 RosterStudent rosterStudentUpdated = RosterStudent.builder()
-                        .id(3L)
-                        .firstName("Test")
-                        .lastName("User")
-                        .studentId("A555555")
-                        .email("testuser@ucsb.edu")
-                        .course(course2)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .githubId(currentUser.getGithubId())
-                        .githubLogin(currentUser.getGithubLogin())
-                        .user(currentUser)
-                        .build();
+                                .id(3L)
+                                .firstName("Test")
+                                .lastName("User")
+                                .studentId("A555555")
+                                .email("testuser@ucsb.edu")
+                                .course(course2)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .githubId(currentUser.getGithubId())
+                                .githubLogin(currentUser.getGithubLogin())
+                                .user(currentUser)
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(3L))).thenReturn(Optional.of(rosterStudent));
                 when(rosterStudentRepository.save(eq(rosterStudentUpdated))).thenReturn(rosterStudentUpdated);
-                when(organizationMemberService.inviteOrganizationMember(any(RosterStudent.class))).thenReturn(OrgStatus.PENDING);
+                when(organizationMemberService.inviteOrganizationMember(any(RosterStudent.class)))
+                                .thenReturn(OrgStatus.PENDING);
 
                 // Act
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/joinCourse")
                                 .with(csrf())
                                 .param("rosterStudentId", "3"))
-                        .andExpect(status().isInternalServerError())
-                        .andReturn();
-
+                                .andExpect(status().isInternalServerError())
+                                .andReturn();
 
                 // Assert
                 verify(rosterStudentRepository).findById(eq(3L));
@@ -1013,28 +1197,28 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 User currentUser = currentUserService.getUser();
 
                 RosterStudent rs1WithUser = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("Chris")
-                        .lastName("Gaucho")
-                        .studentId("A123456")
-                        .email("cgaucho@example.org")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.MANUAL)
-                        .orgStatus(OrgStatus.PENDING)
-                        .user(currentUser)
-                        .build();
+                                .id(1L)
+                                .firstName("Chris")
+                                .lastName("Gaucho")
+                                .studentId("A123456")
+                                .email("cgaucho@example.org")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.MANUAL)
+                                .orgStatus(OrgStatus.PENDING)
+                                .user(currentUser)
+                                .build();
 
                 RosterStudent rs2WithUser = RosterStudent.builder()
-                        .id(2L)
-                        .firstName("Lauren")
-                        .lastName("Del Playa")
-                        .studentId("A987654")
-                        .email("ldelplaya@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .user(currentUser)
-                        .build();
+                                .id(2L)
+                                .firstName("Lauren")
+                                .lastName("Del Playa")
+                                .studentId("A987654")
+                                .email("ldelplaya@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .user(currentUser)
+                                .build();
 
                 List<RosterStudent> expectedRosterStudents = List.of(rs1WithUser, rs2WithUser);
 
@@ -1043,8 +1227,8 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 // Act
                 MvcResult response = mockMvc.perform(get("/api/rosterstudents/associatedRosterStudents")
                                 .with(csrf()))
-                        .andExpect(status().isOk())
-                        .andReturn();
+                                .andExpect(status().isOk())
+                                .andReturn();
 
                 // Assert
                 verify(rosterStudentRepository, times(1)).findAllByUser(eq(currentUser));
@@ -1065,8 +1249,8 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 // Act
                 MvcResult response = mockMvc.perform(get("/api/rosterstudents/associatedRosterStudents")
                                 .with(csrf()))
-                        .andExpect(status().isOk())
-                        .andReturn();
+                                .andExpect(status().isOk())
+                                .andReturn();
 
                 // Assert
                 verify(rosterStudentRepository, times(1)).findAllByUser(eq(currentUser));
@@ -1080,13 +1264,13 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testUpdateRosterStudent_emptyFields() throws Exception {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("firstName", "   ")
-                        .param("lastName", "   ")
-                        .param("studentId", "   "))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("firstName", "   ")
+                                .param("lastName", "   ")
+                                .param("studentId", "   "))
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 verify(rosterStudentRepository, never()).findById(any());
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
@@ -1099,38 +1283,38 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testUpdateRosterStudent_success() throws Exception {
                 RosterStudent existingStudent = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("Old")
-                        .lastName("OldName")
-                        .studentId("A123456")
-                        .email("old@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .build();
+                                .id(1L)
+                                .firstName("Old")
+                                .lastName("OldName")
+                                .studentId("A123456")
+                                .email("old@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
 
                 RosterStudent updatedStudent = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("New")
-                        .lastName("NewName")
-                        .studentId("A123456")
-                        .email("old@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .build();
+                                .id(1L)
+                                .firstName("New")
+                                .lastName("NewName")
+                                .studentId("A123456")
+                                .email("old@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(1L))).thenReturn(Optional.of(existingStudent));
                 when(rosterStudentRepository.save(any(RosterStudent.class))).thenReturn(updatedStudent);
 
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("firstName", "   New   ")
-                        .param("lastName", "   NewName   ")
-                        .param("studentId", "   A123456   "))
-                        .andExpect(status().isOk())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("firstName", "   New   ")
+                                .param("lastName", "   NewName   ")
+                                .param("studentId", "   A123456   "))
+                                .andExpect(status().isOk())
+                                .andReturn();
 
                 ArgumentCaptor<RosterStudent> captor = ArgumentCaptor.forClass(RosterStudent.class);
                 verify(rosterStudentRepository).save(captor.capture());
@@ -1148,39 +1332,39 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testUpdateRosterStudent_duplicateStudentId() throws Exception {
                 RosterStudent existingStudent = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("Old")
-                        .lastName("OldName")
-                        .studentId("A123456")
-                        .email("old@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .build();
+                                .id(1L)
+                                .firstName("Old")
+                                .lastName("OldName")
+                                .studentId("A123456")
+                                .email("old@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
 
                 RosterStudent otherStudent = RosterStudent.builder()
-                        .id(2L)
-                        .firstName("Other")
-                        .lastName("Student")
-                        .studentId("A789012")
-                        .email("other@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .build();
+                                .id(2L)
+                                .firstName("Other")
+                                .lastName("Student")
+                                .studentId("A789012")
+                                .email("other@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(1L))).thenReturn(Optional.of(existingStudent));
                 when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("A789012")))
-                        .thenReturn(Optional.of(otherStudent));
+                                .thenReturn(Optional.of(otherStudent));
 
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("firstName", "New")
-                        .param("lastName", "NewName")
-                        .param("studentId", "A789012"))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("firstName", "New")
+                                .param("lastName", "NewName")
+                                .param("studentId", "A789012"))
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 verify(rosterStudentRepository).findById(eq(1L));
                 verify(rosterStudentRepository).findByCourseIdAndStudentId(eq(1L), eq("A789012"));
@@ -1196,21 +1380,21 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 when(rosterStudentRepository.findById(eq(99L))).thenReturn(Optional.empty());
 
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "99")
-                        .param("firstName", "New")
-                        .param("lastName", "Name")
-                        .param("studentId", "A123456"))
-                        .andExpect(status().isNotFound())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "99")
+                                .param("firstName", "New")
+                                .param("lastName", "Name")
+                                .param("studentId", "A123456"))
+                                .andExpect(status().isNotFound())
+                                .andReturn();
 
                 verify(rosterStudentRepository).findById(eq(99L));
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
 
                 String responseString = response.getResponse().getContentAsString();
                 Map<String, String> expectedMap = Map.of(
-                        "type", "EntityNotFoundException",
-                        "message", "RosterStudent with id 99 not found");
+                                "type", "EntityNotFoundException",
+                                "message", "RosterStudent with id 99 not found");
                 String expectedJson = mapper.writeValueAsString(expectedMap);
                 assertEquals(expectedJson, responseString);
         }
@@ -1219,12 +1403,12 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "USER" })
         public void testUpdateRosterStudent_unauthorized() throws Exception {
                 mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("firstName", "New")
-                        .param("lastName", "Name")
-                        .param("studentId", "A123456"))
-                        .andExpect(status().isForbidden());
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("firstName", "New")
+                                .param("lastName", "Name")
+                                .param("studentId", "A123456"))
+                                .andExpect(status().isForbidden());
 
                 verify(rosterStudentRepository, never()).findById(any());
                 verify(rosterStudentRepository, never()).save(any());
@@ -1234,40 +1418,40 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testUpdateRosterStudent_newStudentIdNotExists() throws Exception {
                 RosterStudent existingStudent = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("Old")
-                        .lastName("OldName")
-                        .studentId("A123456")
-                        .email("old@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .build();
+                                .id(1L)
+                                .firstName("Old")
+                                .lastName("OldName")
+                                .studentId("A123456")
+                                .email("old@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
 
                 RosterStudent updatedStudent = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("New")
-                        .lastName("NewName")
-                        .studentId("A999999") 
-                        .email("old@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .build();
+                                .id(1L)
+                                .firstName("New")
+                                .lastName("NewName")
+                                .studentId("A999999")
+                                .email("old@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(1L))).thenReturn(Optional.of(existingStudent));
                 when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("A999999")))
-                        .thenReturn(Optional.empty());
+                                .thenReturn(Optional.empty());
                 when(rosterStudentRepository.save(any(RosterStudent.class))).thenReturn(updatedStudent);
 
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("firstName", "   New   ")
-                        .param("lastName", "   NewName   ")
-                        .param("studentId", "   A999999   "))
-                        .andExpect(status().isOk())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("firstName", "   New   ")
+                                .param("lastName", "   NewName   ")
+                                .param("studentId", "   A999999   "))
+                                .andExpect(status().isOk())
+                                .andReturn();
 
                 ArgumentCaptor<RosterStudent> captor = ArgumentCaptor.forClass(RosterStudent.class);
                 verify(rosterStudentRepository).save(captor.capture());
@@ -1285,38 +1469,38 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testUpdateRosterStudent_sameStudentIdWithWhitespace() throws Exception {
                 RosterStudent existingStudent = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("Old")
-                        .lastName("OldName")
-                        .studentId("A123456")
-                        .email("old@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .build();
+                                .id(1L)
+                                .firstName("Old")
+                                .lastName("OldName")
+                                .studentId("A123456")
+                                .email("old@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
 
                 RosterStudent updatedStudent = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("New")
-                        .lastName("NewName")
-                        .studentId("A123456")
-                        .email("old@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .build();
+                                .id(1L)
+                                .firstName("New")
+                                .lastName("NewName")
+                                .studentId("A123456")
+                                .email("old@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(1L))).thenReturn(Optional.of(existingStudent));
                 when(rosterStudentRepository.save(any(RosterStudent.class))).thenReturn(updatedStudent);
 
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("firstName", "  New  ")
-                        .param("lastName", "  NewName  ")
-                        .param("studentId", "  A123456  "))
-                        .andExpect(status().isOk())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("firstName", "  New  ")
+                                .param("lastName", "  NewName  ")
+                                .param("studentId", "  A123456  "))
+                                .andExpect(status().isOk())
+                                .andReturn();
 
                 ArgumentCaptor<RosterStudent> captor = ArgumentCaptor.forClass(RosterStudent.class);
                 verify(rosterStudentRepository).save(captor.capture());
@@ -1334,12 +1518,12 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testUpdateRosterStudent_nullFields() throws Exception {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("lastName", "Doe")
-                        .param("studentId", "A123456"))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("lastName", "Doe")
+                                .param("studentId", "A123456"))
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 verify(rosterStudentRepository, never()).findById(any());
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
@@ -1352,12 +1536,12 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testUpdateRosterStudent_nullFirstName() throws Exception {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("lastName", "Doe")
-                        .param("studentId", "A123456"))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("lastName", "Doe")
+                                .param("studentId", "A123456"))
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 verify(rosterStudentRepository, never()).findById(any());
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
@@ -1370,12 +1554,12 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testUpdateRosterStudent_nullLastName() throws Exception {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("firstName", "John")
-                        .param("studentId", "A123456"))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("firstName", "John")
+                                .param("studentId", "A123456"))
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 verify(rosterStudentRepository, never()).findById(any());
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
@@ -1388,12 +1572,12 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testUpdateRosterStudent_nullStudentId() throws Exception {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("firstName", "John")
-                        .param("lastName", "Doe"))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("firstName", "John")
+                                .param("lastName", "Doe"))
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 verify(rosterStudentRepository, never()).findById(any());
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
@@ -1406,13 +1590,13 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testUpdateRosterStudent_emptyFirstName() throws Exception {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("firstName", "")
-                        .param("lastName", "Doe")
-                        .param("studentId", "A123456"))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("firstName", "")
+                                .param("lastName", "Doe")
+                                .param("studentId", "A123456"))
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 verify(rosterStudentRepository, never()).findById(any());
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
@@ -1425,13 +1609,13 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testUpdateRosterStudent_emptyLastName() throws Exception {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("firstName", "John")
-                        .param("lastName", "")
-                        .param("studentId", "A123456"))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("firstName", "John")
+                                .param("lastName", "")
+                                .param("studentId", "A123456"))
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 verify(rosterStudentRepository, never()).findById(any());
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
@@ -1444,13 +1628,13 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testUpdateRosterStudent_emptyStudentId() throws Exception {
                 MvcResult response = mockMvc.perform(put("/api/rosterstudents/update")
-                        .with(csrf())
-                        .param("id", "1")
-                        .param("firstName", "John")
-                        .param("lastName", "Doe")
-                        .param("studentId", ""))
-                        .andExpect(status().isBadRequest())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1")
+                                .param("firstName", "John")
+                                .param("lastName", "Doe")
+                                .param("studentId", ""))
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
 
                 verify(rosterStudentRepository, never()).findById(any());
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
@@ -1464,16 +1648,16 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         public void testJoinCourseOnGitHub_nullUser() throws Exception {
                 // Arrange
                 RosterStudent rosterStudent = RosterStudent.builder()
-                        .id(6L)
-                        .firstName("No")
-                        .lastName("User")
-                        .studentId("A888888")
-                        .email("nouser@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .user(null)  // No user associated
-                        .build();
+                                .id(6L)
+                                .firstName("No")
+                                .lastName("User")
+                                .studentId("A888888")
+                                .email("nouser@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .user(null) // No user associated
+                                .build();
 
                 when(rosterStudentRepository.findById(eq(6L))).thenReturn(Optional.of(rosterStudent));
 
@@ -1481,7 +1665,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 mockMvc.perform(put("/api/rosterstudents/joinCourse")
                                 .with(csrf())
                                 .param("rosterStudentId", "6"))
-                        .andExpect(status().isForbidden());
+                                .andExpect(status().isForbidden());
 
                 // Verify nothing was saved
                 verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
@@ -1491,15 +1675,15 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "INSTRUCTOR" })
         public void testDeleteRosterStudent_success() throws Exception {
                 RosterStudent rosterStudent = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("Test")
-                        .lastName("Student")
-                        .studentId("A123456")
-                        .email("test@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.PENDING)
-                        .build();
+                                .id(1L)
+                                .firstName("Test")
+                                .lastName("Student")
+                                .studentId("A123456")
+                                .email("test@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .orgStatus(OrgStatus.PENDING)
+                                .build();
 
                 List<RosterStudent> students = new ArrayList<>();
                 students.add(rosterStudent);
@@ -1512,18 +1696,18 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 when(courseRepository.save(any(Course.class))).thenReturn(course1);
 
                 MvcResult response = mockMvc.perform(delete("/api/rosterstudents/delete")
-                        .with(csrf())
-                        .param("id", "1"))
-                        .andExpect(status().isOk())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "1"))
+                                .andExpect(status().isOk())
+                                .andReturn();
 
                 verify(rosterStudentRepository).findById(eq(1L));
                 verify(courseRepository).save(any(Course.class));
                 verify(rosterStudentRepository).delete(eq(rosterStudent));
                 verify(studentsSpy).remove(eq(rosterStudent));
 
-                assertEquals("Successfully deleted roster student and removed him/her from the course list", 
-                        response.getResponse().getContentAsString());
+                assertEquals("Successfully deleted roster student and removed him/her from the course list",
+                                response.getResponse().getContentAsString());
         }
 
         @Test
@@ -1532,10 +1716,10 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 when(rosterStudentRepository.findById(eq(99L))).thenReturn(Optional.empty());
 
                 MvcResult response = mockMvc.perform(delete("/api/rosterstudents/delete")
-                        .with(csrf())
-                        .param("id", "99"))
-                        .andExpect(status().isNotFound())
-                        .andReturn();
+                                .with(csrf())
+                                .param("id", "99"))
+                                .andExpect(status().isNotFound())
+                                .andReturn();
 
                 verify(rosterStudentRepository).findById(eq(99L));
                 verify(rosterStudentRepository, never()).delete(any(RosterStudent.class));
@@ -1543,8 +1727,8 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
 
                 String responseString = response.getResponse().getContentAsString();
                 Map<String, String> expectedMap = Map.of(
-                        "type", "EntityNotFoundException",
-                        "message", "RosterStudent with id 99 not found");
+                                "type", "EntityNotFoundException",
+                                "message", "RosterStudent with id 99 not found");
                 String expectedJson = mapper.writeValueAsString(expectedMap);
                 assertEquals(expectedJson, responseString);
         }
@@ -1553,9 +1737,9 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "USER" })
         public void testDeleteRosterStudent_unauthorized() throws Exception {
                 mockMvc.perform(delete("/api/rosterstudents/delete")
-                        .with(csrf())
-                        .param("id", "1"))
-                        .andExpect(status().isForbidden());
+                                .with(csrf())
+                                .param("id", "1"))
+                                .andExpect(status().isForbidden());
 
                 verify(rosterStudentRepository, never()).findById(any());
                 verify(rosterStudentRepository, never()).delete(any(RosterStudent.class));
@@ -1567,39 +1751,40 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
         public void testUpsertStudentWithDuplicateEmail() throws Exception {
                 // Arrange
                 RosterStudent existingStudent = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("Existing")
-                        .lastName("Student")
-                        .studentId("A123456")
-                        .email("cgaucho@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .build();
-                 RosterStudent newStudent = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("New")
-                        .lastName("Student")
-                        .studentId("A123457")
-                        .email("cgaucho@umail.ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.MANUAL)
-                        .build();
+                                .id(1L)
+                                .firstName("Existing")
+                                .lastName("Student")
+                                .studentId("A123456")
+                                .email("cgaucho@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.ROSTER)
+                                .build();
+                RosterStudent newStudent = RosterStudent.builder()
+                                .id(1L)
+                                .firstName("New")
+                                .lastName("Student")
+                                .studentId("A123457")
+                                .email("cgaucho@umail.ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.MANUAL)
+                                .build();
                 RosterStudent expectedSaved = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("New")
-                        .lastName("Student")
-                        .studentId("A123457")
-                        .email("cgaucho@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.MANUAL)
-                        .build();
+                                .id(1L)
+                                .firstName("New")
+                                .lastName("Student")
+                                .studentId("A123457")
+                                .email("cgaucho@ucsb.edu")
+                                .course(course1)
+                                .rosterStatus(RosterStatus.MANUAL)
+                                .build();
 
-                when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));                
-                when(rosterStudentRepository.findByCourseIdAndStudentId(eq(course1.getId()), eq(newStudent.getStudentId())))
-                        .thenReturn(Optional.empty());
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));
+                when(rosterStudentRepository.findByCourseIdAndStudentId(eq(course1.getId()),
+                                eq(newStudent.getStudentId())))
+                                .thenReturn(Optional.empty());
                 when(rosterStudentRepository.findByCourseIdAndEmail(eq(course1.getId()), eq("cgaucho@ucsb.edu")))
-                        .thenReturn(Optional.of(existingStudent));  
-                when(rosterStudentRepository.save(eq(expectedSaved))).thenReturn(expectedSaved); 
+                                .thenReturn(Optional.of(existingStudent));
+                when(rosterStudentRepository.save(eq(expectedSaved))).thenReturn(expectedSaved);
                 doNothing().when(updateUserService).attachUserToRosterStudent(any(RosterStudent.class));
 
                 // act
@@ -1617,7 +1802,8 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 // assert
 
                 String responseString = response.getResponse().getContentAsString();
-                RosterStudentsController.UpsertResponse upsertResponse = mapper.readValue(responseString, RosterStudentsController.UpsertResponse.class);
+                RosterStudentsController.UpsertResponse upsertResponse = mapper.readValue(responseString,
+                                RosterStudentsController.UpsertResponse.class);
                 assertEquals(RosterStudentsController.InsertStatus.UPDATED, upsertResponse.insertStatus());
                 assertEquals(expectedSaved, upsertResponse.rosterStudent());
                 verify(courseRepository, times(1)).findById(eq(1L));
@@ -1625,5 +1811,44 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 verify(rosterStudentRepository, times(1)).findByCourseIdAndEmail(eq(1L), eq("cgaucho@ucsb.edu"));
                 verify(rosterStudentRepository, times(1)).save(eq(expectedSaved));
         }
-                
+
+        @Test
+        public void test_getLastName() {
+                assertEquals("Gaucho", RosterStudentsController.getLastName("Chris Gaucho"));
+                assertEquals("Milnes", RosterStudentsController.getLastName("Christopher Robin Milnes"));
+                assertEquals("Cher", RosterStudentsController.getLastName("Cher"));
+        }
+
+        @Test
+        public void test_getFirstname() {
+                assertEquals("Chris", RosterStudentsController.getFirstName("Chris Gaucho"));
+                assertEquals("Christopher Robin", RosterStudentsController.getFirstName("Christopher Robin Milnes"));
+                assertEquals("", RosterStudentsController.getFirstName("Cher"));
+        }
+
+        @Test
+        public void test_getRosterSourceType() {
+                // Test with UCSB Egrades header
+                String[] ucsbEgradesHeader = RosterStudentsController.UCSB_EGRADES_HEADERS.split(",");
+                assertEquals(RosterSourceType.UCSB_EGRADES,
+                                RosterStudentsController.getRosterSourceType(ucsbEgradesHeader));
+
+                // Test with Chico Canvas header
+                String[] chicoCanvasHeader = RosterStudentsController.CHICO_CANVAS_HEADERS.split(",");
+                assertEquals(RosterSourceType.CHICO_CANVAS,
+                                RosterStudentsController.getRosterSourceType(chicoCanvasHeader));
+
+                // Test with unknown header
+                String[] unknownHeader = { "Unknown Header 1", "Unknown Header 2" };
+                assertEquals(RosterSourceType.UNKNOWN, RosterStudentsController.getRosterSourceType(unknownHeader));
+        }
+
+        @Test
+        public void test_fromCSVRow_UnrecognizedSourceType() {
+                assertThrows(ResponseStatusException.class, () -> {
+                    String[] row = { "Unknown Header 1", "Unknown Header 2" };
+                    RosterStudentsController.fromCSVRow(row, RosterSourceType.UNKNOWN);
+                });
+        }
+
 }


### PR DESCRIPTION
In this PR, we add the ability to upload CSV files of roster students in multiple formats:

* We retain the existing UCSB Egrades format
* We add the Chico State Canvas format