### PR TITLE
Displaying All Roster Students when Displaying Team Mappings

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/TeamsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/TeamsController.java
@@ -74,6 +74,17 @@ public class TeamsController extends ApiController {
           member.getRosterStudent().getLastName(),
           member.getRosterStudent().getGithubLogin());
     }
+
+    public static TeamMemberMapping from(RosterStudent student) {
+      return new TeamMemberMapping(
+          null,
+          null,
+          student.getId(),
+          student.getEmail(),
+          student.getFirstName(),
+          student.getLastName(),
+          student.getGithubLogin());
+    }
   }
 
   /**
@@ -181,15 +192,18 @@ public class TeamsController extends ApiController {
   @PreAuthorize("@CourseSecurity.hasManagePermissions(#root, #courseId)")
   @GetMapping("/mapping")
   public Iterable<TeamMemberMapping> teamMemberMapping(@RequestParam Long courseId) {
-    List<Team> teams =
+    Course course =
         courseRepository
             .findById(courseId)
-            .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId))
-            .getTeams();
+            .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
     List<TeamMemberMapping> mappings = new ArrayList<>();
-    for (Team team : teams) {
-      for (TeamMember member : team.getTeamMembers()) {
-        mappings.add(TeamMemberMapping.from(member));
+    for (RosterStudent student : course.getRosterStudents()) {
+      if (student.getTeamMembers().isEmpty()) {
+        mappings.add(TeamMemberMapping.from(student));
+      } else {
+        for (TeamMember member : student.getTeamMembers()) {
+          mappings.add(TeamMemberMapping.from(member));
+        }
       }
     }
     return mappings;

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/TeamsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/TeamsControllerTests.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import edu.ucsb.cs156.frontiers.ControllerTestCase;
 import edu.ucsb.cs156.frontiers.annotations.WithInstructorCoursePermissions;
+import edu.ucsb.cs156.frontiers.controllers.TeamsController.TeamMemberMapping;
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.entities.Team;
@@ -629,7 +630,9 @@ public class TeamsControllerTests extends ControllerTestCase {
             .build();
     TeamMember teamMember2 = TeamMember.builder().id(2L).team(team).rosterStudent(student2).build();
     team.setTeamMembers(List.of(teamMember, teamMember2));
-    course.setTeams(List.of(team));
+    student.setTeamMembers(List.of(teamMember));
+    student2.setTeamMembers(List.of(teamMember2));
+    course.setRosterStudents(List.of(student, student2));
 
     when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course));
 
@@ -658,6 +661,15 @@ public class TeamsControllerTests extends ControllerTestCase {
   public void testTeamMemberMapping_noTeams() throws Exception {
     // arrange
     Course course = Course.builder().id(1L).courseName("CS156").teams(List.of()).build();
+    RosterStudent student =
+        RosterStudent.builder()
+            .id(1L)
+            .email("cgaucho@ucsb.edu")
+            .firstName("Chris")
+            .lastName("Gaucho")
+            .teamMembers(List.of())
+            .build();
+    course.setRosterStudents(List.of(student));
     when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course));
 
     // act
@@ -668,7 +680,11 @@ public class TeamsControllerTests extends ControllerTestCase {
             .andReturn();
 
     // assert
-    String expectedJson = mapper.writeValueAsString(List.of());
+    String expectedJson =
+        mapper.writeValueAsString(
+            List.of(
+                new TeamMemberMapping(
+                    null, null, 1L, "cgaucho@ucsb.edu", "Chris", "Gaucho", null)));
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
   }


### PR DESCRIPTION
In this PR, I display every roster student and their team mappings (or lack thereof). There is a row for each mapping: For example, if Roster Student #1 is on teams 2 and 3, there will be a "TeamMemberMapping" for Roster Student 1 for Team #2, and one for Team #3.

In this PR, I add the functionality that students that are not on any teams are added, with their team mapping being null.

Deployed to https://frontiers-qa2.dokku-00.cs.ucsb.edu/

Closes #382
