### PR TITLE
Fixing Roster Student Deletion

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
@@ -202,7 +202,7 @@ public class CourseStaffController extends ApiController {
     }
 
     course.getCourseStaff().remove(staffMember);
-    courseRepository.save(course);
+    staffMember.setCourse(null);
     courseStaffRepository.delete(staffMember);
 
     if (!orgRemovalAttempted) {

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -329,9 +329,19 @@ public class RosterStudentsController extends ApiController {
       }
     }
 
-    course.getRosterStudents().remove(rosterStudent);
+    if (!rosterStudent.getTeamMembers().isEmpty()) {
+      rosterStudent
+          .getTeamMembers()
+          .forEach(
+              teamMember -> {
+                teamMember.getTeam().getTeamMembers().remove(teamMember);
+                teamMember.setTeam(null);
+              });
+    }
+
+    rosterStudent.getCourse().getRosterStudents().remove(rosterStudent);
+    rosterStudent.setCourse(null);
     rosterStudentRepository.delete(rosterStudent);
-    courseRepository.save(course);
 
     if (!orgRemovalAttempted) {
       return ResponseEntity.ok(

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffControllerTests.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -873,11 +872,18 @@ public class CourseStaffControllerTests extends ControllerTestCase {
     staffList.add(staffMember);
     course1.setCourseStaff(staffList);
 
-    List<CourseStaff> staffListSpy = Mockito.spy(staffList);
-    course1.setCourseStaff(staffListSpy);
-
     when(courseStaffRepository.findById(eq(1L))).thenReturn(Optional.of(staffMember));
     when(courseRepository.save(any(Course.class))).thenReturn(course1);
+
+    CourseStaff staffMemberUpdated =
+        CourseStaff.builder()
+            .id(1L)
+            .firstName("Test")
+            .lastName("Staff")
+            .email("teststaff@ucsb.edu")
+            .course(null)
+            .orgStatus(OrgStatus.PENDING)
+            .build();
 
     MvcResult response =
         mockMvc
@@ -890,9 +896,8 @@ public class CourseStaffControllerTests extends ControllerTestCase {
             .andReturn();
 
     verify(courseStaffRepository).findById(eq(1L));
-    verify(courseRepository).save(any(Course.class));
-    verify(courseStaffRepository).delete(eq(staffMember));
-    verify(staffListSpy).remove(eq(staffMember));
+    verify(courseStaffRepository).delete(eq(staffMemberUpdated));
+    assertEquals(course1.getCourseStaff(), List.of());
     // Since the staff member doesn't have a GitHub login, removeOrganizationMember
     // should not be called
     verify(organizationMemberService, never()).removeOrganizationMember(any(CourseStaff.class));
@@ -924,12 +929,21 @@ public class CourseStaffControllerTests extends ControllerTestCase {
     staffList.add(staffMember);
     course1.setCourseStaff(staffList);
 
-    List<CourseStaff> staffListSpy = Mockito.spy(staffList);
-    course1.setCourseStaff(staffListSpy);
-
     when(courseStaffRepository.findById(eq(1L))).thenReturn(Optional.of(staffMember));
     when(courseRepository.save(any(Course.class))).thenReturn(course1);
     doNothing().when(organizationMemberService).removeOrganizationMember(any(CourseStaff.class));
+
+    CourseStaff staffMemberUpdated =
+        CourseStaff.builder()
+            .id(1L)
+            .firstName("Test")
+            .lastName("Staff")
+            .email("teststaff@ucsb.edu")
+            .course(null)
+            .orgStatus(OrgStatus.MEMBER)
+            .githubId(67890)
+            .githubLogin("teststaff")
+            .build();
 
     MvcResult response =
         mockMvc
@@ -942,9 +956,8 @@ public class CourseStaffControllerTests extends ControllerTestCase {
             .andReturn();
 
     verify(courseStaffRepository).findById(eq(1L));
-    verify(courseRepository).save(any(Course.class));
-    verify(courseStaffRepository).delete(eq(staffMember));
-    verify(staffListSpy).remove(eq(staffMember));
+    verify(courseStaffRepository).delete(eq(staffMemberUpdated));
+    assertEquals(course1.getCourseStaff(), List.of());
     verify(organizationMemberService).removeOrganizationMember(eq(staffMember));
 
     assertEquals(
@@ -974,11 +987,20 @@ public class CourseStaffControllerTests extends ControllerTestCase {
     staffList.add(staffMember);
     course1.setCourseStaff(staffList);
 
-    List<CourseStaff> staffListSpy = Mockito.spy(staffList);
-    course1.setCourseStaff(staffListSpy);
-
     when(courseStaffRepository.findById(eq(1L))).thenReturn(Optional.of(staffMember));
     when(courseRepository.save(any(Course.class))).thenReturn(course1);
+
+    CourseStaff staffMemberUpdated =
+        CourseStaff.builder()
+            .id(1L)
+            .firstName("Test")
+            .lastName("Staff")
+            .email("teststaff@ucsb.edu")
+            .course(null)
+            .orgStatus(OrgStatus.MEMBER)
+            .githubId(67890)
+            .githubLogin("teststaff")
+            .build();
 
     MvcResult response =
         mockMvc
@@ -991,9 +1013,8 @@ public class CourseStaffControllerTests extends ControllerTestCase {
             .andReturn();
 
     verify(courseStaffRepository).findById(eq(1L));
-    verify(courseRepository).save(any(Course.class));
-    verify(courseStaffRepository).delete(eq(staffMember));
-    verify(staffListSpy).remove(eq(staffMember));
+    verify(courseStaffRepository).delete(eq(staffMemberUpdated));
+    assertEquals(course1.getCourseStaff(), List.of());
     verify(organizationMemberService, never()).removeOrganizationMember(any(CourseStaff.class));
 
     assertEquals(
@@ -1023,11 +1044,20 @@ public class CourseStaffControllerTests extends ControllerTestCase {
     staffList.add(staffMember);
     course1.setCourseStaff(staffList);
 
-    List<CourseStaff> staffListSpy = Mockito.spy(staffList);
-    course1.setCourseStaff(staffListSpy);
-
     when(courseStaffRepository.findById(eq(1L))).thenReturn(Optional.of(staffMember));
     when(courseRepository.save(any(Course.class))).thenReturn(course1);
+
+    CourseStaff staffMemberUpdated =
+        CourseStaff.builder()
+            .id(1L)
+            .firstName("Test")
+            .lastName("Staff")
+            .email("teststaff@ucsb.edu")
+            .course(null)
+            .orgStatus(OrgStatus.MEMBER)
+            .githubId(67890)
+            .githubLogin("teststaff")
+            .build();
 
     MvcResult response =
         mockMvc
@@ -1040,9 +1070,8 @@ public class CourseStaffControllerTests extends ControllerTestCase {
             .andReturn();
 
     verify(courseStaffRepository).findById(eq(1L));
-    verify(courseRepository).save(any(Course.class));
-    verify(courseStaffRepository).delete(eq(staffMember));
-    verify(staffListSpy).remove(eq(staffMember));
+    verify(courseStaffRepository).delete(eq(staffMemberUpdated));
+    assertEquals(course1.getCourseStaff(), List.of());
     verify(organizationMemberService, never()).removeOrganizationMember(any(CourseStaff.class));
 
     assertEquals(
@@ -1072,16 +1101,24 @@ public class CourseStaffControllerTests extends ControllerTestCase {
     staffList.add(staffMember);
     course1.setCourseStaff(staffList);
 
-    List<CourseStaff> staffListSpy = Mockito.spy(staffList);
-    course1.setCourseStaff(staffListSpy);
-
     when(courseStaffRepository.findById(eq(1L))).thenReturn(Optional.of(staffMember));
-    when(courseRepository.save(any(Course.class))).thenReturn(course1);
 
     String errorMessage = "API rate limit exceeded";
     doThrow(new RuntimeException(errorMessage))
         .when(organizationMemberService)
         .removeOrganizationMember(any(CourseStaff.class));
+
+    CourseStaff staffMemberUpdated =
+        CourseStaff.builder()
+            .id(1L)
+            .firstName("Test")
+            .lastName("Staff")
+            .email("teststaff@ucsb.edu")
+            .course(null)
+            .orgStatus(OrgStatus.MEMBER)
+            .githubId(67890)
+            .githubLogin("teststaff")
+            .build();
 
     MvcResult response =
         mockMvc
@@ -1094,9 +1131,8 @@ public class CourseStaffControllerTests extends ControllerTestCase {
             .andReturn();
 
     verify(courseStaffRepository).findById(eq(1L));
-    verify(courseRepository).save(any(Course.class));
-    verify(courseStaffRepository).delete(eq(staffMember));
-    verify(staffListSpy).remove(eq(staffMember));
+    verify(courseStaffRepository).delete(eq(staffMemberUpdated));
+    assertEquals(course1.getCourseStaff(), List.of());
     verify(organizationMemberService).removeOrganizationMember(eq(staffMember));
 
     assertEquals(
@@ -1122,7 +1158,6 @@ public class CourseStaffControllerTests extends ControllerTestCase {
 
     verify(courseStaffRepository).findById(eq(99L));
     verify(courseStaffRepository, never()).delete(any(CourseStaff.class));
-    verify(courseRepository, never()).save(any(Course.class));
 
     String responseString = response.getResponse().getContentAsString();
     Map<String, String> expectedMap =
@@ -1148,6 +1183,5 @@ public class CourseStaffControllerTests extends ControllerTestCase {
 
     verify(courseStaffRepository, never()).findById(any());
     verify(courseStaffRepository, never()).delete(any(CourseStaff.class));
-    verify(courseRepository, never()).save(any(Course.class));
   }
 }


### PR DESCRIPTION
In this PR, I fix Roster Student deletion by doing the following:
1. Properly managing the bidirectional relationship (`@ManyToOne`, `@OneToMany`)
   - Objects should be disconnected from both "sides" of the relationship before deletion, ie `rosterStudent.setCourse(null)` and `course.getRosterStudents.remove(rosterStudent)`
   - There should only be one deletion (in our case, from the child side
 2. Manually disconnecting TeamMembers from their teams
   - Because Teams also reference the `Course` object, Hibernate requires that those `course` references are also removed (in this case, it is easier to disconnect them from the team, since they will be deleted anyway).

CourseStaff is also updated because it behaves similarly.