### PR TITLE
SH-add job name to jobs in backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/Job.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/Job.java
@@ -29,7 +29,7 @@ public class Job {
   @LastModifiedDate private ZonedDateTime updatedAt;
 
   private String status;
-  private String jobname;
+  private String jobName;
 
   // 1048576 is 2^20, which is the max size of a mediumtext in MySQL
   @Column(

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/jobs/JobService.java
@@ -30,10 +30,10 @@ public class JobService {
         Job.builder()
             .createdBy(currentUserService.getUser())
             .status("running")
-            .jobname(jobName)
+            .jobName(jobName)
             .build();
 
-    log.info("Starting job: {}, jobName={}", job.getId(), job.getJobname());
+    log.info("Starting job: {}, jobName={}", job.getId(), job.getJobName());
 
     jobsRepository.save(job);
     self.runJobAsync(job, jobFunction);

--- a/src/main/resources/db/migration/changes/008-add-jobname-to-job.json
+++ b/src/main/resources/db/migration/changes/008-add-jobname-to-job.json
@@ -3,7 +3,7 @@
     {
       "changeSet": {
         "id": "008-add-jobname-to-job",
-        "author": "copilot",
+        "author": "copilot/summit.haque",
         "changes": [
           {
             "addColumn": {
@@ -11,7 +11,7 @@
               "columns": [
                 {
                   "column": {
-                    "name": "JOBNAME",
+                    "name": "JOB_NAME",
                     "type": "VARCHAR(255)",
                     "constraints": {
                       "nullable": true

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/JobServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/JobServiceTests.java
@@ -92,7 +92,7 @@ public class JobServiceTests {
     TestJob job = TestJob.builder().fail(false).sleepMs(0).build();
 
     Job fireJob =
-        Job.builder().jobname("TestJob").createdBy(user.getUser()).status("running").build();
+        Job.builder().jobName("TestJob").createdBy(user.getUser()).status("running").build();
 
     doNothing().when(injectedJobService).runJobAsync(any(), any());
     when(currentUserService.getUser()).thenReturn(user.getUser());


### PR DESCRIPTION


In this PR, we add a column to the jobs table and populate it so that each job is associated with the code that runs that job.  For example, after this PR, we'll be able to tell the difference between an instance of a [`CreateTeamRepositoriesJob`](https://github.com/ucsb-cs156/proj-frontiers/blob/main/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateTeamRepositoriesJob.java) and an instance of [`MembershipAuditJob`](https://github.com/ucsb-cs156/proj-frontiers/blob/main/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java).  Before this PR, it was not possible to know, except to infer from the log output.  When this is made visible in the frontend, it will help admins and instructors to better interpret job output.

1. The attribute "jobname" is added in the Job entity
2. A database change migration is added
3. In the job service procedure, when a job is created, its name is retrieved from the class name and added to it.

## Testing Plan
1. Review the code
4. Review the DB change log.

Deployed to: (https://frontiers-summit.dokku-00.cs.ucsb.edu/)

Closes #529
