### PR TITLE
Rearranging the Roster Student Tab

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -121,7 +121,7 @@ function App() {
           }
         />
         <Route
-          path="/admin/courses/:id"
+          path="/instructor/courses/:id"
           element={
             <ProtectedPage
               component={<InstructorCourseShowPage />}

--- a/frontend/src/main/components/TabComponent/EnrollmentTabComponent.js
+++ b/frontend/src/main/components/TabComponent/EnrollmentTabComponent.js
@@ -1,16 +1,26 @@
 import { toast } from "react-toastify";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import React, { useState } from "react";
-import { Accordion, Col, Form, Row } from "react-bootstrap";
+import {
+  Button,
+  Col,
+  Form,
+  ModalBody,
+  ModalHeader,
+  Row,
+} from "react-bootstrap";
 import RosterStudentCSVUploadForm from "main/components/RosterStudent/RosterStudentCSVUploadForm";
 import RosterStudentForm from "main/components/RosterStudent/RosterStudentForm";
 import RosterStudentTable from "main/components/RosterStudent/RosterStudentTable";
+import Modal from "react-bootstrap/Modal";
 
 export default function EnrollmentTabComponent({
   courseId,
   testIdPrefix,
   currentUser,
 }) {
+  const [postModal, showPostModal] = useState(false);
+  const [csvModal, showCsvModal] = useState(false);
   const { data: rosterStudents } = useBackend(
     [`/api/rosterstudents/course/${courseId}`],
     // Stryker disable next-line StringLiteral : GET and empty string are equivalent
@@ -45,21 +55,22 @@ export default function EnrollmentTabComponent({
     },
   });
 
-  const onSuccessRoster = () => {
+  const onSuccessRoster = (modalFn) => {
     toast("Roster successfully updated.");
     // Clear the search filter to show the updated roster
     setSearchTerm("");
+    modalFn(false);
   };
 
   const rosterPostMutation = useBackendMutation(
     objectToAxiosParamsPost,
-    { onSuccess: onSuccessRoster },
+    { onSuccess: () => onSuccessRoster(showPostModal) },
     [`/api/rosterstudents/course/${courseId}`],
   );
 
   const rosterCsvMutation = useBackendMutation(
     objectToAxiosParamsCSV,
-    { onSuccess: onSuccessRoster },
+    { onSuccess: () => onSuccessRoster(showCsvModal) },
     [`/api/rosterstudents/course/${courseId}`],
   );
 
@@ -73,26 +84,32 @@ export default function EnrollmentTabComponent({
 
   return (
     <div data-testid={`${testIdPrefix}-EnrollmentTabComponent`}>
-      <Row className="py-3">
-        <Accordion defaultActiveKey="upload">
-          <Accordion.Item eventKey="upload">
-            <Accordion.Header>Upload Roster</Accordion.Header>
-            <Accordion.Body>
-              <RosterStudentCSVUploadForm submitAction={handleCsvSubmit} />
-            </Accordion.Body>
-          </Accordion.Item>
-          <Accordion.Item eventKey="individual">
-            <Accordion.Header>Add Individual Student</Accordion.Header>
-            <Accordion.Body>
-              <RosterStudentForm
-                submitAction={handlePostSubmit}
-                cancelDisabled={true}
-              />
-            </Accordion.Body>
-          </Accordion.Item>
-        </Accordion>
-      </Row>
-      <Row className="mb-3">
+      <Modal
+        show={csvModal}
+        onHide={() => showCsvModal(false)}
+        centered={true}
+        data-testid={`${testIdPrefix}-csv-modal`}
+      >
+        <ModalHeader closeButton>Upload CSV Roster</ModalHeader>
+        <ModalBody>
+          <RosterStudentCSVUploadForm submitAction={handleCsvSubmit} />
+        </ModalBody>
+      </Modal>
+      <Modal
+        show={postModal}
+        onHide={() => showPostModal(false)}
+        centered={true}
+        data-testid={`${testIdPrefix}-post-modal`}
+      >
+        <ModalHeader closeButton>Add Individual Student</ModalHeader>
+        <ModalBody>
+          <RosterStudentForm
+            submitAction={handlePostSubmit}
+            cancelDisabled={true}
+          />
+        </ModalBody>
+      </Modal>
+      <Row className="mb-2">
         <Form>
           <Form.Group as={Row} controlId="searchFilter">
             <Form.Label column sm={2}>
@@ -109,6 +126,26 @@ export default function EnrollmentTabComponent({
             </Col>
           </Form.Group>
         </Form>
+      </Row>
+      <Row sm={2} className="p-2">
+        <Col>
+          <Button
+            onClick={() => showCsvModal(true)}
+            data-testid={`${testIdPrefix}-csv-button`}
+            className="w-100"
+          >
+            Upload CSV Roster
+          </Button>
+        </Col>
+        <Col>
+          <Button
+            onClick={() => showPostModal(true)}
+            data-testid={`${testIdPrefix}-post-button`}
+            className="w-100"
+          >
+            Add Individual Student
+          </Button>
+        </Col>
       </Row>
       <Row>
         <RosterStudentTable

--- a/frontend/src/main/pages/HomePageLoggedIn.js
+++ b/frontend/src/main/pages/HomePageLoggedIn.js
@@ -144,6 +144,11 @@ export default function HomePageLoggedIn() {
       <div className="pt-2">
         {hasRole(currentUser, "ROLE_INSTRUCTOR") && (
           <>
+            <CourseModal
+              showModal={viewModal}
+              toggleShowModal={setViewModal}
+              onSubmitAction={onSubmit}
+            />
             <Button
               onClick={createCourse}
               style={{ float: "right", marginBottom: 10 }}
@@ -159,11 +164,6 @@ export default function HomePageLoggedIn() {
             )}
             {instructorCourses.length > 0 && (
               <>
-                <CourseModal
-                  showModal={viewModal}
-                  toggleShowModal={setViewModal}
-                  onSubmitAction={onSubmit}
-                />
                 <>
                   <InstructorCoursesTable
                     courses={instructorCourses}

--- a/frontend/src/main/pages/Instructor/InstructorCourseShowPage.js
+++ b/frontend/src/main/pages/Instructor/InstructorCourseShowPage.js
@@ -36,7 +36,7 @@ export default function InstructorCourseShowPage() {
     if (getCourseFailed) {
       setShowErrorModal(true);
       const timer = setTimeout(() => {
-        navigate("/instructor/courses", { replace: true });
+        navigate("/", { replace: true });
       }, 3000);
       return () => {
         clearTimeout(timer);

--- a/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
+++ b/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.js
@@ -163,7 +163,7 @@ describe("InstructorCourseShowPage tests", () => {
     act(() => {
       jest.advanceTimersByTime(5000);
     });
-    expect(mockedNavigate).toHaveBeenCalledWith("/instructor/courses", {
+    expect(mockedNavigate).toHaveBeenCalledWith("/", {
       replace: true,
     });
     expect(mockedNavigate).toHaveBeenCalledTimes(1);
@@ -263,14 +263,6 @@ describe("InstructorCourseShowPage tests", () => {
     expect(screen.getByText("Management")).toHaveAttribute(
       "aria-selected",
       "true",
-    );
-    expect(screen.getByText("Upload Roster")).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
-    expect(screen.getByText("Add Individual Student")).toHaveAttribute(
-      "aria-expanded",
-      "false",
     );
     const changeTabs = screen.getByText("Enrollment");
     fireEvent.click(changeTabs);


### PR DESCRIPTION
In this PR, I rearrange the `CourseShowPage` to move the content under the enrollment tab into it's own component, `EnrollmentTabComponent`. I then remove the accordion, and replace it with a row of buttons.


New look (with #323)
<img width="1397" height="651" alt="image" src="https://github.com/user-attachments/assets/1ececeef-5192-4cad-8a16-79bf5e2976b7" />

Additionally, I move the `CourseModal` on `HomePageLoggedIn` so you can create a course even if you haven't previously. I also reset the location of the `CourseShowPage`, and allow Instructors to visit it.

Deployed to https://frontiers-qa6.dokku-00.cs.ucsb.edu with #323.

Closes #319 