### PR TITLE
[Hotfix] Configuring Stryker to Accept the Jest Config

### DIFF
--- a/frontend/stryker.config.json
+++ b/frontend/stryker.config.json
@@ -9,7 +9,8 @@
   ],
   "coverageAnalysis": "off",
   "jest": {
-    "projectType": "create-react-app"
+    "projectType": "custom",
+    "configFile": "./jest.config.js"
   },
   "mutate": [
     "src/main/**/*.js",


### PR DESCRIPTION
In this PR, I configure Stryker to accept Jest's configuration, moving us away from the "create-react-app" template for the application.