### PR TITLE
 divyanipunj - UX improvement on InstructorCourseShowPage

### DIFF
--- a/frontend/src/main/pages/Instructor/InstructorCourseShowPage.jsx
+++ b/frontend/src/main/pages/Instructor/InstructorCourseShowPage.jsx
@@ -7,10 +7,11 @@ import { useCurrentUser } from "main/utils/currentUser";
 import { useNavigate, useParams } from "react-router";
 
 import Modal from "react-bootstrap/Modal";
-import { Button, Tab, Tabs } from "react-bootstrap";
+import { Button, Tab, Tabs, OverlayTrigger, Tooltip } from "react-bootstrap";
 import AssignmentTabComponent from "main/components/TabComponent/AssignmentTabComponent";
 import EnrollmentTabComponent from "main/components/TabComponent/EnrollmentTabComponent";
 import StaffTabComponent from "main/components/TabComponent/StaffTabComponent";
+import GithubSettingIcon from "main/components/Common/GithubSettingIcon";
 
 export default function InstructorCourseShowPage() {
   const currentUser = useCurrentUser();
@@ -63,8 +64,53 @@ export default function InstructorCourseShowPage() {
           </Button>
         </Modal.Footer>
       </Modal>
-      <h1 data-testid={`${testId}-title`}>
-        Course: {course ? `${course.courseName} (${course.id})` : "Loading..."}
+      <h1
+        data-testid={`${testId}-title`}
+        className="d-flex align-items-center lh-1 gap-3"
+      >
+        {!course ? (
+          "Course: Loading..."
+        ) : !course.installationId ? (
+          <span>
+            {course.courseName}&nbsp;&nbsp;{course.term}
+          </span>
+        ) : (
+          <>
+            <span>
+              {course.courseName}&nbsp;&nbsp;{course.term}
+            </span>
+            <a
+              className="ms-2"
+              href={`https://github.com/${course.orgName}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid={`${testId}-github-org-link`}
+            >
+              {course.orgName}
+            </a>
+            <OverlayTrigger
+              placement="right"
+              overlay={
+                <Tooltip id={`${testId}-tooltip-github-settings`}>
+                  Manage settings for association between your GitHub
+                  organization and this web application.
+                </Tooltip>
+              }
+            >
+              <a
+                href={`https://github.com/organizations/${course.orgName}/settings/installations/${course.installationId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-testid={`${testId}-github-settings-link`}
+              >
+                <GithubSettingIcon
+                  size={45}
+                  data-testid={`${testId}-github-settings-icon`}
+                />
+              </a>
+            </OverlayTrigger>
+          </>
+        )}
       </h1>
       <Tabs defaultActiveKey={"default"}>
         <Tab eventKey={"default"} title={"Management"} className="pt-2">

--- a/frontend/src/main/pages/Instructor/InstructorCourseShowPage.jsx
+++ b/frontend/src/main/pages/Instructor/InstructorCourseShowPage.jsx
@@ -76,9 +76,7 @@ export default function InstructorCourseShowPage() {
           </span>
         ) : (
           <>
-            <span>
-              {course.courseName}&nbsp;&nbsp;{course.term}
-            </span>
+            <span>{course.courseName}</span>
             <a
               className="ms-2"
               href={`https://github.com/${course.orgName}`}
@@ -109,18 +107,12 @@ export default function InstructorCourseShowPage() {
                 />
               </a>
             </OverlayTrigger>
+            <span> {course.term} </span>
           </>
         )}
       </h1>
       <Tabs defaultActiveKey={"default"}>
-        <Tab eventKey={"default"} title={"Management"} className="pt-2">
-          <InstructorCoursesTable
-            courses={course ? [course] : []}
-            currentUser={currentUser}
-            testId={testId}
-          />
-        </Tab>
-        <Tab eventKey={"enrollment"} title={"Enrollment"} className="pt-2">
+        <Tab eventKey={"students"} title={"Students"} className="pt-2">
           <EnrollmentTabComponent
             courseId={courseId}
             testIdPrefix={testId}
@@ -134,8 +126,12 @@ export default function InstructorCourseShowPage() {
             currentUser={currentUser}
           />
         </Tab>
-        <Tab eventKey={"assignments"} title={"Assignments"} className="pt-2">
-          <AssignmentTabComponent courseId={courseId} />
+        <Tab eventKey={"default"} title={"Assignments"} className="pt-2">
+          <AssignmentTabComponent
+            courseId={courseId}
+            testIdPrefix={testId}
+            currentUser={currentUser}
+          />
         </Tab>
       </Tabs>
     </BasicLayout>

--- a/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.jsx
+++ b/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.jsx
@@ -80,12 +80,11 @@ describe("InstructorCourseShowPage tests", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId(`${testId}-title`)).toHaveTextContent(
-        "CMPSC 156 Spring 2025",
+        "CMPSC 156",
       );
     });
 
-    const orgName = screen.getByText("ucsb-cs156-s25");
-    expect(orgName).toBeInTheDocument();
+    expect(screen.queryByText("ucsb-cs156-s25")).not.toBeInTheDocument();
 
     expect(screen.queryByText("Course Not Found")).not.toBeInTheDocument();
     vi.advanceTimersByTime(3000);
@@ -220,13 +219,10 @@ describe("InstructorCourseShowPage tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
-    expect(screen.getByText("Management")).toHaveAttribute(
+
+    expect(screen.getByText("Students")).toHaveAttribute(
       "data-rr-ui-event-key",
-      "default",
-    );
-    expect(screen.getByText("Enrollment")).toHaveAttribute(
-      "data-rr-ui-event-key",
-      "enrollment",
+      "students",
     );
     expect(screen.getByRole("tab", { name: "Staff" })).toHaveAttribute(
       "data-rr-ui-event-key",
@@ -234,13 +230,13 @@ describe("InstructorCourseShowPage tests", () => {
     );
     expect(screen.getByText("Assignments")).toHaveAttribute(
       "data-rr-ui-event-key",
-      "assignments",
+      "default",
     );
-    expect(screen.getByText("Management")).toHaveAttribute(
+    expect(screen.getByText("Assignments")).toHaveAttribute(
       "aria-selected",
       "true",
     );
-    const changeTabs = screen.getByText("Enrollment");
+    const changeTabs = screen.getByText("Students");
     fireEvent.click(changeTabs);
   });
 
@@ -307,6 +303,9 @@ describe("InstructorCourseShowPage tests", () => {
     expect(
       screen.queryByTestId("InstructorCourseShowPage-github-org-link"),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("InstructorCourseShowPage-tooltip-github-settings"),
+    ).not.toBeInTheDocument();
   });
   test("header displays correct info when course is loaded", async () => {
     setupInstructorUser();
@@ -328,7 +327,7 @@ describe("InstructorCourseShowPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("CMPSC 156 Spring 2025");
+    await screen.findByText("CMPSC 156");
 
     expect(
       screen.getByTestId("InstructorCourseShowPage-title"),
@@ -339,6 +338,7 @@ describe("InstructorCourseShowPage tests", () => {
     expect(
       screen.getByTestId("InstructorCourseShowPage-github-org-link"),
     ).toHaveAttribute("href", "https://github.com/ucsb-cs156-s25");
+    expect(screen.getByText("Spring 2025")).toBeInTheDocument();
   });
   test("expect the correct URL to the organization for the course", async () => {
     setupInstructorUser();
@@ -392,6 +392,10 @@ describe("InstructorCourseShowPage tests", () => {
     );
 
     await screen.findByText("CMPSC 156");
+
+    expect(
+      screen.getByTestId("InstructorCourseShowPage-github-settings-icon"),
+    ).toBeInTheDocument();
 
     fireEvent.mouseOver(
       screen.getByTestId(`InstructorCourseShowPage-github-settings-icon`),

--- a/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.jsx
+++ b/frontend/src/tests/pages/Instructor/InstructorCourseShowPage.test.jsx
@@ -80,7 +80,7 @@ describe("InstructorCourseShowPage tests", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId(`${testId}-title`)).toHaveTextContent(
-        "Course: CMPSC 156 (1)",
+        "CMPSC 156 Spring 2025",
       );
     });
 
@@ -278,5 +278,156 @@ describe("InstructorCourseShowPage tests", () => {
     expect(
       screen.getByTestId("InstructorCourseShowPage-EnrollmentTabComponent"),
     ).toBeInTheDocument();
+  });
+  test("header displays correct info when course is loaded without an installationId", async () => {
+    setupInstructorUser();
+
+    axiosMock
+      .onGet("/api/courses/7")
+      .reply(200, coursesFixtures.severalCourses[2]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/instructor/courses/7"]}>
+          <Routes>
+            <Route
+              path="/instructor/courses/:id"
+              element={<InstructorCourseShowPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("CMPSC 156 Fall 2025");
+
+    expect(
+      screen.getByTestId("InstructorCourseShowPage-title"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("InstructorCourseShowPage-github-org-link"),
+    ).not.toBeInTheDocument();
+  });
+  test("header displays correct info when course is loaded", async () => {
+    setupInstructorUser();
+
+    axiosMock
+      .onGet("/api/courses/7")
+      .reply(200, coursesFixtures.severalCourses[0]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/instructor/courses/7"]}>
+          <Routes>
+            <Route
+              path="/instructor/courses/:id"
+              element={<InstructorCourseShowPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("CMPSC 156 Spring 2025");
+
+    expect(
+      screen.getByTestId("InstructorCourseShowPage-title"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("InstructorCourseShowPage-github-org-link"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("InstructorCourseShowPage-github-org-link"),
+    ).toHaveAttribute("href", "https://github.com/ucsb-cs156-s25");
+  });
+  test("expect the correct URL to the organization for the course", async () => {
+    setupInstructorUser();
+
+    axiosMock
+      .onGet("/api/courses/7")
+      .reply(200, coursesFixtures.severalCourses[0]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/instructor/courses/7"]}>
+          <Routes>
+            <Route
+              path="/instructor/courses/:id"
+              element={<InstructorCourseShowPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("CMPSC 156");
+
+    const githubLink = screen.getByTestId(
+      `InstructorCourseShowPage-github-settings-link`,
+    );
+    expect(githubLink).toBeInTheDocument();
+    expect(githubLink).toHaveAttribute(
+      "href",
+      "https://github.com/organizations/ucsb-cs156-s25/settings/installations/123456",
+    );
+  });
+  test("expect the correct tooltip ID and message for the github icon (that redirects to github installation settings)", async () => {
+    setupInstructorUser();
+
+    axiosMock
+      .onGet("/api/courses/7")
+      .reply(200, coursesFixtures.severalCourses[0]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/instructor/courses/7"]}>
+          <Routes>
+            <Route
+              path="/instructor/courses/:id"
+              element={<InstructorCourseShowPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("CMPSC 156");
+
+    fireEvent.mouseOver(
+      screen.getByTestId(`InstructorCourseShowPage-github-settings-icon`),
+    );
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveAttribute(
+      "id",
+      "InstructorCourseShowPage-tooltip-github-settings",
+    );
+    expect(tooltip).toHaveTextContent(
+      "Manage settings for association between your GitHub organization and this web application.",
+    );
+  });
+  test("does not show error modal on initial render", async () => {
+    setupInstructorUser();
+
+    axiosMock
+      .onGet("/api/courses/7")
+      .reply(200, coursesFixtures.severalCourses[0]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/instructor/courses/7"]}>
+          <Routes>
+            <Route
+              path="/instructor/courses/:id"
+              element={<InstructorCourseShowPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("CMPSC 156");
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**Addresses part of #368**. (Will address second part of feature after completing #431)

**This PR:** 
- removes the management tab from InstructorCourseShowPage and adds all the relevant information from the InstructorCoursesTable to the header. 

Deployed to: https://frontiers-divyanipunj.dokku-00.cs.ucsb.edu/
Storybook: https://67da6ee1a47bfcdda4700814-hbgetzzjvn.chromatic.com/?path=/story/pages-instructor-instructorcourseshowpage--example-course-no-students


### Testing Plan
1. Open the InstructorCoursesShowPage to view the changes made to the header and tab organization. 
2. Make sure that both links in the header work.