### PR TITLE
Ensuring Student Email and Student ID come from the same Roster Student

### DIFF
--- a/docs/examples/egrades_with_duplicate_emails.csv
+++ b/docs/examples/egrades_with_duplicate_emails.csv
@@ -1,0 +1,6 @@
+Enrl Cd,Perm #,Grade,Final Units,Student Last,Student First Middle,Quarter,Course ID,Section,Meeting Time(s) / Location(s),Email,ClassLevel,Major1,Major2,Date/Time,Pronoun
+
+08235,A123456,,4.0,GAUCHO,CHRIS FAKE,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,cgaucho@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,
+08250,A987654,,4.0,DEL PLAYA,LAUREN,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,ldelplaya@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,She (She/Her/Hers)
+08243,1234567,,4.0,TARDE,SABADO,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,sabadotarde@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,He (He/Him/His)
+08243,7654321,,4.0,TARDE,DOMINGO,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,sabadotarde@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,He (He/Him/His)

--- a/docs/examples/egrades_with_duplicate_ids.csv
+++ b/docs/examples/egrades_with_duplicate_ids.csv
@@ -1,0 +1,6 @@
+Enrl Cd,Perm #,Grade,Final Units,Student Last,Student First Middle,Quarter,Course ID,Section,Meeting Time(s) / Location(s),Email,ClassLevel,Major1,Major2,Date/Time,Pronoun
+
+08235,A123456,,4.0,GAUCHO,CHRIS FAKE,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,cgaucho@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,
+08250,A987654,,4.0,DEL PLAYA,LAUREN,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,ldelplaya@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,She (She/Her/Hers)
+08243,1234567,,4.0,TARDE,SABADO,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,sabadotarde@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,He (He/Him/His)
+08243,1234567,,4.0,TARDE,DOMINGO WITH THE SAME ID,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,domingotarde@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,He (He/Him/His)

--- a/docs/examples/egrades_with_email_and_student_ids_from_diff_students.csv
+++ b/docs/examples/egrades_with_email_and_student_ids_from_diff_students.csv
@@ -1,0 +1,5 @@
+Enrl Cd,Perm #,Grade,Final Units,Student Last,Student First Middle,Quarter,Course ID,Section,Meeting Time(s) / Location(s),Email,ClassLevel,Major1,Major2,Date/Time,Pronoun
+
+08235,A123456,,4.0,GAUCHO,CHRIS FAKE,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,cgaucho@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,
+08250,A987654,,4.0,DEL PLAYA,LAUREN,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,ldelplaya@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,She (She/Her/Hers)
+08243,A123456,,4.0,TARDE,SABADO,F23,CMPSC156,0100,T R   2:00- 3:15 SH 1431     W    5:00- 5:50 PHELP 3525  W    6:00- 6:50 PHELP 3525  W    7:00- 7:50 PHELP 3525  ,ldelplaya@umail.ucsb.edu,SR,CMPSC,,9/27/2023 9:39:25 AM,He (He/Him/His)

--- a/frontend/src/fixtures/rosterStudentFixtures.js
+++ b/frontend/src/fixtures/rosterStudentFixtures.js
@@ -94,4 +94,17 @@ const rosterStudentFixtures = {
   ],
 };
 
-export { rosterStudentFixtures };
+const loadResultFixtures = {
+  successful: {
+    created: 1,
+    updated: 2,
+    rejected: [],
+  },
+  failed: {
+    created: 3,
+    updated: 4,
+    rejected: rosterStudentFixtures.oneStudent,
+  },
+};
+
+export { rosterStudentFixtures, loadResultFixtures };

