### PR TITLE
pc - backend changes to support CourseStaff full CRUD operations

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
@@ -7,7 +7,6 @@ import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.CourseStaffRepository;
 import edu.ucsb.cs156.frontiers.services.*;
-import edu.ucsb.cs156.frontiers.services.jobs.JobService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "CourseStaff")
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 public class CourseStaffController extends ApiController {
 
-  @Autowired private JobService jobService;
   @Autowired private OrganizationMemberService organizationMemberService;
 
   @Autowired private CourseStaffRepository courseStaffRepository;
@@ -41,8 +40,8 @@ public class CourseStaffController extends ApiController {
    *
    * @return the created CourseStaff
    */
-  @Operation(summary = "Create a new course staff")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @Operation(summary = "Add a staff member to a course")
+  @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
   @PostMapping("/post")
   public CourseStaff postCourseStaff(
       @Parameter(name = "firstName") @RequestParam String firstName,
@@ -84,8 +83,8 @@ public class CourseStaffController extends ApiController {
    *
    * @return a list of all courses.
    */
-  @Operation(summary = "List all course staff for a course")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @Operation(summary = "List all course staff members for a course")
+  @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
   @GetMapping("/course")
   public Iterable<CourseStaff> courseStaffForCourse(
       @Parameter(name = "courseId") @RequestParam Long courseId) throws EntityNotFoundException {
@@ -146,6 +145,76 @@ public class CourseStaffController extends ApiController {
     } else {
       return ResponseEntity.internalServerError()
           .body("Could not invite staff member to Organization");
+    }
+  }
+
+  @Operation(summary = "Update a staff member")
+  @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
+  @PutMapping("")
+  public CourseStaff updateStaffMember(
+      @Parameter(name = "courseId") @RequestParam Long courseId,
+      @Parameter(name = "id") @RequestParam Long id,
+      @Parameter(name = "firstName") @RequestParam String firstName,
+      @Parameter(name = "lastName") @RequestParam String lastName)
+      throws EntityNotFoundException {
+
+    CourseStaff staffMember =
+        courseStaffRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(CourseStaff.class, id));
+
+    staffMember.setFirstName(firstName.trim());
+    staffMember.setLastName(lastName.trim());
+    return courseStaffRepository.save(staffMember);
+  }
+
+  @Operation(summary = "Delete a staff member")
+  @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
+  @DeleteMapping("/delete")
+  @Transactional
+  public ResponseEntity<String> deleteStaffMember(
+      @Parameter(name = "id") @RequestParam Long id,
+      @Parameter(name = "courseId") @RequestParam Long courseId)
+      throws EntityNotFoundException {
+    CourseStaff staffMember =
+        courseStaffRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(CourseStaff.class, id));
+    Course course = staffMember.getCourse();
+
+    boolean orgRemovalAttempted = false;
+    boolean orgRemovalSuccessful = false;
+    String orgRemovalErrorMessage = null;
+
+    // Try to remove the student from the organization if they have a GitHub login
+    if (staffMember.getGithubLogin() != null
+        && course.getOrgName() != null
+        && course.getInstallationId() != null) {
+      orgRemovalAttempted = true;
+      try {
+        organizationMemberService.removeOrganizationMember(staffMember);
+        orgRemovalSuccessful = true;
+      } catch (Exception e) {
+        log.error("Error removing student from organization: {}", e.getMessage());
+        orgRemovalErrorMessage = e.getMessage();
+        // Continue with deletion even if organization removal fails
+      }
+    }
+
+    course.getCourseStaff().remove(staffMember);
+    courseRepository.save(course);
+    courseStaffRepository.delete(staffMember);
+
+    if (!orgRemovalAttempted) {
+      return ResponseEntity.ok(
+          "Successfully deleted staff member and removed them from the staff roster.");
+    } else if (orgRemovalSuccessful) {
+      return ResponseEntity.ok(
+          "Successfully deleted staff member and removed them from the staff roster and organization.");
+    } else {
+      return ResponseEntity.ok(
+          "Successfully deleted staff member but there was an error removing them from the course organization: "
+              + orgRemovalErrorMessage);
     }
   }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
@@ -197,14 +197,52 @@ public class OrganizationMemberService {
       throw new IllegalArgumentException(
           "Cannot remove student from organization: Course has no linked organization");
     }
+    removeOrganizationMember(
+        course.getOrgName(), student.getGithubLogin(), jwtService.getInstallationToken(course));
+  }
 
-    String ENDPOINT =
-        "https://api.github.com/orgs/"
-            + course.getOrgName()
-            + "/members/"
-            + student.getGithubLogin();
+  /**
+   * Removes a member from an organization.
+   *
+   * @param staffMember The staff member to remove from the organization
+   * @throws NoSuchAlgorithmException if there is an algorithm error
+   * @throws InvalidKeySpecException if there is a key specification error
+   * @throws JsonProcessingException if there is an error processing JSON
+   * @throws IllegalArgumentException if student has no GitHub login or course has no linked
+   *     organization
+   * @throws Exception if there is an error removing the student from the organization
+   */
+  public void removeOrganizationMember(CourseStaff staffMember)
+      throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+    if (staffMember.getGithubLogin() == null) {
+      throw new IllegalArgumentException(
+          "Cannot remove staff member from organization: GitHub login is null");
+    }
+
+    Course course = staffMember.getCourse();
+    if (course.getOrgName() == null || course.getInstallationId() == null) {
+      throw new IllegalArgumentException(
+          "Cannot remove staff member from organization: Course has no linked organization");
+    }
+    removeOrganizationMember(
+        course.getOrgName(), staffMember.getGithubLogin(), jwtService.getInstallationToken(course));
+  }
+
+  /**
+   * Remove member from organization
+   *
+   * @param orgName
+   * @param githubLogin
+   * @param token
+   * @throws NoSuchAlgorithmException
+   * @throws InvalidKeySpecException
+   * @throws JsonProcessingException
+   */
+  public void removeOrganizationMember(String orgName, String githubLogin, String token)
+      throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+
+    String ENDPOINT = "https://api.github.com/orgs/" + orgName + "/members/" + githubLogin;
     HttpHeaders headers = new HttpHeaders();
