### PR TITLE
Removing Useless Eager Joins on Users

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/User.java
@@ -1,11 +1,7 @@
 package edu.ucsb.cs156.frontiers.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import java.util.List;
 import lombok.*;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
 
 /** This is a JPA entity that represents a user. */
 @Data
@@ -27,16 +23,4 @@ public class User {
   private Integer githubId;
   private String githubLogin;
   private String studentId;
-
-  @JsonIgnore
-  @OneToMany(mappedBy = "user")
-  @Fetch(FetchMode.JOIN)
-  @ToString.Exclude
-  private List<RosterStudent> linkedStudents;
-
-  @OneToMany(mappedBy = "user")
-  @Fetch(FetchMode.JOIN)
-  @ToString.Exclude
-  @JsonIgnore
-  private List<CourseStaff> roles;
 }


### PR DESCRIPTION
In this PR, I remove the useless joins on User towards RosterStudent and CourseStaff. They are currently unused and only stress the db on /api/currentUser.

Deployed to https://frontiers-qa8.dokku-00.cs.ucsb.edu/
