### PR TITLE
Handling Drops

### DIFF
--- a/frontend/src/fixtures/rosterStudentFixtures.js
+++ b/frontend/src/fixtures/rosterStudentFixtures.js
@@ -98,6 +98,42 @@ const rosterStudentFixtures = {
       orgStatus: "Illegal status that will never occur",
     },
   ],
+  fourStudentsOneDropped: [
+    {
+      id: 3,
+      studentId: "A123456",
+      firstName: "Alice",
+      lastName: "Brown",
+      email: "alicebrown@ucsb.edu",
+    },
+
+    {
+      id: 4,
+      studentId: "X123456",
+      firstName: "Tom",
+      lastName: "Hanks",
+      email: "tomhanks@ucsb.edu",
+    },
+
+    {
+      id: 6,
+      studentId: "Z123456",
+      firstName: "Emma",
+      lastName: "Watson",
+      email: "emmawatson@ucsb.edu",
+    },
+    {
+      id: 8,
+      studentId: "D123456",
+      firstName: "Arya",
+      lastName: "Sue",
+      email: "aryasue@ucsb.edu",
+      githubLogin: "aryasue",
+      teams: "Team A",
+      orgStatus: "Illegal status that will never occur",
+      rosterStatus: "DROPPED",
+    },
+  ],
 };
 
 const loadResultFixtures = {

--- a/frontend/src/main/components/RosterStudent/DroppedStudentsTable.jsx
+++ b/frontend/src/main/components/RosterStudent/DroppedStudentsTable.jsx
@@ -1,0 +1,67 @@
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+export default function DroppedStudentsTable({ students, courseId }) {
+  const columns = [
+    {
+      header: "id",
+      accessorKey: "id",
+      id: "id",
+    },
+
+    {
+      header: "Student Id",
+      accessorKey: "studentId",
+    },
+
+    {
+      header: "First Name",
+      accessorKey: "firstName",
+    },
+    {
+      header: "Last Name",
+      accessorKey: "lastName",
+    },
+    {
+      header: "Email",
+      accessorKey: "email",
+    },
+  ];
+
+  const cellToAxiosParamsRestore = (cell) => ({
+    url: `/api/rosterstudents/restore`,
+    method: "PUT",
+    params: {
+      id: cell.row.original.id,
+    },
+  });
+
+  const restoreSuccess = () => {
+    toast("Student successfully restored to course.");
+  };
+
+  const restoreMutation = useBackendMutation(
+    cellToAxiosParamsRestore,
+    {
+      onSuccess: restoreSuccess,
+    },
+    [`/api/rosterstudents/course/${courseId}`],
+  );
+
+  const restoreCallback = (cell) => {
+    restoreMutation.mutate(cell);
+  };
+
+  columns.push(
+    ButtonColumn("Restore", "primary", restoreCallback, "RestoreButton"),
+  );
+
+  return (
+    <OurTable
+      columns={columns}
+      data={students}
+      testid={"DroppedStudentsTable"}
+    />
+  );
+}

--- a/frontend/src/main/components/TabComponent/EnrollmentTabComponent.jsx
+++ b/frontend/src/main/components/TabComponent/EnrollmentTabComponent.jsx
@@ -13,6 +13,7 @@ import RosterStudentCSVUploadForm from "main/components/RosterStudent/RosterStud
 import RosterStudentForm from "main/components/RosterStudent/RosterStudentForm";
 import RosterStudentTable from "main/components/RosterStudent/RosterStudentTable";
 import Modal from "react-bootstrap/Modal";
+import DroppedStudentsTable from "main/components/RosterStudent/DroppedStudentsTable";
 
 export default function EnrollmentTabComponent({
   courseId,
@@ -200,25 +201,38 @@ export default function EnrollmentTabComponent({
       </Row>
       <Row>
         <RosterStudentTable
-          students={rosterStudents.filter((student) => {
-            const searchTermLower = searchTerm.toLowerCase();
-            const fullName = `${student.firstName} ${student.lastName}`;
-            if (student.studentId.toLowerCase().includes(searchTermLower)) {
-              return true;
-            } else if (student.email.toLowerCase().includes(searchTermLower)) {
-              return true;
-            } else if (
-              student.githubLogin?.toLowerCase().includes(searchTermLower)
-            ) {
-              return true;
-            } else if (fullName.toLowerCase().includes(searchTermLower)) {
-              return true;
-            }
-            return false;
-          })}
+          students={rosterStudents
+            .filter((student) => {
+              const searchTermLower = searchTerm.toLowerCase();
+              const fullName = `${student.firstName} ${student.lastName}`;
+              if (student.studentId.toLowerCase().includes(searchTermLower)) {
+                return true;
+              } else if (
+                student.email.toLowerCase().includes(searchTermLower)
+              ) {
+                return true;
+              } else if (
+                student.githubLogin?.toLowerCase().includes(searchTermLower)
+              ) {
+                return true;
+              } else if (fullName.toLowerCase().includes(searchTermLower)) {
+                return true;
+              }
+              return false;
+            })
+            .filter((student) => student.rosterStatus !== "DROPPED")}
           currentUser={currentUser}
           courseId={courseId}
           testIdPrefix={`${testIdPrefix}-RosterStudentTable`}
+        />
+      </Row>
+      <Row>
+        <h2>Dropped Students</h2>
+        <DroppedStudentsTable
+          students={rosterStudents.filter(
+            (student) => student.rosterStatus === "DROPPED",
+          )}
+          courseId={courseId}
         />
       </Row>
     </div>

--- a/frontend/src/stories/components/RosterStudent/DroppedStudentsTable.stories.jsx
+++ b/frontend/src/stories/components/RosterStudent/DroppedStudentsTable.stories.jsx
@@ -1,0 +1,70 @@
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { rosterStudentFixtures } from "fixtures/rosterStudentFixtures";
+import React from "react";
+import DroppedStudentsTable from "main/components/RosterStudent/DroppedStudentsTable";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/RosterStudent/DroppedStudentsTable",
+  component: DroppedStudentsTable,
+};
+
+const Template = (args) => {
+  return <DroppedStudentsTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  students: [],
+  courseId: "",
+  currentUser: currentUserFixtures.userOnly,
+};
+
+Empty.parameters = {
+  msw: [
+    http.put("/api/rosterstudents/restore", ({ request }) => {
+      const url = new URL(request.url);
+      window.alert(
+        "Invoked put with URL: " +
+          url +
+          " and params: " +
+          JSON.stringify(Object.fromEntries(url.searchParams)),
+      );
+      return HttpResponse.json(
+        {},
+        {
+          status: 200,
+        },
+      );
+    }),
+  ],
+};
+
+export const ThreeItems = Template.bind({});
+
+ThreeItems.args = {
+  students: rosterStudentFixtures.threeStudents,
+  currentUser: currentUserFixtures.userOnly,
+  courseId: "1",
+};
+
+ThreeItems.parameters = {
+  msw: [
+    http.put("/api/rosterstudents/restore", ({ request }) => {
+      const url = new URL(request.url);
+      window.alert(
+        "Invoked put with URL: " +
+          url +
+          " and params: " +
+          JSON.stringify(Object.fromEntries(url.searchParams)),
+      );
+      return HttpResponse.json(
+        {},
+        {
+          status: 200,
+        },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/RosterStudent/DroppedStudentsTable.test.jsx
+++ b/frontend/src/tests/components/RosterStudent/DroppedStudentsTable.test.jsx
@@ -1,0 +1,90 @@
+import AxiosMockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import { expect, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import DroppedStudentsTable from "main/components/RosterStudent/DroppedStudentsTable";
+import { rosterStudentFixtures } from "fixtures/rosterStudentFixtures";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const axiosMock = new AxiosMockAdapter(axios);
+const queryClient = new QueryClient();
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    toast: (x) => mockToast(x),
+  };
+});
+describe("DroppedStudentsTable tests", () => {
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    vi.clearAllMocks();
+  });
+  test("renders correctly", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DroppedStudentsTable
+          students={rosterStudentFixtures.threeStudents}
+          courseId={1}
+        />
+        ,
+      </QueryClientProvider>,
+    );
+    const headers = ["id", "Student Id", "First Name", "Last Name", "Email"];
+    const accessors = ["id", "studentId", "firstName", "lastName", "email"];
+    headers.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+    accessors.forEach((accessor) => {
+      expect(
+        screen.getByTestId(`DroppedStudentsTable-cell-row-0-col-${accessor}`),
+      ).toBeInTheDocument();
+    });
+  });
+  test("restore works correctly", async () => {
+    const queryClientSpecific = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          staleTime: Infinity,
+        },
+      },
+    });
+    queryClientSpecific.setQueryData(
+      ["/api/rosterstudents/course/7"],
+      rosterStudentFixtures.threeStudents,
+    );
+    queryClientSpecific.setQueryData(["mock queryData"], null);
+    axiosMock.onPut("/api/rosterstudents/restore").reply(200);
+    render(
+      <QueryClientProvider client={queryClientSpecific}>
+        <DroppedStudentsTable
+          students={rosterStudentFixtures.threeStudents}
+          courseId={7}
+        />
+        ,
+      </QueryClientProvider>,
+    );
+    const restoreButton = await screen.findByTestId(
+      "RestoreButton-cell-row-0-col-Restore-button",
+    );
+    fireEvent.click(restoreButton);
+    await waitFor(() => expect(axiosMock.history.put.length).toEqual(1));
+    expect(mockToast).toBeCalledWith(
+      "Student successfully restored to course.",
+    );
+    expect(axiosMock.history.put.length).toEqual(1);
+    expect(axiosMock.history.put[0].params).toEqual({
+      id: 3,
+    });
+    expect(
+      queryClientSpecific.getQueryState(["/api/rosterstudents/course/7"])
+        .isInvalidated,
+    ).toBe(true);
+    expect(
+      queryClientSpecific.getQueryState(["mock queryData"]).isInvalidated,
+    ).toBe(false);
+  });
+});

