### PR TITLE
Creating a Smoke Test

### DIFF
--- a/.devcontainer/production/devcontainer.json
+++ b/.devcontainer/production/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/java-postgres
+{
+	"name": "Java & PostgreSQL",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// This can be used to network with other containers or with the host.
+	// "forwardPorts": [5432],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/production/docker-compose.yml
+++ b/.devcontainer/production/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       # NOTE: POSTGRES_DB/USER/PASSWORD should match values in db container
         DATABASE_URL: postgres://postgres:postgres@postgresdb:5432/postgres
+        PORT: 8080
 
 #    volumes:
 #      - ../..:/workspaces:cached

--- a/.devcontainer/production/docker-compose.yml
+++ b/.devcontainer/production/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       # NOTE: POSTGRES_DB/USER/PASSWORD should match values in db container
         DATABASE_URL: postgres://postgres:postgres@postgresdb:5432/postgres
         PORT: 8080
+        WEBHOOK_SECRET: fake-webhook-secret
 
 #    volumes:
 #      - ../..:/workspaces:cached

--- a/.devcontainer/production/docker-compose.yml
+++ b/.devcontainer/production/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.8'
+
+volumes:
+  postgres-data:
+
+services:
+  app:
+    container_name: javadev
+    build: 
+      context: ../../
+      dockerfile: Dockerfile
+    environment:
+      # NOTE: POSTGRES_DB/USER/PASSWORD should match values in db container
+        DATABASE_URL: postgres://postgres:postgres@postgresdb:5432/postgres
+
+#    volumes:
+#      - ../..:/workspaces:cached
+      
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    container_name: postgresdb
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      # NOTE: POSTGRES_DB/USER/PASSWORD should match values in app container
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)

--- a/.github/workflows/42-smoke-test.yml
+++ b/.github/workflows/42-smoke-test.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - name: Start containers
         run: docker-compose -f "docker-compose.yml" up -d --build
 

--- a/.github/workflows/42-smoke-test.yml
+++ b/.github/workflows/42-smoke-test.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1
 
       - name: Start containers
-        run: docker-compose -f "docker-compose.yml" up -d --build
+        run: docker compose -f "docker-compose.yml" up -d --build
 
       - name: Run Healthcheck
         uses: Wandalen/wretry.action@master
@@ -30,4 +30,4 @@ jobs:
 
       - name: Stop containers
         if: always()
-        run: docker-compose -f "docker-compose.yml" down
+        run: docker compose -f "docker-compose.yml" down

--- a/.github/workflows/42-smoke-test.yml
+++ b/.github/workflows/42-smoke-test.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           command: "docker exec javadev curl -s --fail http://localhost:8080/"
           attempt_limit: 3
+          attempt_delay: 15000
 
       - name: Stop containers
         if: always()

--- a/.github/workflows/42-smoke-test.yml
+++ b/.github/workflows/42-smoke-test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/setup-compose-action@v1
 
       - name: Start containers
-        run: docker compose -f "docker-compose.yml" up -d --build
+        run: docker compose -f ".devcontainer/production/docker-compose.yml" up -d --build
 
       - name: Run Healthcheck
         uses: Wandalen/wretry.action@master
@@ -30,4 +30,4 @@ jobs:
 
       - name: Stop containers
         if: always()
-        run: docker compose -f "docker-compose.yml" down
+        run: docker compose -f ".devcontainer/production/docker-compose.yml" down

--- a/.github/workflows/42-smoke-test.yml
+++ b/.github/workflows/42-smoke-test.yml
@@ -9,11 +9,22 @@ on:
 
 jobs:
   smoke-test:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: devcontainers/ci@v0.3
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Start containers
+        run: docker-compose -f "docker-compose.yml" up -d --build
+
+      - name: Run Healthcheck
+        uses: Wandalen/wretry.action@master
         with:
-          configFile: .devcontainer/production/devcontainer.json
-          runCmd: "/home/app/startup.sh /home/app/target/frontiers-1.0.0.jar"
+          command: "curl -s --fail http://localhost:8080/"
+          attempt_limit: 3
+
+      - name: Stop containers
+        if: always()
+        run: docker-compose -f "docker-compose.yml" down

--- a/.github/workflows/42-smoke-test.yml
+++ b/.github/workflows/42-smoke-test.yml
@@ -1,0 +1,19 @@
+name: 42-smoke-test.yml
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: [ src/**, pom.xml, lombok.config, frontend/**, .github/workflows/42-smoke-test.yml ]
+  push:
+    branches: [ main ]
+    paths: [ src/**, pom.xml, lombok.config, frontend/**, .github/workflows/42-smoke-test.yml ]
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: devcontainers/ci@v0.3
+        with:
+          configFile: .devcontainer/production/devcontainer.json
+          runCmd: "/home/app/startup.sh /home/app/target/frontiers-1.0.0.jar"

--- a/.github/workflows/42-smoke-test.yml
+++ b/.github/workflows/42-smoke-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run Healthcheck
         uses: Wandalen/wretry.action@master
         with:
-          command: "curl -s --fail http://localhost:8080/"
+          command: "docker exec javadev curl -s --fail http://localhost:8080/"
           attempt_limit: 3
 
       - name: Stop containers

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /app
 RUN java -version
 RUN curl --version
 
-ENV NODE_VERSION=20.17.0
+ENV NODE_VERSION=22.18.0
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}


### PR DESCRIPTION
In this PR, I design a smoke test for proj-frontiers in a production environment. Using a `docker-compose`, I create a container from our Dockerfile and also a postgres environment.

I also add a devcontainer in case any local development would like to be tested in a "production" postgres environment.

As an example of a test for this, see #433 (Example of Smoking for Smoke Test) which adds a bogus database migration.