### PR TITLE
Customizing Permissions Level on Repos

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RepositoryController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RepositoryController.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.frontiers.controllers;
 
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.Job;
+import edu.ucsb.cs156.frontiers.enums.RepositoryPermissions;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
 import edu.ucsb.cs156.frontiers.jobs.CreateStudentRepositoriesJob;
@@ -46,7 +47,7 @@ public class RepositoryController extends ApiController {
     */
     @PostMapping("/createRepos")
     @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
-    public Job createRepos(@RequestParam Long courseId, @RequestParam String repoPrefix, @RequestParam Optional<Boolean> isPrivate) {
+    public Job createRepos(@RequestParam Long courseId, @RequestParam String repoPrefix, @RequestParam Optional<Boolean> isPrivate, @RequestParam RepositoryPermissions permissions) {
         Course course = courseRepository.findById(courseId).orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
             if (course.getOrgName() == null || course.getInstallationId() == null) {
                 throw new NoLinkedOrganizationException(course.getCourseName());
@@ -56,6 +57,7 @@ public class RepositoryController extends ApiController {
                         .isPrivate(isPrivate.orElse(false))
                         .repositoryService(repositoryService)
                         .course(course)
+                        .permissions(permissions)
                         .build();
                 return jobService.runAsJob(job);
         }

--- a/src/main/java/edu/ucsb/cs156/frontiers/enums/RepositoryPermissions.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/enums/RepositoryPermissions.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.frontiers.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum RepositoryPermissions {
+    READ("pull"), WRITE("push"), MAINTAIN("maintain"), ADMIN("admin"),
+    ;
+
+    private final String apiName;
+
+    private RepositoryPermissions(String apiName){
+        this.apiName = apiName;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentRepositoriesJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentRepositoriesJob.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.frontiers.jobs;
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.enums.RepositoryPermissions;
 import edu.ucsb.cs156.frontiers.services.RepositoryService;
 import edu.ucsb.cs156.frontiers.services.jobs.JobContext;
 import edu.ucsb.cs156.frontiers.services.jobs.JobContextConsumer;
@@ -14,13 +15,14 @@ public class CreateStudentRepositoriesJob implements JobContextConsumer {
     RepositoryService repositoryService;
     String repositoryPrefix;
     Boolean isPrivate;
+    RepositoryPermissions permissions;
 
     @Override
     public void accept(JobContext ctx) throws Exception {
         ctx.log("Processing...");
         for(RosterStudent student : course.getRosterStudents()){
-            if(student.getGithubLogin() != null && student.getOrgStatus() == OrgStatus.MEMBER){
-                repositoryService.createStudentRepository(course, student, repositoryPrefix, isPrivate);
+            if(student.getGithubLogin() != null && (student.getOrgStatus() == OrgStatus.MEMBER || student.getOrgStatus() == OrgStatus.OWNER)){
+                repositoryService.createStudentRepository(course, student, repositoryPrefix, isPrivate, permissions);
             }
         }
         ctx.log("Done");

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RepositoryControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RepositoryControllerTests.java
@@ -58,6 +58,7 @@ public class RepositoryControllerTests extends ControllerTestCase {
                 .with(csrf())
                 .param("courseId", "2")
                 .param("repoPrefix", "repo1")
+                .param("permissions", "WRITE")
         ).andExpect(status().isForbidden())
         .andReturn();
     }
@@ -71,6 +72,7 @@ public class RepositoryControllerTests extends ControllerTestCase {
                         .with(csrf())
                         .param("courseId", "2")
                         .param("repoPrefix", "repo1")
+                        .param("permissions", "WRITE")
                 ).andExpect(status().isBadRequest())
                 .andReturn();
         Map<String, Object> json = responseToJson(response);
@@ -87,6 +89,7 @@ public class RepositoryControllerTests extends ControllerTestCase {
                         .with(csrf())
                         .param("courseId", "2")
                         .param("repoPrefix", "repo1")
+                        .param("permissions", "WRITE")
                 ).andExpect(status().isBadRequest())
                 .andReturn();
         Map<String, Object> json = responseToJson(response);
@@ -105,6 +108,7 @@ public class RepositoryControllerTests extends ControllerTestCase {
                         .with(csrf())
                         .param("courseId", "2")
                         .param("repoPrefix", "repo1")
+                        .param("permissions", "WRITE")
                 ).andExpect(status().isOk())
                 .andReturn();
 
@@ -124,6 +128,7 @@ public class RepositoryControllerTests extends ControllerTestCase {
                         .with(csrf())
                         .param("courseId", "2")
                         .param("repoPrefix", "repo1")
+                        .param("permissions", "WRITE")
                 ).andExpect(status().isOk())
                 .andReturn();
 
@@ -141,6 +146,7 @@ public class RepositoryControllerTests extends ControllerTestCase {
                         .with(csrf())
                         .param("courseId", "2")
                         .param("repoPrefix", "repo1")
+                        .param("permissions", "WRITE")
                 ).andExpect(status().isNotFound())
                 .andReturn();
         Map<String, Object> json = responseToJson(response);


### PR DESCRIPTION
In this PR, I allow the customizing of permissions levels when creating repositories for Students.

These are contained in an enum, with the constant being the user-friendly definition, and a method to get it's name in the GitHub API.

Additionally, I move the part where it sets the permissions level for students to run regardless of if the repo is created or not.

If the student is already added as a collaborator, the returned `204 (No Content)` will be ignored.

Test Plan:
Attempt to create repos using swagger on a course with RosterStudents that are part of the organization. If there is a student who is an owner, this will cover the edge case of attempting to give lower than admin permissions to an owner.

Deployed to https://proj-frontiers-division7.dokku-00.cs.ucsb.edu/