-    String token = jwtService.getInstallationToken(course);
 
     headers.add("Authorization", "Bearer " + token);
     headers.add("Accept", "application/vnd.github+json");
@@ -212,9 +250,6 @@ public class OrganizationMemberService {
     HttpEntity<String> entity = new HttpEntity<>(headers);
 
     restTemplate.exchange(ENDPOINT, HttpMethod.DELETE, entity, String.class);
-    log.info(
-        "Successfully removed student {} from organization {}",
-        student.getGithubLogin(),
-        course.getOrgName());
+    log.info("Successfully removed student {} from organization {}", githubLogin, orgName);
   }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffControllerTests.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.annotations.WithInstructorCoursePermissions;
 import edu.ucsb.cs156.frontiers.entities.*;
 import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
@@ -18,10 +19,14 @@ import edu.ucsb.cs156.frontiers.services.CurrentUserService;
 import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
 import edu.ucsb.cs156.frontiers.services.UpdateUserService;
 import edu.ucsb.cs156.frontiers.services.jobs.JobService;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -320,9 +325,10 @@ public class CourseStaffControllerTests extends ControllerTestCase {
     String responseString = response.getResponse().getContentAsString();
     Map<String, String> expectedMap =
         Map.of(
-            "type", "IllegalArgumentException",
+            "type",
+            "IllegalArgumentException",
             "message",
-                "This operation is restricted to the user associated with staff member with id 4");
+            "This operation is restricted to the user associated with staff member with id 4");
     String expectedJson = mapper.writeValueAsString(expectedMap);
     assertEquals(expectedJson, responseString);
     verify(courseStaffRepository, never()).save(any(CourseStaff.class));
@@ -354,9 +360,10 @@ public class CourseStaffControllerTests extends ControllerTestCase {
     String responseString = response.getResponse().getContentAsString();
     Map<String, String> expectedMap =
         Map.of(
-            "type", "IllegalArgumentException",
+            "type",
+            "IllegalArgumentException",
             "message",
-                "This operation is restricted to the user associated with staff member with id 4");
+            "This operation is restricted to the user associated with staff member with id 4");
     String expectedJson = mapper.writeValueAsString(expectedMap);
     assertEquals(expectedJson, responseString);
     verify(courseStaffRepository, never()).save(any(CourseStaff.class));