--- a/frontend/src/tests/components/RosterStudent/DroppedStudentsTable.test.jsx
+++ b/frontend/src/tests/components/RosterStudent/DroppedStudentsTable.test.jsx
@@ -42,6 +42,9 @@ describe("DroppedStudentsTable tests", () => {
         screen.getByTestId(`DroppedStudentsTable-cell-row-0-col-${accessor}`),
       ).toBeInTheDocument();
     });
+    expect(
+      screen.getByTestId("DroppedStudentsTable-cell-row-0-col-id"),
+    ).toHaveTextContent("3");
   });
   test("restore works correctly", async () => {
     const queryClientSpecific = new QueryClient({
@@ -70,6 +73,7 @@ describe("DroppedStudentsTable tests", () => {
     const restoreButton = await screen.findByTestId(
       "RestoreButton-cell-row-0-col-Restore-button",
     );
+    expect(restoreButton).toHaveClass("btn-primary");
     fireEvent.click(restoreButton);
     await waitFor(() => expect(axiosMock.history.put.length).toEqual(1));
     expect(mockToast).toBeCalledWith(

--- a/frontend/src/tests/components/TabComponent/EnrollmentTabComponent.test.jsx
+++ b/frontend/src/tests/components/TabComponent/EnrollmentTabComponent.test.jsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import {
   loadResultFixtures,
   rosterStudentFixtures,
@@ -133,6 +139,41 @@ describe("EnrollmentTabComponent Tests", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByTestId(`${testId}-csv-error-modal`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("Dropped Students appear correctly", async () => {
+    axiosMock
+      .onGet("/api/rosterstudents/course/1")
+      .reply(200, rosterStudentFixtures.fourStudentsOneDropped);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EnrollmentTabComponent
+          courseId={1}
+          testIdPrefix={testId}
+          currentUser={currentUserFixtures.instructorUser}
+        />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-RosterStudentTable-cell-row-0-col-id`),
+      ).toHaveTextContent(rosterStudentFixtures.fourStudentsOneDropped[0].id);
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`DroppedStudentsTable-cell-row-0-col-studentId`),
+      ).toHaveTextContent(
+        rosterStudentFixtures.fourStudentsOneDropped[3].studentId,
+      );
+    });
+    const table = screen.getByTestId(
+      "InstructorCourseShowPage-RosterStudentTable",
+    );
+    expect(
+      within(table).queryByText("aryasue@ucsb.edu"),
     ).not.toBeInTheDocument();
   });
 

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsCSVController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsCSVController.java
@@ -8,11 +8,14 @@ import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.enums.InsertStatus;
 import edu.ucsb.cs156.frontiers.enums.RosterStatus;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.jobs.RemoveStudentsJob;
 import edu.ucsb.cs156.frontiers.models.LoadResult;
 import edu.ucsb.cs156.frontiers.models.UpsertResponse;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
 import edu.ucsb.cs156.frontiers.services.UpdateUserService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -48,6 +51,8 @@ public class RosterStudentsCSVController extends ApiController {
   @Autowired private CourseRepository courseRepository;
 
   @Autowired private UpdateUserService updateUserService;
+  @Autowired private OrganizationMemberService organizationMemberService;
+  @Autowired private JobService jobService;
 
   public enum RosterSourceType {
     UCSB_EGRADES,
@@ -117,9 +122,12 @@ public class RosterStudentsCSVController extends ApiController {
             .findById(courseId)
             .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
 
+    course.getRosterStudents().stream()
+        .filter(filteredStudent -> filteredStudent.getRosterStatus() == RosterStatus.ROSTER)
+        .forEach(student -> student.setRosterStatus(RosterStatus.DROPPED));
+
     int counts[] = {0, 0};
     List<RosterStudent> rejectedStudents = new ArrayList<>();
-    List<RosterStudent> saveableStudents = new ArrayList<>();
 
     try (InputStream inputStream = new BufferedInputStream(file.getInputStream());
         InputStreamReader reader = new InputStreamReader(inputStream);
@@ -141,23 +149,37 @@ public class RosterStudentsCSVController extends ApiController {
         if (upsertResponse.getInsertStatus() == InsertStatus.REJECTED) {
           rejectedStudents.add(upsertResponse.rosterStudent());
         } else {
-          saveableStudents.add(upsertResponse.rosterStudent());
           InsertStatus s = upsertResponse.getInsertStatus();
+          if (s == InsertStatus.INSERTED) {
+            course.getRosterStudents().add(upsertResponse.rosterStudent());
+          }
           counts[s.ordinal()]++;
         }
       }
     }
-    LoadResult loadResult =
-        new LoadResult(
-            counts[InsertStatus.INSERTED.ordinal()],
-            counts[InsertStatus.UPDATED.ordinal()],
-            rejectedStudents);
     if (rejectedStudents.isEmpty()) {
-      saveableStudents = rosterStudentRepository.saveAll(saveableStudents);
-      updateUserService.attachUsersToRosterStudents(saveableStudents);
-      return ResponseEntity.ok(loadResult);
+      List<RosterStudent> droppedStudents =
+          course.getRosterStudents().stream()
+              .filter(student -> student.getRosterStatus() == RosterStatus.DROPPED)
+              .toList();
+      LoadResult successfulResult =
+          new LoadResult(
+              counts[InsertStatus.INSERTED.ordinal()],
+              counts[InsertStatus.UPDATED.ordinal()],
+              droppedStudents.size(),
+              List.of());
+      rosterStudentRepository.saveAll(course.getRosterStudents());
+      updateUserService.attachUsersToRosterStudents(course.getRosterStudents());
+      RemoveStudentsJob job =
+          RemoveStudentsJob.builder()
+              .students(droppedStudents)
+              .organizationMemberService(organizationMemberService)
+              .build();
+      jobService.runAsJob(job);
+      return ResponseEntity.ok(successfulResult);
     } else {
-      return ResponseEntity.status(HttpStatus.CONFLICT).body(loadResult);
+      LoadResult conflictResult = new LoadResult(0, 0, 0, rejectedStudents);
+      return ResponseEntity.status(HttpStatus.CONFLICT).body(conflictResult);
     }
   }
 

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsCSVController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsCSVController.java
@@ -174,6 +174,7 @@ public class RosterStudentsCSVController extends ApiController {
           RemoveStudentsJob.builder()
               .students(droppedStudents)
               .organizationMemberService(organizationMemberService)
+              .rosterStudentRepository(rosterStudentRepository)
               .build();
       jobService.runAsJob(job);
       return ResponseEntity.ok(successfulResult);

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -218,6 +218,11 @@ public class RosterStudentsController extends ApiController {
       throw new AccessDeniedException("User not authorized join the course as this roster student");
     }
 
+    if (rosterStudent.getRosterStatus() == RosterStatus.DROPPED) {
+      throw new AccessDeniedException(
+          "You have dropped this course. Please contact your instructor.");
+    }
+
     if (rosterStudent.getGithubId() != null
         && rosterStudent.getGithubLogin() != null
         && (rosterStudent.getOrgStatus() == OrgStatus.MEMBER

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -301,6 +301,21 @@ public class RosterStudentsController extends ApiController {
     return rosterStudentRepository.save(rosterStudent);
   }
 
+  @Operation(
+      summary = "Restore a roster student",
+      description = "Makes a student who previously dropped the course able to join and interact")
+  @PreAuthorize("@CourseSecurity.hasRosterStudentManagementPermissions(#root, #id)")
+  @PutMapping("/restore")
+  public RosterStudent restoreRosterStudent(@Parameter(name = "id") @RequestParam Long id)
+      throws EntityNotFoundException {
+    RosterStudent rosterStudent =
+        rosterStudentRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(RosterStudent.class, id));
+    rosterStudent.setRosterStatus(RosterStatus.MANUAL);
+    return rosterStudentRepository.save(rosterStudent);
+  }
+
   @Operation(summary = "Delete a roster student")
   @PreAuthorize("@CourseSecurity.hasRosterStudentManagementPermissions(#root, #id)")
   @DeleteMapping("/delete")

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -92,12 +92,12 @@ public class RosterStudentsController extends ApiController {
             .email(email)
             .build();
 
-    UpsertResponse upsertResponse =
-        upsertStudent(
-            rosterStudentRepository, updateUserService, rosterStudent, course, RosterStatus.MANUAL);
+    UpsertResponse upsertResponse = upsertStudent(rosterStudent, course, RosterStatus.MANUAL);
     if (upsertResponse.getInsertStatus() == InsertStatus.REJECTED) {
       return ResponseEntity.status(HttpStatus.CONFLICT).body(upsertResponse);
     } else {
+      rosterStudent = rosterStudentRepository.save(upsertResponse.rosterStudent());
+      updateUserService.attachUserToRosterStudent(rosterStudent);
       return ResponseEntity.ok(upsertResponse);
     }
   }
@@ -125,16 +125,17 @@ public class RosterStudentsController extends ApiController {
   }
 
   public static UpsertResponse upsertStudent(
-      RosterStudentRepository rosterStudentRepository,
-      UpdateUserService updateUserService,
-      RosterStudent student,
-      Course course,
-      RosterStatus rosterStatus) {
+      RosterStudent student, Course course, RosterStatus rosterStatus) {
     String convertedEmail = CanonicalFormConverter.convertToValidEmail(student.getEmail());
     Optional<RosterStudent> existingStudent =
-        rosterStudentRepository.findByCourseIdAndStudentId(course.getId(), student.getStudentId());
+        course.getRosterStudents().stream()
+            .filter(
+                filteringStudent -> student.getStudentId().equals(filteringStudent.getStudentId()))
+            .findFirst();
     Optional<RosterStudent> existingStudentByEmail =
-        rosterStudentRepository.findByCourseIdAndEmail(course.getId(), convertedEmail);
+        course.getRosterStudents().stream()
+            .filter(filteringStudent -> convertedEmail.equals(filteringStudent.getEmail()))
+            .findFirst();
     if (existingStudent.isPresent() && existingStudentByEmail.isPresent()) {
       if (existingStudent.get().getId().equals(existingStudentByEmail.get().getId())) {
         RosterStudent existingStudentObj = existingStudent.get();
@@ -142,7 +143,6 @@ public class RosterStudentsController extends ApiController {
         existingStudentObj.setFirstName(student.getFirstName());
         existingStudentObj.setLastName(student.getLastName());
         existingStudentObj.setSection(student.getSection());
-        rosterStudentRepository.save(existingStudentObj);
         return new UpsertResponse(InsertStatus.UPDATED, existingStudentObj);
       } else {
         return new UpsertResponse(InsertStatus.REJECTED, student);
@@ -156,8 +156,6 @@ public class RosterStudentsController extends ApiController {
       existingStudentObj.setSection(student.getSection());
       existingStudentObj.setEmail(convertedEmail);
       existingStudentObj.setStudentId(student.getStudentId());
-      existingStudentObj = rosterStudentRepository.save(existingStudentObj);
-      updateUserService.attachUserToRosterStudent(existingStudentObj);
       return new UpsertResponse(InsertStatus.UPDATED, existingStudentObj);
     } else {
       student.setCourse(course);
@@ -170,8 +168,6 @@ public class RosterStudentsController extends ApiController {
       } else {
         student.setOrgStatus(OrgStatus.PENDING);
       }
-      student = rosterStudentRepository.save(student);
-      updateUserService.attachUserToRosterStudent(student);
       return new UpsertResponse(InsertStatus.INSERTED, student);
     }
   }

--- a/src/main/java/edu/ucsb/cs156/frontiers/enums/OrgStatus.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/enums/OrgStatus.java
@@ -5,5 +5,6 @@ public enum OrgStatus {
   JOINCOURSE,
   INVITED,
   MEMBER,
-  OWNER
+  OWNER,
+  REMOVED
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/RemoveStudentsJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/RemoveStudentsJob.java
@@ -1,0 +1,36 @@
+package edu.ucsb.cs156.frontiers.jobs;
+
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobContext;
+import edu.ucsb.cs156.frontiers.services.jobs.JobContextConsumer;
+import java.util.List;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+
+@Builder
+@EqualsAndHashCode
+public class RemoveStudentsJob implements JobContextConsumer {
+  private OrganizationMemberService organizationMemberService;
+  private List<RosterStudent> students;
+  private RosterStudentRepository rosterStudentRepository;
+
+  @Override
+  public void accept(JobContext c) throws Exception {
+    for (RosterStudent student : students) {
+      if (student.getCourse().getOrgName() != null
+          && student.getCourse().getInstallationId() != null) {
+        if (student.getGithubLogin() != null && student.getGithubId() != null) {
+          organizationMemberService.removeOrganizationMember(student);
+          c.log("Removed student %s from Organization".formatted(student.getGithubLogin()));
+          student.setOrgStatus(OrgStatus.REMOVED);
+          student.setGithubId(null);
+          student.setGithubLogin(null);
+          rosterStudentRepository.save(student);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/models/LoadResult.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/models/LoadResult.java
@@ -3,4 +3,5 @@ package edu.ucsb.cs156.frontiers.models;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import java.util.List;
 
-public record LoadResult(Integer created, Integer updated, List<RosterStudent> rejected) {}
+public record LoadResult(
+    Integer created, Integer updated, Integer dropped, List<RosterStudent> rejected) {}

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/UpdateUserService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/UpdateUserService.java
@@ -36,7 +36,7 @@ public class UpdateUserService {
   /**
    * This method attaches the CourseStaff to the User based on their email.
    *
-   * @param user The user to whom the RosterStudents will be attached
+   * @param user The user to whom the CourseStaff will be attached
    */
   public void attachCourseStaff(User user) {
     List<CourseStaff> matchedStaff = courseStaffRepository.findAllByEmail(user.getEmail());
@@ -66,6 +66,13 @@ public class UpdateUserService {
   }
 
   /** This method attaches a SingleRoster student to the User based on their email. */
+  public void attachUsersToRosterStudents(List<RosterStudent> rosterStudents) {
+    for (RosterStudent matchedStudent : rosterStudents) {
+      attachUserToRosterStudent(matchedStudent);
+    }
+  }
+
+  /** This method attaches a Single Course Staff member to the User based on their email. */
   public void attachUserToCourseStaff(CourseStaff courseStaff) {
     String email = courseStaff.getEmail();
     Optional<User> optionalUser = userRepository.findByEmail(email);

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsCSVControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsCSVControllerTests.java
@@ -2,10 +2,9 @@ package edu.ucsb.cs156.frontiers.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -179,25 +178,16 @@ public class RosterStudentsCSVControllerTests extends ControllerTestCase {
             .orgStatus(OrgStatus.PENDING)
             .build();
 
+    course1.setRosterStudents(List.of(rs1BeforeWithId, rs2BeforeWithId));
+
     MockMultipartFile file =
         new MockMultipartFile(
             "file", "roster.csv", MediaType.TEXT_PLAIN_VALUE, sampleCSVContentsChico.getBytes());
 
     when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));
-    when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("013228559")))
-        .thenReturn(Optional.of(rs1BeforeWithId));
-    when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("013205354")))
-        .thenReturn(Optional.of(rs2BeforeWithId));
-    when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("013251642")))
-        .thenReturn(Optional.empty());
 
-    when(rosterStudentRepository.save(eq(rs1AfterWithId))).thenReturn(rs1AfterWithId);
-    when(rosterStudentRepository.save(eq(rs2AfterWithId))).thenReturn(rs2AfterWithId);
-    when(rosterStudentRepository.save(eq(rs3NoId))).thenReturn(rs3WithId);
-
-    doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs1AfterWithId));
-    doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs2AfterWithId));
-    doNothing().when(updateUserService).attachUserToRosterStudent(eq(rs3WithId));
+    when(rosterStudentRepository.saveAll(List.of(rs1AfterWithId, rs2AfterWithId, rs3NoId)))
+        .thenReturn(List.of(rs1AfterWithId, rs2AfterWithId, rs3WithId));
 
     // act
 
@@ -214,19 +204,10 @@ public class RosterStudentsCSVControllerTests extends ControllerTestCase {
     // assert
 
     verify(courseRepository, atLeastOnce()).findById(eq(1L));
-    verify(rosterStudentRepository, atLeastOnce())
-        .findByCourseIdAndStudentId(eq(1L), eq("013228559"));
-    verify(rosterStudentRepository, atLeastOnce())
-        .findByCourseIdAndStudentId(eq(1L), eq("013205354"));
-    verify(rosterStudentRepository, atLeastOnce())
-        .findByCourseIdAndStudentId(eq(1L), eq("013251642"));
-    verify(rosterStudentRepository, atLeastOnce()).save(eq(rs1AfterWithId));
-    verify(rosterStudentRepository, atLeastOnce()).save(eq(rs2AfterWithId));
-    verify(rosterStudentRepository, atLeastOnce()).save(eq(rs3NoId));
-
-    verify(updateUserService, times(1)).attachUserToRosterStudent(eq(rs1AfterWithId));
-    verify(updateUserService, times(1)).attachUserToRosterStudent(eq(rs2AfterWithId));
-    verify(updateUserService, times(1)).attachUserToRosterStudent(eq(rs3WithId));
+    verify(rosterStudentRepository, times(1))
+        .saveAll(List.of(rs1AfterWithId, rs2AfterWithId, rs3NoId));
+    verify(updateUserService, times(1))
+        .attachUsersToRosterStudents(List.of(rs1AfterWithId, rs2AfterWithId, rs3WithId));
 
     String responseString = response.getResponse().getContentAsString();
     LoadResult expectedResult = new LoadResult(1, 2, List.of());
@@ -242,19 +223,12 @@ public class RosterStudentsCSVControllerTests extends ControllerTestCase {
     RosterStudent student1Email = RosterStudent.builder().id(2L).email("cgaucho@ucsb.edu").build();
     RosterStudent student2 =
         RosterStudent.builder().id(3L).studentId("A987654").email("ldelplaya@ucsb.edu").build();
-    RosterStudent student3 = RosterStudent.builder().id(4L).email("sabadotarde@ucsb.edu").build();
-    Course course1 = Course.builder().id(1L).build();
+    Course course1 =
+        Course.builder()
+            .id(1L)
+            .rosterStudents(List.of(student1ID, student1Email, student2))
+            .build();
     when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));
-    when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("A123456")))
-        .thenReturn(Optional.of(student1ID));
-    when(rosterStudentRepository.findByCourseIdAndEmail(eq(1L), eq("cgaucho@ucsb.edu")))
-        .thenReturn(Optional.of(student1Email));
-    when(rosterStudentRepository.findByCourseIdAndStudentId(eq(1L), eq("A987654")))
-        .thenReturn(Optional.of(student2));
-    when(rosterStudentRepository.findByCourseIdAndEmail(eq(1L), eq("ldelplaya@ucsb.edu")))
-        .thenReturn(Optional.of(student2));
-    when(rosterStudentRepository.findByCourseIdAndEmail(eq(1L), eq("sabadotarde@ucsb.edu")))
-        .thenReturn(Optional.of(student3));
     MockMultipartFile file =
         new MockMultipartFile(
             "file", "roster.csv", MediaType.TEXT_PLAIN_VALUE, sampleCSVContentsUCSB.getBytes());
@@ -298,11 +272,9 @@ public class RosterStudentsCSVControllerTests extends ControllerTestCase {
             .rosterStatus(RosterStatus.ROSTER)
             .build();
 
-    verify(rosterStudentRepository, times(2)).save(any(RosterStudent.class));
-    verify(rosterStudentRepository, atLeastOnce()).save(eq(rosterStudent2Updated));
-    verify(rosterStudentRepository, atLeastOnce()).save(eq(rosterStudent3Updated));
+    verify(rosterStudentRepository, never()).saveAll(List.of());
     String responseString = response.getResponse().getContentAsString();
-    LoadResult expectedResult = new LoadResult(0, 2, List.of(rosterStudentRejected));
+    LoadResult expectedResult = new LoadResult(1, 1, List.of(rosterStudentRejected));
     String expectedJson = mapper.writeValueAsString(expectedResult);
     assertEquals(expectedJson, responseString);
   }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -629,6 +629,46 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
 
   @Test
   @WithMockUser(roles = {"USER", "GITHUB"})
+  public void access_denied_on_dropped() throws Exception {
+    User currentUser = currentUserService.getUser();
+
+    Course course2 =
+        Course.builder()
+            .id(2L)
+            .installationId("1234")
+            .orgName("ucsb-cs156")
+            .courseName("course")
+            .instructorEmail("instructoremail@ucsb.edu")
+            .build();
+
+    RosterStudent rosterStudent =
+        RosterStudent.builder()
+            .id(3L)
+            .firstName("Test")
+            .lastName("User")
+            .studentId("A555555")
+            .email("testuser@ucsb.edu")
+            .course(course2)
+            .rosterStatus(RosterStatus.DROPPED)
+            .orgStatus(OrgStatus.JOINCOURSE)
+            .githubId(null) // Not linked yet
+            .githubLogin(null) // Not linked yet
+            .user(currentUser) // Current user owns this roster entry
+            .build();
+
+    when(rosterStudentRepository.findById(eq(3L))).thenReturn(Optional.of(rosterStudent));
+
+    // Act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/rosterstudents/joinCourse").with(csrf()).param("rosterStudentId", "3"))
+            .andExpect(status().isForbidden())
+            .andReturn();
+  }
+
+  @Test
+  @WithMockUser(roles = {"USER", "GITHUB"})
   public void no_fire_on_no_org_name() throws Exception {
     User currentUser = currentUserService.getUser();
 

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/RemoveStudentsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/RemoveStudentsJobTests.java
@@ -1,0 +1,133 @@
+package edu.ucsb.cs156.frontiers.jobs;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobContext;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class RemoveStudentsJobTests {
+
+  @Mock private OrganizationMemberService organizationMemberService;
+  @Mock private JobContext jobContext;
+  @Mock private RosterStudentRepository rosterStudentRepository;
+
+  private RemoveStudentsJob removeStudentsJob;
+  private List<RosterStudent> validStudents;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testAccept_validStudents_callsRemoveOrganizationMember() throws Exception {
+    Course course = Course.builder().orgName("testOrg").installationId("123456").build();
+    RosterStudent student1 =
+        RosterStudent.builder()
+            .course(course)
+            .githubLogin("testLogin1")
+            .githubId(123545)
+            .orgStatus(OrgStatus.MEMBER)
+            .build();
+    RosterStudent student2 =
+        RosterStudent.builder()
+            .course(course)
+            .githubLogin("testLogin2")
+            .orgStatus(OrgStatus.OWNER)
+            .githubId(123456)
+            .build();
+
+    RosterStudent student1Updated =
+        RosterStudent.builder().course(course).orgStatus(OrgStatus.REMOVED).build();
+    RosterStudent student2Updated =
+        RosterStudent.builder().course(course).orgStatus(OrgStatus.REMOVED).build();
+
+    validStudents = List.of(student1, student2);
+
+    removeStudentsJob =
+        RemoveStudentsJob.builder()
+            .organizationMemberService(organizationMemberService)
+            .rosterStudentRepository(rosterStudentRepository)
+            .students(validStudents)
+            .build();
+
+    // Act
+    removeStudentsJob.accept(jobContext);
+
+    // Assert
+    verify(organizationMemberService, times(2)).removeOrganizationMember(any(RosterStudent.class));
+    verify(rosterStudentRepository, times(2)).save(any(RosterStudent.class));
+    verify(rosterStudentRepository, atLeastOnce()).save(student1Updated);
+    verify(rosterStudentRepository, atLeastOnce()).save(student2Updated);
+  }
+
+  @Test
+  public void testAccept_incompleteCourseData_doesNotCallRemoveOrganizationMember()
+      throws Exception {
+    // Arrange
+    Course unlinkedCourse = Course.builder().orgName(null).installationId(null).build();
+    RosterStudent unlinkedCourseStudent1 =
+        RosterStudent.builder()
+            .course(unlinkedCourse)
+            .githubLogin("testLogin")
+            .githubId(123456)
+            .build();
+    Course incompleteCourse = Course.builder().orgName("org-1").installationId(null).build();
+    RosterStudent unlinkedCourseStudent2 =
+        RosterStudent.builder()
+            .course(incompleteCourse)
+            .githubLogin("testLogin")
+            .githubId(123456)
+            .build();
+    removeStudentsJob =
+        RemoveStudentsJob.builder()
+            .organizationMemberService(organizationMemberService)
+            .rosterStudentRepository(rosterStudentRepository)
+            .students(List.of(unlinkedCourseStudent1, unlinkedCourseStudent2))
+            .build();
+
+    // Act
+    removeStudentsJob.accept(jobContext);
+
+    // Assert
+    verify(organizationMemberService, never()).removeOrganizationMember(any(RosterStudent.class));
+    verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
+  }
+
+  @Test
+  public void testAccept_incompleteGithubData_doesNotCallRemoveOrganizationMember()
+      throws Exception {
+    // Arrange
+    Course course = Course.builder().orgName("testOrg").installationId("123456").build();
+    RosterStudent studentNoGithubData =
+        RosterStudent.builder().course(course).githubLogin(null).githubId(null).build();
+    RosterStudent studentNoGithubId =
+        RosterStudent.builder().course(course).githubLogin("fakeusername").githubId(null).build();
+    removeStudentsJob =
+        RemoveStudentsJob.builder()
+            .organizationMemberService(organizationMemberService)
+            .rosterStudentRepository(rosterStudentRepository)
+            .students(List.of(studentNoGithubData, studentNoGithubId))
+            .build();
+
+    // Act
+    removeStudentsJob.accept(jobContext);
+
+    // Assert
+    verify(organizationMemberService, never()).removeOrganizationMember(any(RosterStudent.class));
+    verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/UpdateUserServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/UpdateUserServiceTests.java
@@ -191,4 +191,24 @@ public class UpdateUserServiceTests {
     assertEquals(user, staff1.getUser());
     assertEquals(user, staff2.getUser());
   }
+
+  @Test
+  public void testAttachUsesrToRosterStudents_userExists() {
+    // Arrange
+    String email = "test@example.com";
+    User user = User.builder().email(email).build();
+
+    RosterStudent rosterStudent = new RosterStudent();
+    rosterStudent.setEmail(email);
+
+    when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+    // Act
+    updateUserService.attachUsersToRosterStudents(List.of(rosterStudent));
+
+    // Assert
+    verify(userRepository, times(1)).findByEmail(email);
+    verify(rosterStudentRepository, times(1)).save(rosterStudent);
+    assertEquals(rosterStudent.getUser(), user);
+  }
 }


### PR DESCRIPTION
In this PR, I refactor the UpsertResponse method so that the actual saving is handled outside the method. Additionally, the method is refactored to search for students who are present on the course roster student list, as it will cut down on the number of database calls and make the list much easier to handle, as it keeps down the number of objects and means when students are "updated", they are already present on the list of students for the course.

I do so with the intention to allow marking students as dropped from the CSV endpoint without having to refetch students from the database.

Then, I refactor the method to mark students with the RosterStatus `ROSTER` as dropped. It then updates the list with everyone on the roster (updated students update existing object references on the list, and new students are added to the list), and sends the dropped students off to be removed.

I'm not exactly a fan of how I completed this (having to reattach users to the entire course list is inefficient). However, the only other way I could come up with was to maintain a separate list of "updated" students to be reattached, and rely on object references in the initial course list to be updated, leaving only truly dropped students with the dropped status. However, this would be fairly unclear to developers looking at it.

I'm very open to suggestions on how to make this clearer and/or more efficient.

Closes #393 as described

deployed to https://frontiers-qa8.dokku-00.cs.ucsb.edu/

Test plan: 
1. Add yourself to an accepted CSV format
2. Upload that csv format so that you are present as a Roster Student
3. Join the course on GitHub
4. Upload an empty version of an accepted CSV format
5. Ensure you are removed from the course organization

Future work: currently does not handle students who are invited and have not joined the course.
