### PR TITLE
Allowing Course Staff to Complete Actions

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
@@ -41,7 +41,7 @@ public class CourseStaffController extends ApiController {
    * @return the created CourseStaff
    */
   @Operation(summary = "Add a staff member to a course")
-  @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
+  @PreAuthorize("@CourseSecurity.hasInstructorPermissions(#root, #courseId)")
   @PostMapping("/post")
   public CourseStaff postCourseStaff(
       @Parameter(name = "firstName") @RequestParam String firstName,
@@ -149,7 +149,7 @@ public class CourseStaffController extends ApiController {
   }
 
   @Operation(summary = "Update a staff member")
-  @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
+  @PreAuthorize("@CourseSecurity.hasInstructorPermissions(#root, #courseId)")
   @PutMapping("")
   public CourseStaff updateStaffMember(
       @Parameter(name = "courseId") @RequestParam Long courseId,
@@ -169,7 +169,7 @@ public class CourseStaffController extends ApiController {
   }
 
   @Operation(summary = "Delete a staff member")
-  @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
+  @PreAuthorize("@CourseSecurity.hasInstructorPermissions(#root, #courseId)")
   @DeleteMapping("/delete")
   @Transactional
   public ResponseEntity<String> deleteStaffMember(

--- a/src/test/java/edu/ucsb/cs156/frontiers/annotations/WithInstructorCoursePermissions.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/annotations/WithInstructorCoursePermissions.java
@@ -8,7 +8,8 @@ import org.springframework.security.test.context.support.WithMockUser;
  * This annotation interacts with the mock CourseSecurity annotation. It adds authorities that tell
  * the CourseSecurity annotation used in testing that the user has permission to manage the course
  * being accessed. It should be used on methods that have the
- * <i>@PreAuthorize("@CourseSecurity.hasManagePermissions")</i> annotation. This should not be
+ * <i>@PreAuthorize("@CourseSecurity.hasManagePermissions")</i> or
+ * <i>@PreAuthorize("@CourseSecurity.hasInstructorPermissions")</i> annotations. This should not be
  * combined with <i>@WithMockUser</i>, because this annotation implies
  * <i>@WithMockUser("ROLE_INSTRUCTOR")</i>
  */

--- a/src/test/java/edu/ucsb/cs156/frontiers/security/CourseSecurityTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/security/CourseSecurityTests.java
@@ -5,11 +5,13 @@ import static org.mockito.Mockito.when;
 
 import edu.ucsb.cs156.frontiers.config.CourseSecurity;
 import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.CourseStaff;
 import edu.ucsb.cs156.frontiers.entities.User;
 import edu.ucsb.cs156.frontiers.models.CurrentUser;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import edu.ucsb.cs156.frontiers.services.CurrentUserService;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +51,8 @@ public class CourseSecurityTests {
     public void setup() {
       User user = User.builder().id(1L).email("admin@example.com").build();
       User user2 = User.builder().id(2L).email("instructor@example.com").build();
-      Course testCourse = Course.builder().id(1L).instructorEmail(user2.getEmail()).build();
+      Course testCourse =
+          Course.builder().id(1L).instructorEmail(user2.getEmail()).courseStaff(List.of()).build();
       when(currentUserService.getCurrentUser())
           .thenReturn(
               CurrentUser.builder()
@@ -69,11 +72,43 @@ public class CourseSecurityTests {
   }
 
   @Nested
+  public class SuccessfulCourseStaff {
+    @BeforeEach
+    public void setup() {
+      User user = User.builder().id(1L).email("coursestaff@example.com").build();
+      CourseStaff courseStaff =
+          CourseStaff.builder().id(1L).user(user).email("coursestaff@example.com").build();
+      Course testCourse =
+          Course.builder()
+              .id(1L)
+              .instructorEmail("alternateemail@ucsb.edu")
+              .courseStaff(List.of(courseStaff))
+              .build();
+      when(currentUserService.getCurrentUser())
+          .thenReturn(
+              CurrentUser.builder()
+                  .user(user)
+                  .roles(Set.of(new SimpleGrantedAuthority("ROLE_USER")))
+                  .build());
+      when(courseRepository.findById(1L)).thenReturn(java.util.Optional.of(testCourse));
+    }
+
+    @Test
+    @WithMockUser(
+        setupBefore = TestExecutionEvent.TEST_EXECUTION,
+        roles = {"INSTRUCTOR"})
+    public void instructor_can_load_owned_course() {
+      DummyCourseSecurity.loadCourse(1L);
+    }
+  }
+
+  @Nested
   public class SuccessfulInstructor {
     @BeforeEach
     public void setup() {
       User user = User.builder().id(1L).email("instructor@example.com").build();
-      Course testCourse = Course.builder().id(1L).instructorEmail(user.getEmail()).build();
+      Course testCourse =
+          Course.builder().id(1L).instructorEmail(user.getEmail()).courseStaff(List.of()).build();
       when(currentUserService.getCurrentUser())
           .thenReturn(
               CurrentUser.builder()
@@ -98,7 +133,14 @@ public class CourseSecurityTests {
     public void setup() {
       User user = User.builder().id(1L).email("instructor1@example.com").build();
       User user2 = User.builder().id(2L).email("instructor2@example.com").build();
-      Course testCourse = Course.builder().id(1L).instructorEmail(user2.getEmail()).build();
+      CourseStaff courseStaff =
+          CourseStaff.builder().id(1L).user(user).email("coursestaff@example.com").build();
+      Course testCourse =
+          Course.builder()
+              .id(1L)
+              .instructorEmail(user2.getEmail())
+              .courseStaff(List.of(courseStaff))
+              .build();
       when(currentUserService.getCurrentUser())
           .thenReturn(
               CurrentUser.builder()
@@ -137,6 +179,110 @@ public class CourseSecurityTests {
         roles = {"INSTRUCTOR"})
     public void null_on_null() {
       assertTrue(DummyCourseSecurity.nullTest(1L));
+    }
+  }
+
+  @Nested
+  public class SuccessfulAdminPerms {
+
+    @BeforeEach
+    public void setup() {
+      User user = User.builder().id(1L).email("admin@example.com").build();
+      User user2 = User.builder().id(2L).email("instructor@example.com").build();
+      Course testCourse =
+          Course.builder().id(1L).instructorEmail(user2.getEmail()).courseStaff(List.of()).build();
+      when(currentUserService.getCurrentUser())
+          .thenReturn(
+              CurrentUser.builder()
+                  .user(user)
+                  .roles(Set.of(new SimpleGrantedAuthority("ROLE_ADMIN")))
+                  .build());
+      when(courseRepository.findById(1L)).thenReturn(java.util.Optional.of(testCourse));
+    }
+
+    @Test
+    @WithMockUser(
+        setupBefore = TestExecutionEvent.TEST_EXECUTION,
+        roles = {"ADMIN"})
+    public void instructor_can_load_owned_course() {
+      DummyCourseSecurity.loadCourseInstructor(1L);
+    }
+  }
+
+  @Nested
+  public class SuccessfulInstructorPerms {
+
+    @BeforeEach
+    public void setup() {
+      User user = User.builder().id(1L).email("instructor@example.com").build();
+      Course testCourse =
+          Course.builder().id(1L).instructorEmail(user.getEmail()).courseStaff(List.of()).build();
+      when(currentUserService.getCurrentUser())
+          .thenReturn(
+              CurrentUser.builder()
+                  .user(user)
+                  .roles(Set.of(new SimpleGrantedAuthority("ROLE_INSTRUCTOR")))
+                  .build());
+      when(courseRepository.findById(1L)).thenReturn(java.util.Optional.of(testCourse));
+    }
+
+    @Test
+    @WithMockUser(
+        setupBefore = TestExecutionEvent.TEST_EXECUTION,
+        roles = {"INSTRUCTOR"})
+    public void instructor_can_load_owned_course() {
+      DummyCourseSecurity.loadCourseInstructor(1L);
+    }
+  }
+
+  @Nested
+  public class UnsuccessfulInstructorPerms {
+
+    @BeforeEach
+    public void setup() {
+      User user = User.builder().id(1L).email("instructor1@example.com").build();
+      User user2 = User.builder().id(2L).email("instructor2@example.com").build();
+      Course testCourse =
+          Course.builder().id(1L).instructorEmail(user2.getEmail()).courseStaff(List.of()).build();
+      when(currentUserService.getCurrentUser())
+          .thenReturn(
+              CurrentUser.builder()
+                  .user(user)
+                  .roles(Set.of(new SimpleGrantedAuthority("ROLE_INSTRUCTOR")))
+                  .build());
+      when(courseRepository.findById(1L)).thenReturn(java.util.Optional.of(testCourse));
+    }
+
+    @Test
+    @WithMockUser(
+        setupBefore = TestExecutionEvent.TEST_EXECUTION,
+        roles = {"INSTRUCTOR"})
+    public void instructor_cant_load_non_owned_course() {
+      assertThrows(AccessDeniedException.class, () -> DummyCourseSecurity.loadCourseInstructor(1L));
+    }
+  }
+
+  @Nested
+  public class NotFoundInstructor {
+
+    @BeforeEach
+    public void setup() {
+      User user = User.builder().id(1L).build();
+      when(currentUserService.getCurrentUser())
+          .thenReturn(
+              CurrentUser.builder()
+                  .user(user)
+                  .roles(Set.of(new SimpleGrantedAuthority("ROLE_INSTRUCTOR")))
+                  .build());
+      when(courseRepository.findById(1L)).thenReturn(Optional.empty());
+    }
+
+    @Test
+    @WithMockUser(
+        setupBefore = TestExecutionEvent.TEST_EXECUTION,
+        roles = {"INSTRUCTOR"})
+    public void null_on_null() {
+      assertTrue(DummyCourseSecurity.nullTestInstructor(1L));
     }
   }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/security/DummyCourseSecurity.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/security/DummyCourseSecurity.java
@@ -34,6 +34,25 @@ public class DummyCourseSecurity {
     }
   }
 
+  @PreAuthorize("@CourseSecurity.hasInstructorPermissions(#root, #courseId)")
+  public Course loadCourseInstructor(Long courseId) {
+    /*
+    This method simply exists to add the preauthorization annotation so that the method can be tested directly.
+     */
+    return courseRepository
+        .findById(courseId)
+        .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
+  }
+
+  @PreAuthorize("@CourseSecurity.hasInstructorPermissions(#root, #courseId)")
+  public boolean nullTestInstructor(Long courseId) {
+    if (courseRepository.findById(courseId).isEmpty()) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   @Bean
   public static RoleHierarchy loadedRoleHierarchy() {
     return SecurityConfig.roleHierarchy();

--- a/src/test/java/edu/ucsb/cs156/frontiers/testconfig/TestCourseSecurity.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/testconfig/TestCourseSecurity.java
@@ -7,8 +7,15 @@ import org.springframework.security.access.prepost.PreAuthorize;
 @TestComponent("CourseSecurity")
 public class TestCourseSecurity {
   @PreAuthorize(
-      "(hasRole('ROLE_INSTRUCTOR') && hasAuthority('COURSE_PERMISSIONS'))|| hasRole('ROLE_ADMIN')")
+      "((hasRole('ROLE_INSTRUCTOR') || hasRole('ROLE_USER')) && hasAuthority('COURSE_PERMISSIONS'))|| hasRole('ROLE_ADMIN')")
   public Boolean hasManagePermissions(
+      MethodSecurityExpressionOperations operations, Long courseId) {
+    return true;
+  }
+
+  @PreAuthorize(
+      "(hasRole('ROLE_INSTRUCTOR') && hasAuthority('COURSE_PERMISSIONS'))|| hasRole('ROLE_ADMIN')")
+  public Boolean hasInstructorPermissions(
       MethodSecurityExpressionOperations operations, Long courseId) {
     return true;
   }


### PR DESCRIPTION
In this PR, I add a new annotation to CourseSecurity (`hasInstructorPermissions`) that checks to see if the User is the Instructor of Record (instructor email) for a course. Additionally, I add a check to `hasManagePermissions` to allow course staff to perform actions labelled with this annotation.

Test Plan:
1. As a course staff member, attempt to post a roster student
2. As a course staff member, attempt to post another course staff member
3. See that you fail to post another course staff member
4. As an instructor, post another course staff member.

Deployed to https://frontiers-qa1.dokku-00.cs.ucsb.edu/