### PR TITLE
Upload Teams by CSV now triggers the Push Teams To Github Job

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/TeamsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/TeamsController.java
@@ -7,10 +7,13 @@ import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.entities.Team;
 import edu.ucsb.cs156.frontiers.entities.TeamMember;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.jobs.PushTeamsToGithubJob;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import edu.ucsb.cs156.frontiers.repositories.TeamMemberRepository;
 import edu.ucsb.cs156.frontiers.repositories.TeamRepository;
+import edu.ucsb.cs156.frontiers.services.GithubTeamService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,6 +45,10 @@ public class TeamsController extends ApiController {
   @Autowired private CourseRepository courseRepository;
 
   @Autowired private RosterStudentRepository rosterStudentRepository;
+
+  @Autowired private JobService jobService;
+
+  @Autowired private GithubTeamService githubTeamService;
 
   public record TeamMemberResult(
       TeamMember teamMember, TeamMemberStatus status, String rejectedEmail) {
@@ -156,6 +163,8 @@ public class TeamsController extends ApiController {
               counts[TeamMemberStatus.CREATED.ordinal()],
               counts[TeamMemberStatus.EXISTS.ordinal()],
               failed);
+
+      launchPushTeamsToGithubJob(courseId);
 
       if (!failed.isEmpty()) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
@@ -397,5 +406,17 @@ public class TeamsController extends ApiController {
     } else {
       return new TeamMemberResult(row[1]);
     }
+  }
+
+  private void launchPushTeamsToGithubJob(Long courseId) {
+    PushTeamsToGithubJob pushTeamsToGithubJob =
+        PushTeamsToGithubJob.builder()
+            .courseId(courseId)
+            .courseRepository(courseRepository)
+            .teamRepository(teamRepository)
+            .teamMemberRepository(teamMemberRepository)
+            .githubTeamService(githubTeamService)
+            .build();
+    jobService.runAsJob(pushTeamsToGithubJob);
   }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/TeamsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/TeamsControllerTests.java
@@ -15,6 +15,7 @@ import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.entities.Team;
 import edu.ucsb.cs156.frontiers.entities.TeamMember;
+import edu.ucsb.cs156.frontiers.jobs.PushTeamsToGithubJob;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import edu.ucsb.cs156.frontiers.repositories.TeamMemberRepository;
@@ -820,6 +821,7 @@ public class TeamsControllerTests extends ControllerTestCase {
     verify(teamRepository).save(eq(team2Created));
     verify(teamMemberRepository, atLeastOnce()).save(eq(teamMemberCreated2));
     verify(teamMemberRepository, never()).save(eq(teamMemberFor3));
+    verify(jobService, times(1)).runAsJob(any(PushTeamsToGithubJob.class));
 
     TeamsController.TeamCreationResponse expectedResponse =
         new TeamsController.TeamCreationResponse(
@@ -888,6 +890,7 @@ public class TeamsControllerTests extends ControllerTestCase {
     verify(teamRepository).save(eq(team2Created));
     verify(teamMemberRepository, atLeastOnce()).save(eq(teamMemberCreated2));
     verify(teamMemberRepository, never()).save(eq(teamMemberFor3));
+    verify(jobService, times(1)).runAsJob(any(PushTeamsToGithubJob.class));
 
     TeamsController.TeamCreationResponse expectedResponse =
         new TeamsController.TeamCreationResponse(
@@ -920,6 +923,7 @@ public class TeamsControllerTests extends ControllerTestCase {
 
     // assert
     verify(courseRepository, times(1)).findById(999L);
+    verify(jobService, never()).runAsJob(any(PushTeamsToGithubJob.class));
 
     String responseString = response.getResponse().getContentAsString();
     Map<String, String> expectedMap =
@@ -956,6 +960,7 @@ public class TeamsControllerTests extends ControllerTestCase {
 
     // assert
     verify(courseRepository, times(1)).findById(1L);
+    verify(jobService, never()).runAsJob(any(PushTeamsToGithubJob.class));
     assertEquals("Unknown Roster Source Type", response.getResponse().getErrorMessage());
   }
 
@@ -985,6 +990,7 @@ public class TeamsControllerTests extends ControllerTestCase {
 
     // assert
     verify(courseRepository, times(1)).findById(1L);
+    verify(jobService, never()).runAsJob(any(PushTeamsToGithubJob.class));
     assertEquals("Unknown Roster Source Type", response.getResponse().getErrorMessage());
   }
 }


### PR DESCRIPTION
Merge after #563 and #569

In this PR we add functionality to automatically run the push teams to github job once the upload teams by csv endpoint is finished running. This prevents the need to keep the job button on the teams tab, and also continues with our goal of making all team updates automatically sync up with Github.

## Testing Plan
1. Login to dokku
2. Go to the test-derek course
3. Go to the teams tab, then upload a CSV file in the correct format for uploading teams
4. Check that the push teams to github job started after a successful CSV file upload

Deployed to: https://frontiers-qa2.dokku-00.cs.ucsb.edu/

Closes #570
