### PR TITLE
Adding a Confirmation Modal on Student Delete

### DIFF
--- a/frontend/src/main/components/RosterStudent/RosterStudentDeleteModal.jsx
+++ b/frontend/src/main/components/RosterStudent/RosterStudentDeleteModal.jsx
@@ -1,0 +1,55 @@
+import Modal from "react-bootstrap/Modal";
+import { useForm } from "react-hook-form";
+import { Form } from "react-bootstrap";
+
+export default function RosterStudentDeleteModal({
+  onSubmitAction,
+  showModal,
+  toggleShowModal,
+}) {
+  const hideModal = () => {
+    toggleShowModal(false);
+  };
+
+  const { register, handleSubmit } = useForm();
+
+  return (
+    <Modal
+      show={showModal}
+      onHide={hideModal}
+      centered={true}
+      data-testid="RosterStudentDeleteModal"
+    >
+      <Modal.Header closeButton>Delete Roster Student</Modal.Header>
+      <Form onSubmit={handleSubmit(onSubmitAction)}>
+        <Modal.Body>
+          <Form.Text>
+            Are you sure you want to delete this roster student?
+          </Form.Text>
+          <Form.Group>
+            <Form.Check
+              type="radio"
+              label="Yes, I'd like to remove them from the GitHub Organization"
+              value="true"
+              id="remove-yes"
+              {...register("removeFromOrg")}
+            />
+            <Form.Check
+              type="radio"
+              label="No, I'd like to keep them in the GitHub Organization"
+              value="false"
+              id="remove-no"
+              defaultChecked
+              {...register("removeFromOrg")}
+            />
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <button type="submit" className="btn btn-primary">
+            Delete Student
+          </button>
+        </Modal.Footer>
+      </Form>
+    </Modal>
+  );
+}

--- a/frontend/src/main/utils/rosterStudentUtils.js
+++ b/frontend/src/main/utils/rosterStudentUtils.js
@@ -1,16 +1,10 @@
-import { toast } from "react-toastify";
-
-export function onDeleteSuccess(message) {
-  console.log(message);
-  toast(message);
-}
-
-export function cellToAxiosParamsDelete(cell) {
+export function cellToAxiosParamsDelete(formData) {
   return {
     url: "/api/rosterstudents/delete",
     method: "DELETE",
     params: {
-      id: cell.row.original.id,
+      id: formData.id,
+      removeFromOrg: formData.removeFromOrg,
     },
   };
 }

--- a/frontend/src/stories/components/RosterStudent/RosterStudentDeleteModal.stories.jsx
+++ b/frontend/src/stories/components/RosterStudent/RosterStudentDeleteModal.stories.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+import { Button } from "react-bootstrap";
+import RosterStudentDeleteModal from "main/components/RosterStudent/RosterStudentDeleteModal";
+
+export default {
+  title: "components/RosterStudent/RosterStudentDeleteModal",
+  component: RosterStudentDeleteModal,
+};
+
+const Template = (args) => {
+  const [modal, setModalState] = useState(false);
+  return (
+    <div>
+      <Button onClick={() => setModalState(true)}>Open Modal</Button>
+      <RosterStudentDeleteModal
+        showModal={modal}
+        toggleShowModal={setModalState}
+        {...args}
+      />
+    </div>
+  );
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  onSubmitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/tests/components/RosterStudent/RosterStudentDeleteModal.test.jsx
+++ b/frontend/src/tests/components/RosterStudent/RosterStudentDeleteModal.test.jsx
@@ -1,0 +1,90 @@
+import { vi } from "vitest";
+import RosterStudentDeleteModal from "main/components/RosterStudent/RosterStudentDeleteModal";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+
+const mockSubmit = vi.fn();
+const showModal = vi.fn();
+const toggleShowModal = vi.fn();
+describe("RosterStudentDeleteModal tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  test("RosterStudentDeleteModal renders correctly, submits default", async () => {
+    render(
+      <div
+        className="modal show"
+        style={{ display: "block", position: "initial" }}
+      >
+        <RosterStudentDeleteModal
+          showModal={showModal}
+          toggleShowModal={toggleShowModal}
+          onSubmitAction={mockSubmit}
+        />
+      </div>,
+    );
+
+    expect(screen.getByTestId("RosterStudentDeleteModal")).toHaveClass(
+      "modal-dialog-centered",
+    );
+
+    const submitButton = await screen.findByText("Delete Student");
+    fireEvent.click(submitButton);
+    await waitFor(() => expect(mockSubmit).toHaveBeenCalledTimes(1));
+    expect(mockSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        removeFromOrg: "false",
+      }),
+      expect.anything(),
+    );
+  });
+
+  test("RosterStudentDeleteModal submits selected answer", async () => {
+    render(
+      <div
+        className="modal show"
+        style={{ display: "block", position: "initial" }}
+      >
+        <RosterStudentDeleteModal
+          showModal={showModal}
+          toggleShowModal={toggleShowModal}
+          onSubmitAction={mockSubmit}
+        />
+      </div>,
+    );
+
+    const submitButton = await screen.findByText("Delete Student");
+    fireEvent.click(
+      screen.getByLabelText(
+        "Yes, I'd like to remove them from the GitHub Organization",
+      ),
+    );
+    fireEvent.click(submitButton);
+    await waitFor(() => expect(mockSubmit).toHaveBeenCalledTimes(1));
+    expect(mockSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        removeFromOrg: "true",
+      }),
+      expect.anything(),
+    );
+  });
+
+  test("Can click close", async () => {
+    render(
+      <div
+        className="modal show"
+        style={{ display: "block", position: "initial" }}
+      >
+        <RosterStudentDeleteModal
+          showModal={showModal}
+          toggleShowModal={toggleShowModal}
+          onSubmitAction={mockSubmit}
+        />
+      </div>,
+    );
+
+    const closeButton = await screen.findByRole("button", { name: "Close" });
+    fireEvent.click(closeButton);
+    await waitFor(() => expect(toggleShowModal).toHaveBeenCalledTimes(1));
+    expect(toggleShowModal).toHaveBeenCalledWith(false);
+  });
+});

