### PR TITLE
Disabling the Instructor Courses call without the Instructor Role

### DIFF
--- a/frontend/src/main/pages/HomePageLoggedIn.js
+++ b/frontend/src/main/pages/HomePageLoggedIn.js
@@ -47,6 +47,10 @@ export default function HomePageLoggedIn() {
     { method: "GET", url: "/api/courses/allForInstructors" },
     // Stryker disable next-line all : don't test default value of empty list
     [],
+    false,
+    {
+      enabled: hasRole(currentUser, "ROLE_INSTRUCTOR"),
+    },
   );
 
   const onJoinSuccess = (message) => {

--- a/frontend/src/main/pages/HomePageLoggedIn.js
+++ b/frontend/src/main/pages/HomePageLoggedIn.js
@@ -49,7 +49,7 @@ export default function HomePageLoggedIn() {
     [],
     false,
     {
-      enabled: hasRole(currentUser, "ROLE_INSTRUCTOR"),
+      enabled: Boolean(hasRole(currentUser, "ROLE_INSTRUCTOR")),
     },
   );
 

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -30,6 +30,7 @@ export function useBackend(
   axiosParameters,
   initialData,
   suppressToasts = false,
+  options = {},
 ) {
   return useQuery({
     queryKey: queryKey,
@@ -47,6 +48,7 @@ export function useBackend(
       }
     },
     initialData: initialData,
+    ...options,
   });
 }
 

--- a/frontend/src/tests/pages/HomePageLoggedIn.test.js
+++ b/frontend/src/tests/pages/HomePageLoggedIn.test.js
@@ -286,6 +286,9 @@ describe("HomePageLoggedIn tests", () => {
     expect(
       queryClient.getQueryState(["/api/courses/staffCourses"]).dataUpdateCount,
     ).toBe(2);
+    expect(
+      queryClient.isFetching({ queryKey: ["/api/courses/allForInstructors"] }),
+    ).toBe(0);
   });
 
   test("right message on 400", async () => {
@@ -506,5 +509,26 @@ describe("HomePageLoggedIn tests", () => {
       queryClient.getQueryState(["/api/courses/allForInstructors"]),
     ).toBeTruthy();
     expect(screen.queryByTestId("CourseModal-base")).not.toBeInTheDocument();
+  });
+
+  test("toast called on instructor error", async () => {
+    setupInstructorUser();
+    axiosMock.onGet("/api/courses/allForInstructors").reply(500);
+    axiosMock
+      .onGet("/api/courses/staffCourses")
+      .reply(200, coursesFixtures.oneCourseWithEachStatus);
+    axiosMock
+      .onGet("/api/courses/list")
+      .reply(200, coursesFixtures.oneCourseWithEachStatus);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HomePageLoggedIn />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(mockToast).toHaveBeenCalled());
   });
 });

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -111,6 +111,40 @@ describe("utils/useBackend tests", () => {
       );
       expect(mockToast).not.toHaveBeenCalled();
     });
+    test("useBackend handles disabled correctly", async () => {
+      // See: https://react-query.tanstack.com/guides/testing#turn-off-retries
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            // ✅ turns retries off
+            retry: false,
+          },
+        },
+      });
+      const wrapper = ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+
+      var axiosMock = new AxiosMockAdapter(axios);
+
+      axiosMock.onGet("/api/admin/users").reply(404, {});
+
+      const { result } = renderHook(
+        () =>
+          useBackend(
+            ["/api/admin/users"],
+            { method: "GET", url: "/api/admin/users" },
+            ["initialData"],
+            false,
+            { enabled: false },
+          ),
+        { wrapper },
+      );
+
+      expect(result.current.isLoading).toBe(false);
+    });
   });
   describe("utils/useBackend useBackendMutation tests", () => {
     test("useBackendMutation handles success correctly", async () => {


### PR DESCRIPTION
In this PR, I disable the call to `/api/courses/allForInstructors` in useBackend if the user does not have the instructor role.

This can be done with the new parameter to useBackend(queryKey, axiosParams, suppressToasts, **options**) :
any option listed [here](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery) can be used, and will override the ones listed above if necessary.

Deployed to https://proj-frontiers-division7.dokku-00.cs.ucsb.edu

Closes #342 