### PR TITLE
Narrowing the Scope of CustomErrorController

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CustomErrorController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CustomErrorController.java
@@ -2,28 +2,39 @@ package edu.ucsb.cs156.frontiers.controllers;
 
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.boot.web.servlet.error.ErrorController;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
 
 /**
  * Custom error controller that replaces the default white label error page with a more
  * user-friendly error page.
  */
 @Controller
-public class CustomErrorController implements ErrorController {
+@Slf4j
+public class CustomErrorController extends BasicErrorController {
+
+  public CustomErrorController(ErrorAttributes errorAttributes, ServerProperties properties) {
+    super(errorAttributes, properties.getError());
+  }
 
   /**
    * Handles error requests and returns a custom error page.
    *
    * @param request the HTTP request
-   * @param model the model to pass attributes to the view
+   * @param response the HTTP response
    * @return the name of the error view template
    */
-  @RequestMapping("/error")
-  public String handleError(HttpServletRequest request, Model model) {
+  @RequestMapping(produces = "text/html")
+  @Override
+  public ModelAndView errorHtml(HttpServletRequest request, HttpServletResponse response) {
     // Get error status
     Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
     int statusCode = 500; // Default to internal server error
@@ -56,6 +67,8 @@ public class CustomErrorController implements ErrorController {
       }
     }
 
+    ModelMap model = new ModelMap();
+
     // Add attributes to the model
     model.addAttribute("status", statusCode);
     model.addAttribute("error", HttpStatus.valueOf(statusCode).getReasonPhrase());
@@ -65,6 +78,6 @@ public class CustomErrorController implements ErrorController {
     model.addAttribute("timestamp", java.time.LocalDateTime.now());
     model.addAttribute("path", request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI));
 
-    return "error";
+    return new ModelAndView("error", model);
   }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CustomErrorControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CustomErrorControllerTests.java
@@ -8,6 +8,7 @@ import jakarta.servlet.RequestDispatcher;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(controllers = CustomErrorController.class)
@@ -21,7 +22,8 @@ public class CustomErrorControllerTests extends ControllerTestCase {
             .perform(
                 get("/error")
                     .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 404)
-                    .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/some-non-existent-page"))
+                    .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/some-non-existent-page")
+                    .accept(MediaType.TEXT_HTML))
             .andExpect(status().isOk())
             .andExpect(view().name("error"))
             .andExpect(model().attributeExists("status", "error", "message", "timestamp", "path"))
@@ -43,7 +45,8 @@ public class CustomErrorControllerTests extends ControllerTestCase {
             .perform(
                 get("/error")
                     .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 403)
-                    .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/admin/something"))
+                    .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/admin/something")
+                    .accept(MediaType.TEXT_HTML))
             .andExpect(status().isOk())
             .andExpect(view().name("error"))
             .andExpect(model().attributeExists("status", "error", "message", "timestamp", "path"))
@@ -65,7 +68,8 @@ public class CustomErrorControllerTests extends ControllerTestCase {
                 get("/error")
                     .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 500)
                     .requestAttr(RequestDispatcher.ERROR_EXCEPTION, testException)
-                    .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/api/something"))
+                    .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/api/something")
+                    .accept(MediaType.TEXT_HTML))
             .andExpect(status().isOk())
             .andExpect(view().name("error"))
             .andExpect(
@@ -94,7 +98,8 @@ public class CustomErrorControllerTests extends ControllerTestCase {
             .perform(
                 get("/error")
                     .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/some-path")
-                    .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 400))
+                    .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 400)
+                    .accept(MediaType.TEXT_HTML))
             .andExpect(status().isOk())
             .andExpect(view().name("error"))
             .andExpect(model().attributeExists("status", "error", "message", "timestamp", "path"))
@@ -112,7 +117,8 @@ public class CustomErrorControllerTests extends ControllerTestCase {
             .perform(
                 get("/error")
                     .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 500)
-                    .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/api/something"))
+                    .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/api/something")
+                    .accept(MediaType.TEXT_HTML))
             .andExpect(status().isOk())
             .andExpect(view().name("error"))
             .andExpect(
@@ -130,7 +136,9 @@ public class CustomErrorControllerTests extends ControllerTestCase {
     MvcResult response =
         mockMvc
             .perform(
-                get("/error").requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/api/something"))
+                get("/error")
+                    .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/api/something")
+                    .accept(MediaType.TEXT_HTML))
             .andExpect(status().isOk())
             .andExpect(view().name("error"))
             .andExpect(


### PR DESCRIPTION
In this PR, I narrow the scope of CustomErrorController to only handle text/html errors so that json errors are properly handled by default Spring Boot error handling. CustomErrorController now extends BasicErrorController to keep this functionality. Tests were tweaked to recieve html output.

Deployed to https://frontiers-qa2.dokku-00.cs.ucsb.edu/