--- a/frontend/src/tests/utils/rosterStudentUtils.test.jsx
+++ b/frontend/src/tests/utils/rosterStudentUtils.test.jsx
@@ -1,8 +1,4 @@
-import {
-  onDeleteSuccess,
-  cellToAxiosParamsDelete,
-} from "main/utils/rosterStudentUtils";
-import mockConsole from "tests/testutils/mockConsole";
+import { cellToAxiosParamsDelete } from "main/utils/rosterStudentUtils";
 import { vi } from "vitest";
 
 const mockToast = vi.fn();
@@ -14,36 +10,22 @@ vi.mock("react-toastify", async (importOriginal) => {
 });
 
 describe("rosterStudentUtils", () => {
-  describe("onDeleteSuccess", () => {
-    test("It puts the message on console.log and in a toast", () => {
-      // arrange
-      const restoreConsole = mockConsole();
-
-      // act
-      onDeleteSuccess("abc");
-
-      // assert
-      expect(mockToast).toHaveBeenCalledWith("abc");
-      expect(console.log).toHaveBeenCalled();
-      const message = console.log.mock.calls[0][0];
-      expect(message).toMatch("abc");
-
-      restoreConsole();
-    });
-  });
   describe("cellToAxiosParamsDelete", () => {
     test("It returns the correct params", () => {
       // arrange
-      const cell = { row: { original: { id: 2 } } };
+      const formReturn = {
+        id: 2,
+        removeFromOrg: false,
+      };
 
       // act
-      const result = cellToAxiosParamsDelete(cell);
+      const result = cellToAxiosParamsDelete(formReturn);
 
       // assert
       expect(result).toEqual({
         url: "/api/rosterstudents/delete",
         method: "DELETE",
-        params: { id: 2 },
+        params: { id: 2, removeFromOrg: false },
       });
     });
   });


### PR DESCRIPTION
In this PR, I add `RosterStudentDeleteModal`, its stories, its tests, and add it to the RosterStudentTable.

It defaults to "don't remove from organization", but this can be changed.

Deployed to https://frontiers-qa4.dokku-00.cs.ucsb.edu

Closes #425 