### PR TITLE
Refactor smoke test workflow to use centralized action

### DIFF
--- a/.github/workflows/42-smoke-test.yml
+++ b/.github/workflows/42-smoke-test.yml
@@ -9,12 +9,7 @@ on:
 
 jobs:
   smoke-test:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-
-    run-smoke-test:
-      - name: Run centralized smoke-test workflow
-        uses: ucsb-cs156/workflows/.github/workflows/42-smoke-test.yml@main
-        with:
-          compose-location: .devcontainer/production/docker-compose.yml
+    uses: ucsb-cs156/workflows/.github/workflows/42-smoke-test.yml@main
+    with:
+      compose-location: .devcontainer/production/docker-compose.yml
       


### PR DESCRIPTION
In this PR, I migrated the smoke-test workflow to the workflows repository and replace it with a reusable call.