@@ -779,5 +786,368 @@ public class CourseStaffControllerTests extends ControllerTestCase {
     assertEquals(
         "Could not invite staff member to Organization",
         response.getResponse().getContentAsString());
+  }
+
+  @Test
+  @WithInstructorCoursePermissions
+  public void testUpdateRosterStudent_success() throws Exception {
+    CourseStaff existingStaffMember =
+        CourseStaff.builder()
+            .id(1L)
+            .firstName("Old")
+            .lastName("OldName")
+            .email("old@ucsb.edu")
+            .course(course1)
+            .orgStatus(OrgStatus.PENDING)
+            .build();
+
+    CourseStaff updatedStaffMember =
+        CourseStaff.builder()
+            .id(1L)
+            .firstName("New")
+            .lastName("NewName")
+            .email("old@ucsb.edu")
+            .course(course1)
+            .orgStatus(OrgStatus.PENDING)
+            .build();
+
+    when(courseStaffRepository.findById(eq(1L))).thenReturn(Optional.of(existingStaffMember));
+    when(courseStaffRepository.save(any(CourseStaff.class))).thenReturn(updatedStaffMember);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/coursestaff")
+                    .with(csrf())
+                    .param("courseId", "1")
+                    .param("id", "1")
+                    .param("firstName", "   New   ")
+                    .param("lastName", "   NewName   "))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ArgumentCaptor<CourseStaff> captor = ArgumentCaptor.forClass(CourseStaff.class);
+    verify(courseStaffRepository).save(captor.capture());
+    CourseStaff saved = captor.getValue();
+    assertEquals("New", saved.getFirstName());
+    assertEquals("NewName", saved.getLastName());
+
+    String responseString = response.getResponse().getContentAsString();
+    String expectedJson = mapper.writeValueAsString(updatedStaffMember);
+    assertEquals(expectedJson, responseString);
+  }
+
+  @Test
+  @WithInstructorCoursePermissions
+  public void testUpdateRosterStudent_course_not_found() throws Exception {
+
+    when(courseRepository.findById(eq(42L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/coursestaff")
+                    .with(csrf())
+                    .param("courseId", "42")
+                    .param("id", "1")
+                    .param("firstName", "   New   ")
+                    .param("lastName", "   NewName   "))
+            .andExpect(status().isNotFound())
+            .andReturn();
+  }
+
+  @Test
+  @WithInstructorCoursePermissions
+  public void testDeleteCourseStaff_success() throws Exception {
+    CourseStaff staffMember =
+        CourseStaff.builder()
+            .id(1L)
+            .firstName("Test")
+            .lastName("Staff")
+            .email("teststaff@ucsb.edu")
+            .course(course1)
+            .orgStatus(OrgStatus.PENDING)
+            .build();
+
+    List<CourseStaff> staffList = new ArrayList<>();
+    staffList.add(staffMember);
+    course1.setCourseStaff(staffList);
+
+    List<CourseStaff> staffListSpy = Mockito.spy(staffList);
+    course1.setCourseStaff(staffListSpy);
+
+    when(courseStaffRepository.findById(eq(1L))).thenReturn(Optional.of(staffMember));
+    when(courseRepository.save(any(Course.class))).thenReturn(course1);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                delete("/api/coursestaff/delete")
+                    .with(csrf())
+                    .param("id", "1")
+                    .param("courseId", "7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(courseStaffRepository).findById(eq(1L));
+    verify(courseRepository).save(any(Course.class));
+    verify(courseStaffRepository).delete(eq(staffMember));
+    verify(staffListSpy).remove(eq(staffMember));
+    // Since the staff member doesn't have a GitHub login, removeOrganizationMember
+    // should not be called
+    verify(organizationMemberService, never()).removeOrganizationMember(any(CourseStaff.class));
+
+    assertEquals(
+        "Successfully deleted staff member and removed them from the staff roster.",
+        response.getResponse().getContentAsString());
+  }
+
+  @Test
+  @WithInstructorCoursePermissions
+  public void testDeleteCourseStaff_withGithubLogin_success() throws Exception {
+    course1.setOrgName("test-org");
+    course1.setInstallationId("12345");
+
+    CourseStaff staffMember =
+        CourseStaff.builder()
+            .id(1L)
+            .firstName("Test")
+            .lastName("Staff")
+            .email("teststaff@ucsb.edu")
+            .course(course1)
+            .orgStatus(OrgStatus.MEMBER)
+            .githubId(67890)
+            .githubLogin("teststaff")
+            .build();
+
+    List<CourseStaff> staffList = new ArrayList<>();
+    staffList.add(staffMember);
+    course1.setCourseStaff(staffList);
+
+    List<CourseStaff> staffListSpy = Mockito.spy(staffList);
+    course1.setCourseStaff(staffListSpy);
+
+    when(courseStaffRepository.findById(eq(1L))).thenReturn(Optional.of(staffMember));
+    when(courseRepository.save(any(Course.class))).thenReturn(course1);
+    doNothing().when(organizationMemberService).removeOrganizationMember(any(CourseStaff.class));
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                delete("/api/coursestaff/delete")
+                    .with(csrf())
+                    .param("id", "1")
+                    .param("courseId", "7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(courseStaffRepository).findById(eq(1L));
+    verify(courseRepository).save(any(Course.class));
+    verify(courseStaffRepository).delete(eq(staffMember));
+    verify(staffListSpy).remove(eq(staffMember));
+    verify(organizationMemberService).removeOrganizationMember(eq(staffMember));
+
+    assertEquals(
+        "Successfully deleted staff member and removed them from the staff roster and organization.",
+        response.getResponse().getContentAsString());
+  }
+
+  @Test
+  @WithInstructorCoursePermissions
+  public void testDeleteCourseStaff_withGithubLogin_noOrgName_success() throws Exception {
+    course1.setOrgName(null);
+    course1.setInstallationId("12345");
+
+    CourseStaff staffMember =
+        CourseStaff.builder()
+            .id(1L)
+            .firstName("Test")
+            .lastName("Staff")
+            .email("teststaff@ucsb.edu")
+            .course(course1)
+            .orgStatus(OrgStatus.MEMBER)
+            .githubId(67890)
+            .githubLogin("teststaff")
+            .build();
+
+    List<CourseStaff> staffList = new ArrayList<>();
+    staffList.add(staffMember);
+    course1.setCourseStaff(staffList);
+
+    List<CourseStaff> staffListSpy = Mockito.spy(staffList);
+    course1.setCourseStaff(staffListSpy);
+
+    when(courseStaffRepository.findById(eq(1L))).thenReturn(Optional.of(staffMember));
+    when(courseRepository.save(any(Course.class))).thenReturn(course1);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                delete("/api/coursestaff/delete")
+                    .with(csrf())
+                    .param("id", "1")
+                    .param("courseId", "7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(courseStaffRepository).findById(eq(1L));
+    verify(courseRepository).save(any(Course.class));
+    verify(courseStaffRepository).delete(eq(staffMember));
+    verify(staffListSpy).remove(eq(staffMember));
+    verify(organizationMemberService, never()).removeOrganizationMember(any(CourseStaff.class));
+
+    assertEquals(
+        "Successfully deleted staff member and removed them from the staff roster.",
+        response.getResponse().getContentAsString());
+  }
+
+  @Test
+  @WithInstructorCoursePermissions
+  public void testDeleteCourseStaff_withGithubLogin_noInstallationId_success() throws Exception {
+    course1.setOrgName("test-org");
+    course1.setInstallationId(null);
+
+    CourseStaff staffMember =
+        CourseStaff.builder()
+            .id(1L)
+            .firstName("Test")
+            .lastName("Staff")
+            .email("teststaff@ucsb.edu")
+            .course(course1)
+            .orgStatus(OrgStatus.MEMBER)
+            .githubId(67890)
+            .githubLogin("teststaff")
+            .build();
+
+    List<CourseStaff> staffList = new ArrayList<>();
+    staffList.add(staffMember);
+    course1.setCourseStaff(staffList);
+
+    List<CourseStaff> staffListSpy = Mockito.spy(staffList);
+    course1.setCourseStaff(staffListSpy);
+
+    when(courseStaffRepository.findById(eq(1L))).thenReturn(Optional.of(staffMember));
+    when(courseRepository.save(any(Course.class))).thenReturn(course1);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                delete("/api/coursestaff/delete")
+                    .with(csrf())
+                    .param("id", "1")
+                    .param("courseId", "1"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(courseStaffRepository).findById(eq(1L));
+    verify(courseRepository).save(any(Course.class));
+    verify(courseStaffRepository).delete(eq(staffMember));
+    verify(staffListSpy).remove(eq(staffMember));
+    verify(organizationMemberService, never()).removeOrganizationMember(any(CourseStaff.class));
+
+    assertEquals(
+        "Successfully deleted staff member and removed them from the staff roster.",
+        response.getResponse().getContentAsString());
+  }
+
+  @Test
+  @WithInstructorCoursePermissions
+  public void testDeleteCourseStaff_withGithubLogin_orgRemovalFails() throws Exception {
+    course1.setOrgName("test-org");
+    course1.setInstallationId("12345");
+
+    CourseStaff staffMember =
+        CourseStaff.builder()
+            .id(1L)
+            .firstName("Test")
+            .lastName("Staff")
+            .email("teststaff@ucsb.edu")
+            .course(course1)
+            .orgStatus(OrgStatus.MEMBER)
+            .githubId(67890)
+            .githubLogin("teststaff")
+            .build();
+
+    List<CourseStaff> staffList = new ArrayList<>();
+    staffList.add(staffMember);
+    course1.setCourseStaff(staffList);
+
+    List<CourseStaff> staffListSpy = Mockito.spy(staffList);
+    course1.setCourseStaff(staffListSpy);
+
+    when(courseStaffRepository.findById(eq(1L))).thenReturn(Optional.of(staffMember));
+    when(courseRepository.save(any(Course.class))).thenReturn(course1);
+
+    String errorMessage = "API rate limit exceeded";
+    doThrow(new RuntimeException(errorMessage))
+        .when(organizationMemberService)
+        .removeOrganizationMember(any(CourseStaff.class));
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                delete("/api/coursestaff/delete")
+                    .with(csrf())
+                    .param("id", "1")
+                    .param("courseId", "1"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(courseStaffRepository).findById(eq(1L));
+    verify(courseRepository).save(any(Course.class));
+    verify(courseStaffRepository).delete(eq(staffMember));
+    verify(staffListSpy).remove(eq(staffMember));
+    verify(organizationMemberService).removeOrganizationMember(eq(staffMember));
+
+    assertEquals(
+        "Successfully deleted staff member but there was an error removing them from the course organization: "
+            + errorMessage,
+        response.getResponse().getContentAsString());
+  }
+
+  @Test
+  @WithInstructorCoursePermissions
+  public void testDeleteCourseStaff_notFound() throws Exception {
+    when(courseStaffRepository.findById(eq(99L))).thenReturn(Optional.empty());
+    when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));
+    MvcResult response =
+        mockMvc
+            .perform(
+                delete("/api/coursestaff/delete")
+                    .with(csrf())
+                    .param("id", "99")
+                    .param("courseId", "1"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(courseStaffRepository).findById(eq(99L));
+    verify(courseStaffRepository, never()).delete(any(CourseStaff.class));
+    verify(courseRepository, never()).save(any(Course.class));
+
+    String responseString = response.getResponse().getContentAsString();
+    Map<String, String> expectedMap =
+        Map.of(
+            "type", "EntityNotFoundException",
+            "message", "CourseStaff with id 99 not found");
+    String expectedJson = mapper.writeValueAsString(expectedMap);
+    assertEquals(expectedJson, responseString);
+  }
+
+  @Test
+  @WithMockUser(roles = {"USER"})
+  public void testDeleteCourseStaff_unauthorized() throws Exception {
+    MvcResult response =
+        mockMvc
+            .perform(
+                delete("/api/coursestaff/delete")
+                    .with(csrf())
+                    .param("id", "1")
+                    .param("courseId", "7"))
+            .andExpect(status().isForbidden())
+            .andReturn();
+
+    verify(courseStaffRepository, never()).findById(any());
+    verify(courseStaffRepository, never()).delete(any(CourseStaff.class));
+    verify(courseRepository, never()).save(any(Course.class));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
@@ -463,7 +463,6 @@ public class CoursesControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, responseString);
   }
 
-  /** Test the POST endpoint */
   @Test
   public void testListCoursesForCurrentUser() throws Exception {
     String email = "student@example.com";

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberServiceTests.java
@@ -533,6 +533,26 @@ public class OrganizationMemberServiceTests {
   }
 
   @Test
+  void testRemoveOrganizationMember_Success_staffMember() throws Exception {
+    CourseStaff testStaffMember =
+        CourseStaff.builder().githubId(12345).githubLogin("testuser").course(testCourse).build();
+
+    mockServer
+        .expect(requestTo("https://api.github.com/orgs/" + TEST_ORG + "/members/testuser"))
+        .andExpect(method(HttpMethod.DELETE))
+        .andExpect(header("Authorization", "Bearer " + TEST_TOKEN))
+        .andExpect(header("Accept", "application/vnd.github+json"))
+        .andExpect(header("X-GitHub-Api-Version", "2022-11-28"))
+        .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+    // No exception should be thrown
+    organizationMemberService.removeOrganizationMember(testStaffMember);
+
+    mockServer.verify();
+    // No assertion needed as we're just verifying no exception is thrown
+  }
+
+  @Test
   void testRemoveOrganizationMember_NullGithubLogin() throws Exception {
     RosterStudent testStudent =
         RosterStudent.builder().githubId(12345).githubLogin(null).course(testCourse).build();
@@ -574,6 +594,50 @@ public class OrganizationMemberServiceTests {
   }
 
   @Test
+  void testRemoveOrganizationMember_NullOrgName_staffMember() throws Exception {
+    Course courseWithoutOrg = Course.builder().installationId("123").orgName(null).build();
+
+    CourseStaff testStaffMember =
+        CourseStaff.builder()
+            .githubId(12345)
+            .githubLogin("testuser")
+            .course(courseWithoutOrg)
+            .build();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              organizationMemberService.removeOrganizationMember(testStaffMember);
+            });
+
+    assertEquals(
+        "Cannot remove staff member from organization: Course has no linked organization",
+        exception.getMessage());
+    mockServer.verify();
+  }
+
+  @Test
+  void testRemoveOrganizationMember_NullGithubLogin_staffMember() throws Exception {
+    Course courseWithoutOrg = Course.builder().installationId("123").orgName(null).build();
+
+    CourseStaff testStaffMember =
+        CourseStaff.builder().githubId(12345).githubLogin(null).course(courseWithoutOrg).build();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              organizationMemberService.removeOrganizationMember(testStaffMember);
+            });
+
+    assertEquals(
+        "Cannot remove staff member from organization: GitHub login is null",
+        exception.getMessage());
+    mockServer.verify();
+  }
+
+  @Test
   void testRemoveOrganizationMember_NullInstallationId() throws Exception {
     Course courseWithoutInstallation =
         Course.builder().orgName(TEST_ORG).installationId(null).build();
@@ -594,6 +658,31 @@ public class OrganizationMemberServiceTests {
 
     assertEquals(
         "Cannot remove student from organization: Course has no linked organization",
+        exception.getMessage());
+    mockServer.verify();
+  }
+
+  @Test
+  void testRemoveOrganizationMember_NullInstallationId_staffMember() throws Exception {
+    Course courseWithoutInstallation =
+        Course.builder().orgName(TEST_ORG).installationId(null).build();
+
+    CourseStaff testStaffMember =
+        CourseStaff.builder()
+            .githubId(12345)
+            .githubLogin("testuser")
+            .course(courseWithoutInstallation)
+            .build();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              organizationMemberService.removeOrganizationMember(testStaffMember);
+            });
+
+    assertEquals(
+        "Cannot remove staff member from organization: Course has no linked organization",
         exception.getMessage());
     mockServer.verify();
   }


### PR DESCRIPTION
In this PR, we add PUT and DELETE endpoints for CourseStaff (just the backend) to support being able to:

* Modify staff members to update first name, last name.
* Delete staff members.