### PR TITLE
pc - correct erroneous role enforcement; this page needs to be available to instructors too, not just admins

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -142,7 +142,7 @@ function App() {
           element={
             <ProtectedPage
               component={<InstructorCourseShowPage />}
-              enforceRole={"ROLE_ADMIN"}
+              enforceRole={"ROLE_INSTRUCTOR"}
               currentUser={currentUser}
             />
           }


### PR DESCRIPTION
Test plan:

* Add a second account as instructor only, not admin.
* Ensure that with this instructor only account, you can create a course, link a course, add students, etc.