--- a/frontend/src/main/components/TabComponent/EnrollmentTabComponent.jsx
+++ b/frontend/src/main/components/TabComponent/EnrollmentTabComponent.jsx
@@ -64,7 +64,14 @@ export default function EnrollmentTabComponent({
 
   const rosterPostMutation = useBackendMutation(
     objectToAxiosParamsPost,
-    { onSuccess: () => onSuccessRoster(setPostModal) },
+    {
+      onSuccess: () => onSuccessRoster(setPostModal),
+      onError: (error) => {
+        toast.error(
+          `Error adding student: ${JSON.stringify(error.response.data, null, 2)}`,
+        );
+      },
+    },
     [`/api/rosterstudents/course/${courseId}`],
   );
 

--- a/frontend/src/main/components/TabComponent/EnrollmentTabComponent.jsx
+++ b/frontend/src/main/components/TabComponent/EnrollmentTabComponent.jsx
@@ -19,8 +19,8 @@ export default function EnrollmentTabComponent({
   testIdPrefix,
   currentUser,
 }) {
-  const [postModal, showPostModal] = useState(false);
-  const [csvModal, showCsvModal] = useState(false);
+  const [postModal, setPostModal] = useState(false);
+  const [csvModal, setCsvModal] = useState(false);
   const { data: rosterStudents } = useBackend(
     [`/api/rosterstudents/course/${courseId}`],
     // Stryker disable next-line StringLiteral : GET and empty string are equivalent
@@ -64,13 +64,20 @@ export default function EnrollmentTabComponent({
 
   const rosterPostMutation = useBackendMutation(
     objectToAxiosParamsPost,
-    { onSuccess: () => onSuccessRoster(showPostModal) },
+    { onSuccess: () => onSuccessRoster(setPostModal) },
     [`/api/rosterstudents/course/${courseId}`],
   );
 
   const rosterCsvMutation = useBackendMutation(
     objectToAxiosParamsCSV,
-    { onSuccess: () => onSuccessRoster(showCsvModal) },
+    {
+      onSuccess: () => onSuccessRoster(setCsvModal),
+      onError: (error) => {
+        toast.error(
+          `Error uploading CSV: ${JSON.stringify(error.response.data, null, 2)}`,
+        );
+      },
+    },
     [`/api/rosterstudents/course/${courseId}`],
   );
 
@@ -90,7 +97,7 @@ export default function EnrollmentTabComponent({
     <div data-testid={`${testIdPrefix}-EnrollmentTabComponent`}>
       <Modal
         show={csvModal}
-        onHide={() => showCsvModal(false)}
+        onHide={() => setCsvModal(false)}
         centered={true}
         data-testid={`${testIdPrefix}-csv-modal`}
       >
@@ -101,7 +108,7 @@ export default function EnrollmentTabComponent({
       </Modal>
       <Modal
         show={postModal}
-        onHide={() => showPostModal(false)}
+        onHide={() => setPostModal(false)}
         centered={true}
         data-testid={`${testIdPrefix}-post-modal`}
       >
@@ -134,7 +141,7 @@ export default function EnrollmentTabComponent({
       <Row sm={3} className="p-2">
         <Col>
           <Button
-            onClick={() => showCsvModal(true)}
+            onClick={() => setCsvModal(true)}
             data-testid={`${testIdPrefix}-csv-button`}
             className="w-100"
           >
@@ -143,7 +150,7 @@ export default function EnrollmentTabComponent({
         </Col>
         <Col>
           <Button
-            onClick={() => showPostModal(true)}
+            onClick={() => setPostModal(true)}
             data-testid={`${testIdPrefix}-post-button`}
             className="w-100"
           >

--- a/frontend/src/stories/components/Courses/InstructorCoursesTable.stories.jsx
+++ b/frontend/src/stories/components/Courses/InstructorCoursesTable.stories.jsx
@@ -18,7 +18,6 @@ export const AdminUser = Template.bind({});
 export const InstructorUser = Template.bind({});
 export const EmptyTable = Template.bind({});
 export const AdminUserWithBadEmailError = Template.bind({});
-export const AdminUserWithNetworkError = Template.bind({});
 
 AdminUser.args = {
   courses: coursesFixtures.severalCourses,

--- a/frontend/src/tests/components/TabComponent/EnrollmentTabComponent.test.jsx
+++ b/frontend/src/tests/components/TabComponent/EnrollmentTabComponent.test.jsx
@@ -385,12 +385,6 @@ describe("EnrollmentTabComponent Tests", () => {
     ).toStrictEqual([]);
 
     const openModal = await screen.findByTestId(`${testId}-post-button`);
-    const arbitraryUpdateCount = queryClientSpecific.getQueryState([
-      "arbitraryQuery",
-    ]).dataUpdateCount;
-    const updateCountStudent = queryClientSpecific.getQueryState([
-      "/api/rosterstudents/course/7",
-    ]).dataUpdateCount;
 
     fireEvent.click(openModal);
     await screen.findByLabelText("Student Id");

--- a/frontend/src/tests/components/TabComponent/EnrollmentTabComponent.test.jsx
+++ b/frontend/src/tests/components/TabComponent/EnrollmentTabComponent.test.jsx
@@ -1,5 +1,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { rosterStudentFixtures } from "fixtures/rosterStudentFixtures";
+import {
+  loadResultFixtures,
+  rosterStudentFixtures,
+} from "fixtures/rosterStudentFixtures";
 import AxiosMockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {
@@ -11,15 +14,17 @@ import EnrollmentTabComponent from "main/components/TabComponent/EnrollmentTabCo
 import userEvent from "@testing-library/user-event";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import { vi } from "vitest";
+import { toast } from "react-toastify";
 
 const axiosMock = new AxiosMockAdapter(axios);
 const queryClient = new QueryClient();
 const testId = "InstructorCourseShowPage";
-const mockToast = vi.fn();
 vi.mock("react-toastify", async (importOriginal) => {
+  const mockToast = vi.fn();
+  mockToast.error = vi.fn();
   return {
     ...(await importOriginal()),
-    toast: (x) => mockToast(x),
+    toast: mockToast,
   };
 });
 
@@ -42,6 +47,7 @@ describe("EnrollmentTabComponent Tests", () => {
     axiosMock.reset();
     axiosMock.resetHistory();
     queryClient.clear();
+    vi.resetAllMocks();
   });
 
   test("Table Renders", async () => {
@@ -189,7 +195,7 @@ describe("EnrollmentTabComponent Tests", () => {
       });
     });
     expect(axiosMock.history.post[0].data.get("file")).toEqual(file);
-    expect(mockToast).toBeCalledWith("Roster successfully updated.");
+    expect(toast).toBeCalledWith("Roster successfully updated.");
     expect(
       queryClientSpecific.getQueryState(["arbitraryQuery"]).dataUpdateCount,
     ).toBe(arbitraryUpdateCount);
@@ -203,6 +209,54 @@ describe("EnrollmentTabComponent Tests", () => {
       expect(searchInput.value).toBe("");
     });
     expect(screen.queryByTestId(`${testId}-csv-modal`)).not.toBeInTheDocument();
+  });
+
+  test("CsvForm error returns correctly", async () => {
+    const file = new File(["there"], "egrades.csv", { type: "text/csv" });
+
+    axiosMock
+      .onGet("/api/rosterstudents/course/7")
+      .reply(200, rosterStudentFixtures.threeStudents);
+
+    axiosMock
+      .onPost("/api/rosterstudents/upload/csv")
+      .reply(409, loadResultFixtures.failed);
+
+    const user = userEvent.setup();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EnrollmentTabComponent
+          courseId={7}
+          testIdPrefix={testId}
+          currentUser={currentUserFixtures.instructorUser}
+        />
+      </QueryClientProvider>,
+    );
+    const openModal = await screen.findByTestId(`${testId}-csv-button`);
+
+    // Get the search input and set a search term
+    const searchInput = screen.getByTestId("InstructorCourseShowPage-search");
+    fireEvent.change(searchInput, { target: { value: "test search" } });
+    expect(searchInput.value).toBe("test search");
+
+    fireEvent.click(openModal);
+    expect(screen.getByTestId(`${testId}-csv-modal`)).toHaveClass(
+      "modal-dialog modal-dialog-centered",
+    );
+
+    const upload = await screen.findByTestId(
+      "RosterStudentCSVUploadForm-upload",
+    );
+    const submitButton = screen.getByTestId(
+      "RosterStudentCSVUploadForm-submit",
+    );
+    await user.upload(upload, file);
+    fireEvent.click(submitButton);
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        `Error uploading CSV: ${JSON.stringify(loadResultFixtures.failed, null, 2)}`,
+      ),
+    );
   });
 
   test("RosterStudentForm submit works and clears search filter", async () => {
@@ -276,8 +330,8 @@ describe("EnrollmentTabComponent Tests", () => {
       lastName: "Gaucho",
       email: "cgaucho@ucsb.edu",
     });
-    await waitFor(() => expect(mockToast).toBeCalled());
-    expect(mockToast).toBeCalledWith("Roster successfully updated.");
+    await waitFor(() => expect(toast).toBeCalled());
+    expect(toast).toBeCalledWith("Roster successfully updated.");
     expect(
       queryClientSpecific.getQueryState(["arbitraryQuery"]).dataUpdateCount,
     ).toBe(arbitraryUpdateCount);
@@ -293,6 +347,83 @@ describe("EnrollmentTabComponent Tests", () => {
     expect(
       screen.queryByTestId(`${testId}-post-modal`),
     ).not.toBeInTheDocument();
+  });
+
+  test("RosterStudentForm works on error", async () => {
+    const queryClientSpecific = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          staleTime: Infinity,
+        },
+      },
+    });
+    const postResponse = {
+      insertStatus: "REJECTED",
+      rosterStudent: rosterStudentFixtures.oneStudent[0],
+    };
+
+    axiosMock
+      .onGet("/api/rosterstudents/course/7")
+      .reply(200, rosterStudentFixtures.threeStudents);
+
+    axiosMock.onPost("/api/rosterstudents/post").reply(409, postResponse);
+    render(
+      <QueryClientProvider client={queryClientSpecific}>
+        <ArbitraryTestQueryComponent />
+        <EnrollmentTabComponent
+          courseId={7}
+          testIdPrefix={testId}
+          currentUser={currentUserFixtures.instructorUser}
+        />
+      </QueryClientProvider>,
+    );
+
+    //Great time to check initial values
+    expect(
+      queryClientSpecific.getQueryData(["/api/rosterstudents/course/7"]),
+    ).toStrictEqual([]);
+
+    const openModal = await screen.findByTestId(`${testId}-post-button`);
+    const arbitraryUpdateCount = queryClientSpecific.getQueryState([
+      "arbitraryQuery",
+    ]).dataUpdateCount;
+    const updateCountStudent = queryClientSpecific.getQueryState([
+      "/api/rosterstudents/course/7",
+    ]).dataUpdateCount;
+
+    fireEvent.click(openModal);
+    await screen.findByLabelText("Student Id");
+    expect(screen.getByTestId(`${testId}-post-modal`)).toHaveClass(
+      "modal-dialog modal-dialog-centered",
+    );
+
+    // Get the search input and set a search term
+    const searchInput = screen.getByTestId("InstructorCourseShowPage-search");
+    fireEvent.change(searchInput, { target: { value: "test search" } });
+    expect(searchInput.value).toBe("test search");
+
+    expect(screen.queryByText("Cancel")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Student Id"), {
+      target: { value: "1234567" },
+    });
+    fireEvent.change(screen.getByLabelText("First Name"), {
+      target: { value: "Bob" },
+    });
+    fireEvent.change(screen.getByLabelText("Last Name"), {
+      target: { value: "Smith" },
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "bobsmith@ucsb.edu" },
+    });
+    fireEvent.click(screen.getByTestId("RosterStudentForm-submit"));
+    screen.debug(null, 1000000);
+    await waitFor(() => expect(axiosMock.history.post.length).toEqual(1));
+    await waitFor(() =>
+      expect(toast.error).toBeCalledWith(
+        `Error adding student: ${JSON.stringify(postResponse, null, 2)}`,
+      ),
+    );
   });
 
   test("Modals close on close buttons (respectively), download works", async () => {

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -185,7 +185,7 @@ public class RosterStudentsController extends ApiController {
   @PostMapping(
       value = "/upload/csv",
       consumes = {"multipart/form-data"})
-  public LoadResult uploadRosterStudentsCSV(
+  public ResponseEntity<LoadResult> uploadRosterStudentsCSV(
       @Parameter(name = "courseId") @RequestParam Long courseId,
       @Parameter(name = "file") @RequestParam("file") MultipartFile file)
       throws JsonProcessingException, IOException, CsvException {
@@ -222,10 +222,16 @@ public class RosterStudentsController extends ApiController {
         }
       }
     }
-    return new LoadResult(
-        counts[InsertStatus.INSERTED.ordinal()],
-        counts[InsertStatus.UPDATED.ordinal()],
-        rejectedStudents);
+    LoadResult loadResult =
+        new LoadResult(
+            counts[InsertStatus.INSERTED.ordinal()],
+            counts[InsertStatus.UPDATED.ordinal()],
+            rejectedStudents);
+    if (rejectedStudents.isEmpty()) {
+      return ResponseEntity.ok(loadResult);
+    } else {
+      return ResponseEntity.status(HttpStatus.CONFLICT).body(loadResult);
+    }
   }
 
   public static RosterStudent fromCSVRow(String[] row, RosterSourceType sourceType) {

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -125,7 +125,7 @@ public class RosterStudentsController extends ApiController {
   @Operation(summary = "Create a new roster student")
   @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
   @PostMapping("/post")
-  public UpsertResponse postRosterStudent(
+  public ResponseEntity<UpsertResponse> postRosterStudent(
       @Parameter(name = "studentId") @RequestParam String studentId,
       @Parameter(name = "firstName") @RequestParam String firstName,
       @Parameter(name = "lastName") @RequestParam String lastName,
@@ -149,7 +149,11 @@ public class RosterStudentsController extends ApiController {
             .build();
 
     UpsertResponse upsertResponse = upsertStudent(rosterStudent, course, RosterStatus.MANUAL);
-    return upsertResponse;
+    if (upsertResponse.insertStatus == InsertStatus.REJECTED) {
+      return ResponseEntity.status(HttpStatus.CONFLICT).body(upsertResponse);
+    } else {
+      return ResponseEntity.ok(upsertResponse);
+    }
   }
 
   /**

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -634,7 +634,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                     .file(file)
                     .param("courseId", "1")
                     .with(csrf()))
-            .andExpect(status().isOk())
+            .andExpect(status().isConflict())
             .andReturn();
 
     RosterStudent rosterStudentRejected =

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -23,6 +23,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.frontiers.ControllerTestCase;
 import edu.ucsb.cs156.frontiers.annotations.WithInstructorCoursePermissions;
+import edu.ucsb.cs156.frontiers.controllers.RosterStudentsController.LoadResult;
+import edu.ucsb.cs156.frontiers.annotations.WithInstructorCoursePermissions;
 import edu.ucsb.cs156.frontiers.controllers.RosterStudentsController.RosterSourceType;
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.Job;
@@ -468,11 +470,8 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
     verify(updateUserService, times(1)).attachUserToRosterStudent(eq(rs3WithId));
 
     String responseString = response.getResponse().getContentAsString();
-    Map<String, String> expectedMap =
-        Map.of(
-            "filename", "roster.csv",
-            "message", "Inserted 1 new students, Updated 2 students");
-    String expectedJson = mapper.writeValueAsString(expectedMap);
+    LoadResult expectedResult = new LoadResult(1, 2, List.of());
+    String expectedJson = mapper.writeValueAsString(expectedResult);
     assertEquals(expectedJson, responseString);
   }
 
@@ -603,16 +602,68 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
     verify(updateUserService, times(1)).attachUserToRosterStudent(eq(rs3WithId));
 
     String responseString = response.getResponse().getContentAsString();
-    Map<String, String> expectedMap =
-        Map.of(
-            "filename", "roster.csv",
-            "message", "Inserted 1 new students, Updated 2 students");
-    String expectedJson = mapper.writeValueAsString(expectedMap);
+    LoadResult expectedResult = new LoadResult(1, 2, List.of());
+    String expectedJson = mapper.writeValueAsString(expectedResult);
     assertEquals(expectedJson, responseString);
   }
 
-  @WithInstructorCoursePermissions
   @Test
+  @WithInstructorCoursePermissions
+  public void students_with_non_matching_student_id_and_email_are_rejected() throws Exception {
+    RosterStudent student1ID = RosterStudent.builder().id(1L).studentId("A123456").build();
+    RosterStudent student1Email = RosterStudent.builder().id(2L).email("cgaucho@ucsb.edu").build();
+    RosterStudent student2 =
+        RosterStudent.builder().id(3L).studentId("A987654").email("ldelplaya@ucsb.edu").build();
+    Course course1 = Course.builder().id(1L).build();
+    when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));
+    when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("A123456")))
+        .thenReturn(Optional.of(student1ID));
+    when(rosterStudentRepository.findByCourseIdAndEmail(eq(1L), eq("cgaucho@ucsb.edu")))
+        .thenReturn(Optional.of(student1Email));
+    when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("A987654")))
+        .thenReturn(Optional.of(student2));
+    when(rosterStudentRepository.findByCourseIdAndEmail(eq(1L), eq("ldelplaya@ucsb.edu")))
+        .thenReturn(Optional.of(student2));
+    MockMultipartFile file =
+        new MockMultipartFile(
+            "file", "roster.csv", MediaType.TEXT_PLAIN_VALUE, sampleCSVContentsUCSB.getBytes());
+    MvcResult response =
+        mockMvc
+            .perform(
+                multipart("/api/rosterstudents/upload/csv")
+                    .file(file)
+                    .param("courseId", "1")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    RosterStudent rosterStudentRejected =
+        RosterStudent.builder()
+            .firstName("CHRIS FAKE")
+            .lastName("GAUCHO")
+            .studentId("A123456")
+            .email("cgaucho@ucsb.edu")
+            .build();
+    RosterStudent rosterStudent2Updated =
+        RosterStudent.builder()
+            .id(3L)
+            .firstName("LAUREN")
+            .lastName("DEL PLAYA")
+            .email("ldelplaya@ucsb.edu")
+            .studentId("A987654")
+            .rosterStatus(RosterStatus.ROSTER)
+            .build();
+
+    verify(rosterStudentRepository, times(2)).save(any(RosterStudent.class));
+    verify(rosterStudentRepository, atLeastOnce()).save(eq(rosterStudent2Updated));
+    String responseString = response.getResponse().getContentAsString();
+    LoadResult expectedResult = new LoadResult(1, 1, List.of(rosterStudentRejected));
+    String expectedJson = mapper.writeValueAsString(expectedResult);
+    assertEquals(expectedJson, responseString);
+  }
+
+  @Test
+  @WithInstructorCoursePermissions
   public void unrecognized_csv_format_throws_an_exception() throws Exception {
 
     MockMultipartFile file =
@@ -640,6 +691,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
   /** Test that you cannot upload a roster for a course that does not exist */
   @WithMockUser(roles = {"ADMIN"})
   @Test
+  @WithInstructorCoursePermissions
   public void instructor_cannot_upload_students_for_a_course_that_does_not_exist()
       throws Exception {
 


### PR DESCRIPTION
In this PR, I ensure that roster students submitted by CSV and POST are consistent in the database. When submitted, the method checks if there is already a Roster Student with that email and a Roster Student with that Student ID. If they are the same, it updates them. If they come from different Roster Students, it rejects it. They are then added to the list of rejected Roster Students, for the Instructor to handle.

The frontend will currently fail silently, but this is not a common bug.
## Testing Plan
1. Clear the Roster Students for a course
2. Upload a roster student with the ID `A123456`
3. Upload a different roster student with the email `cgaucho@ucsb.edu`
4. Try to upload the `egrades.csv`
5. Ensure that the Chris Fake roster student has not been created.

Deployed to: https://frontiers-qa2.dokku-00.cs.ucsb.edu/

Closes #278 
Closes #47 