### PR TITLE
divyanipunj - redirects to correct page after linking organization [DRAFT]

### DIFF
--- a/frontend/src/main/components/Courses/InstructorCoursesTable.jsx
+++ b/frontend/src/main/components/Courses/InstructorCoursesTable.jsx
@@ -8,6 +8,7 @@ import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 import UpdateInstructorForm from "main/components/Courses/UpdateInstructorForm";
 import Modal from "react-bootstrap/Modal";
+import { useLocation } from "react-router";
 
 const columns = [
   {
@@ -54,6 +55,8 @@ export default function InstructorCoursesTable({
   testId = "InstructorCoursesTable",
   enableInstructorUpdate = false,
 }) {
+  const location = useLocation();
+
   const [showModal, setShowModal] = useState(false);
   const [selectedCourse, setSelectedCourse] = useState(null);
   const cellToAxiosParamsEdit = (formData) => {
@@ -103,7 +106,10 @@ export default function InstructorCoursesTable({
     formData.courseId = selectedCourse.id;
     editMutation.mutate(formData);
   };
+
   const installCallback = (cell) => {
+    sessionStorage.setItem("redirect", location.pathname);
+
     const url = `/api/courses/redirect?courseId=${cell.row.original.id}`;
     if (storybook) {
       window.alert(`would have navigated to: ${url}`);

--- a/frontend/src/main/pages/Auth/SignInSuccessPage.jsx
+++ b/frontend/src/main/pages/Auth/SignInSuccessPage.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router";
 
 export default function SignInSuccessPage() {
   const storedReturn = sessionStorage.getItem("redirect");
-  console.log(storedReturn);
+
   const navigation = useNavigate();
   if (storedReturn) {
     navigation(storedReturn);

--- a/frontend/src/tests/components/Courses/InstructorCoursesTable.test.jsx
+++ b/frontend/src/tests/components/Courses/InstructorCoursesTable.test.jsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import coursesFixtures from "fixtures/coursesFixtures";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import InstructorCoursesTable from "main/components/Courses/InstructorCoursesTable";
-import { BrowserRouter } from "react-router";
+import { BrowserRouter, MemoryRouter } from "react-router";
 import AxiosMockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import { vi } from "vitest";
@@ -205,13 +205,13 @@ describe("InstructorCoursesTable tests", () => {
     test("Tests that when storybook is explictly false all still works as expected", async () => {
       render(
         <QueryClientProvider client={queryClient}>
-          <BrowserRouter>
+          <MemoryRouter initialEntries={["/instructor/courses"]}>
             <InstructorCoursesTable
               courses={coursesFixtures.severalCourses}
               currentUser={currentUserFixtures.instructorUser}
               storybook={false}
             />
-          </BrowserRouter>
+          </MemoryRouter>
         </QueryClientProvider>,
       );
 
@@ -229,6 +229,8 @@ describe("InstructorCoursesTable tests", () => {
       });
 
       expect(window.location.href).toBe("/api/courses/redirect?courseId=3");
+      expect(sessionStorage.getItem("redirect")).toBe("/instructor/courses");
+      sessionStorage.clear();
     });
     test("Tests for GitHub link", async () => {
       render(

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -169,7 +169,7 @@ public class CoursesController extends ApiController {
    *     marked as the state parameter, which GitHub will return.
    */
   @Operation(summary = "Authorize Frontiers to a Github Course")
-  @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #id)")
+  @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
   @GetMapping("/redirect")
   public ResponseEntity<Void> linkCourse(@Parameter Long courseId)
       throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException {
@@ -232,7 +232,7 @@ public class CoursesController extends ApiController {
                 });
         courseRepository.save(course);
         return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
-            .header(HttpHeaders.LOCATION, "/instructor/courses?success=True&course=" + state)
+            .header(HttpHeaders.LOCATION, "/login/success")
             .build();
       }
     }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
@@ -280,7 +280,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
     String responseUrl = response.getResponse().getHeader(HttpHeaders.LOCATION);
     verify(courseRepository, times(1)).save(eq(course2));
-    assertEquals("/instructor/courses?success=True&course=1", responseUrl);
+    assertEquals("/login/success", responseUrl);
   }
 
   @Test
@@ -326,7 +326,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
     String responseUrl = response.getResponse().getHeader(HttpHeaders.LOCATION);
     verify(courseRepository, times(1)).save(eq(course2));
-    assertEquals("/instructor/courses?success=True&course=1", responseUrl);
+    assertEquals("/login/success", responseUrl);
   }
 
   @Test
@@ -419,7 +419,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
     String responseUrl = response.getResponse().getHeader(HttpHeaders.LOCATION);
     verify(courseRepository, times(1)).save(eq(courseAfter));
-    assertEquals("/instructor/courses?success=True&course=1", responseUrl);
+    assertEquals("/login/success", responseUrl);
   }
 
   @Test


### PR DESCRIPTION
This PR addresses #378.

This PR: 
- edits the CoursesController endpoint /api/courses/link and tests to navigate back to the page the user was originally on.
- edits InsturctorCourseTable and tests to save path before redirecting to GitHub. 

dokku: https://frontiers-divyanipunj.dokku-00.cs.ucsb.edu/