### PR TITLE
pc - fix logic error in script for setting up application secret key on localhost

### DIFF
--- a/keyconvert-localhost.sh
+++ b/keyconvert-localhost.sh
@@ -50,9 +50,7 @@ fi
 cat <<EOF > secrets.yaml
 app:
   private:
-    key: "-----BEGIN PRIVATE KEY-----
-$key_content
------END PRIVATE KEY-----"
+    key: "$key_content"
 EOF
 
 echo "secrets.yaml has been created with the converted key."


### PR DESCRIPTION
This PR fixes a logic error in the script for setting up application secret key on localhost.

The script was putting in the text at the `START` and `END` of the key twice, resulting in the key being invalid.   Now it works properly.