### PR TITLE
dp - Removed all instances of Stryker disables for cache query key in useBackend and useBackendMutation.

### DIFF
--- a/frontend/src/main/components/CourseStaff/CourseStaffTable.jsx
+++ b/frontend/src/main/components/CourseStaff/CourseStaffTable.jsx
@@ -63,14 +63,11 @@ export default function CourseStaffTable({
     hideDeleteModal();
   };
 
-  // Stryker disable all : hard to test for query caching
   const deleteMutation = useBackendMutation(
     cellToAxiosParamsDelete,
     { onSuccess: onDeleteSuccess },
-    // Stryker disable next-line all
     [`/api/coursestaff/course?courseId=${courseId}`],
   );
-  // Stryker restore all
 
   // Stryker disable next-line all
   const deleteCallback = async (cell) => {
@@ -88,7 +85,6 @@ export default function CourseStaffTable({
   const editMutation = useBackendMutation(
     cellToAxiosParamsEdit,
     { onSuccess: onEditSuccess },
-    // Stryker disable next-line all
     [`/api/coursestaff/course?courseId=${courseId}`],
   );
 

--- a/frontend/src/main/components/Courses/StudentCoursesTable.jsx
+++ b/frontend/src/main/components/Courses/StudentCoursesTable.jsx
@@ -5,7 +5,6 @@ import React from "react";
 
 export function StudentCoursesTable({ testid }) {
   const { data: courses } = useBackend(
-    // Stryker disable next-line all : don't test internal caching of React Query
     ["/api/courses/list"],
     // Stryker disable next-line StringLiteral : The default value for an empty ("") method is GET. Therefore, there is no way to kill a mutation that transforms "GET" to ""
     { method: "GET", url: "/api/courses/list" },

--- a/frontend/src/main/components/Settings/CanvasApiForm.jsx
+++ b/frontend/src/main/components/Settings/CanvasApiForm.jsx
@@ -17,7 +17,6 @@ function CanvasApiForm({
   } = useForm();
 
   const { data: canvasInfo } = useBackend(
-    // Stryker disable next-line all : don't test internal caching of React Query
     [`/api/courses/getCanvasInfo?courseId=${courseId}`],
     // Stryker disable next-line StringLiteral : The default value for an empty ("") method is GET. Therefore, there is no way to kill a mutation that transforms "GET" to ""
     { method: "GET", url: `/api/courses/getCanvasInfo?courseId=${courseId}` },

--- a/frontend/src/main/components/TabComponent/SettingsTabComponent.jsx
+++ b/frontend/src/main/components/TabComponent/SettingsTabComponent.jsx
@@ -23,7 +23,6 @@ export default function SettingsTabComponent({ courseId, testIdPrefix }) {
     {
       onSuccess: onSuccessCanvasCredentialsAdded,
     },
-    // Stryker disable next-line all : hard to set up test for caching
     [`/api/courses/getCanvasInfo?courseId=${courseId}`],
   );
 

--- a/frontend/src/main/pages/Admin/AdminUsersPage.jsx
+++ b/frontend/src/main/pages/Admin/AdminUsersPage.jsx
@@ -11,7 +11,6 @@ const AdminUsersPage = () => {
     error: _error,
     status: _status,
   } = useBackend(
-    // Stryker disable next-line all : don't test internal caching of React Query
     [`/api/admin/users/${currentPage - 1}`],
     {
       method: "GET",

--- a/frontend/src/main/pages/Admin/AdminsCreatePage.jsx
+++ b/frontend/src/main/pages/Admin/AdminsCreatePage.jsx
@@ -20,7 +20,6 @@ export default function AdminsCreatePage({ storybook = false }) {
   const mutation = useBackendMutation(
     objectToAxiosParams,
     { onSuccess },
-    // Stryker disable next-line all : hard to set up test for caching
     ["/api/admin/all"], // mutation makes this key stale so that pages relying on it reload
   );
 

--- a/frontend/src/main/pages/Admin/AdminsIndexPage.jsx
+++ b/frontend/src/main/pages/Admin/AdminsIndexPage.jsx
@@ -11,7 +11,6 @@ export default function AdminsIndexPage() {
     error: _error,
     status: _status,
   } = useBackend(
-    // Stryker disable next-line all : don't test internal caching of React Query
     ["/api/admin/all"],
     { method: "GET", url: "/api/admin/all" },
     // Stryker disable next-line all : don't test default value of empty list

--- a/frontend/src/main/pages/Admin/CoursesIndexPage.jsx
+++ b/frontend/src/main/pages/Admin/CoursesIndexPage.jsx
@@ -39,12 +39,9 @@ export default function CoursesIndexPage() {
     setViewModal(false);
   };
 
-  const mutation = useBackendMutation(
-    objectToAxiosParams,
-    { onSuccess },
-    // Stryker disable next-line all : hard to set up test for caching
-    ["/api/courses/allForAdmins"],
-  );
+  const mutation = useBackendMutation(objectToAxiosParams, { onSuccess }, [
+    "/api/courses/allForAdmins",
+  ]);
 
   const onSubmit = async (data) => {
     mutation.mutate(data);

--- a/frontend/src/main/pages/Admin/InstructorsCreatePage.jsx
+++ b/frontend/src/main/pages/Admin/InstructorsCreatePage.jsx
@@ -22,7 +22,6 @@ export default function InstructorsCreatePage({ storybook = false }) {
   const mutation = useBackendMutation(
     objectToAxiosParams,
     { onSuccess },
-    // Stryker disable next-line all : hard to set up test for caching
     ["/api/admin/instructors/all"], // mutation makes this key stale so that pages relying on it reload
   );
 

--- a/frontend/src/main/pages/Admin/InstructorsIndexPage.jsx
+++ b/frontend/src/main/pages/Admin/InstructorsIndexPage.jsx
@@ -11,7 +11,6 @@ export default function InstructorsIndexPage() {
     error: _error,
     status: _status,
   } = useBackend(
-    // Stryker disable next-line all : don't test internal caching of React Query
     ["/api/admin/instructors/get"],
     { method: "GET", url: "/api/admin/instructors/get" },
     // Stryker disable next-line all : don't test default value of empty list

--- a/frontend/src/main/pages/ArtifactSelectionPage.jsx
+++ b/frontend/src/main/pages/ArtifactSelectionPage.jsx
@@ -11,7 +11,6 @@ export default function ArtifactSelectionPage() {
     error: _error,
     status: _status,
   } = useBackend(
-    // Stryker disable next-line all : don't test internal caching of React Query
     ["/api/collections/list"],
     // Stryker disable next-line StringLiteral : The default value for an empty ("") method is GET. Therefore, there is no way to kill a mutation that transforms "GET" to ""
     { method: "GET", url: "/api/collections/list" },

--- a/frontend/src/main/pages/HomePageLoggedIn.jsx
+++ b/frontend/src/main/pages/HomePageLoggedIn.jsx
@@ -17,7 +17,6 @@ export default function HomePageLoggedIn() {
     error: _staffError,
     status: _staffStatus,
   } = useBackend(
-    // Stryker disable next-line all : don't test internal caching of React Query
     ["/api/courses/staffCourses"],
     // Stryker disable next-line StringLiteral : The default value for an empty ("") method is GET.
     { method: "GET", url: "/api/courses/staffCourses" },
@@ -29,7 +28,6 @@ export default function HomePageLoggedIn() {
     error: _instructorError,
     status: _instructorStatus,
   } = useBackend(
-    // Stryker disable next-line all : don't test internal caching of React Query
     ["/api/courses/allForInstructors"],
     // Stryker disable next-line StringLiteral : The default value for an empty ("") method is GET. Therefore, there is no way to kill a mutation that transforms "GET" to ""
     { method: "GET", url: "/api/courses/allForInstructors" },
@@ -91,12 +89,9 @@ export default function HomePageLoggedIn() {
     setViewModal(false);
   };
 
-  const mutation = useBackendMutation(
-    objectToAxiosParams,
-    { onSuccess },
-    // Stryker disable next-line all : don't test internal caching of React Query
-    ["/api/courses/allForInstructors"],
-  );
+  const mutation = useBackendMutation(objectToAxiosParams, { onSuccess }, [
+    "/api/courses/allForInstructors",
+  ]);
 
   const onSubmit = async (data) => {
     mutation.mutate(data);

--- a/frontend/src/tests/components/CourseStaff/CourseStaffTable.test.jsx
+++ b/frontend/src/tests/components/CourseStaff/CourseStaffTable.test.jsx
@@ -6,10 +6,14 @@ import { MemoryRouter } from "react-router";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { vi } from "vitest";
+import { afterEach, vi } from "vitest";
+import * as useBackendModule from "main/utils/useBackend";
 
 const queryClient = new QueryClient();
 const mockToast = vi.fn();
+
+const useBackendMutationSpy = vi.spyOn(useBackendModule, "useBackendMutation");
+
 vi.mock("react-toastify", async (importOriginal) => {
   return {
     ...(await importOriginal()),
@@ -42,6 +46,10 @@ describe("CourseStaffTable tests", () => {
     axiosMock.resetHistory();
     queryClient.clear();
     mockToast.mockClear();
+  });
+
+  afterEach(() => {
+    useBackendMutationSpy.mockClear();
   });
 
   test("renders empty table correctly", () => {
@@ -484,5 +492,35 @@ describe("CourseStaffTable tests", () => {
 
     const tooltip = await screen.findByRole("tooltip");
     expect(tooltip).toHaveAttribute("id", "member-tooltip");
+  });
+  test("useBackendMutation is called with correct cache query key", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+    const courseId = 7;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseStaffTable
+            staff={courseStaffFixtures.staffWithEachStatus}
+            currentUser={currentUser}
+            courseId={courseId}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(useBackendMutationSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Function),
+      { onSuccess: expect.any(Function) },
+      [`/api/coursestaff/course?courseId=${courseId}`],
+    );
+
+    expect(useBackendMutationSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Function),
+      { onSuccess: expect.any(Function) },
+      [`/api/coursestaff/course?courseId=${courseId}`],
+    );
   });
 });

--- a/frontend/src/tests/components/Courses/StudentCoursesTable.test.jsx
+++ b/frontend/src/tests/components/Courses/StudentCoursesTable.test.jsx
@@ -1,16 +1,21 @@
 import AxiosMockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { vi } from "vitest";
+import { afterEach, vi } from "vitest";
 import coursesFixtures from "fixtures/coursesFixtures";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { StudentCoursesTable } from "main/components/Courses/StudentCoursesTable";
 import React from "react";
+import * as useBackendModule from "main/utils/useBackend";
 
 const axiosMock = new AxiosMockAdapter(axios);
 const queryClient = new QueryClient();
 const mockToast = vi.fn();
+
+const useBackendSpy = vi.spyOn(useBackendModule, "useBackend");
+const useBackendMutationSpy = vi.spyOn(useBackendModule, "useBackendMutation");
+
 vi.mock("react-toastify", async (importOriginal) => {
   return {
     ...(await importOriginal()),
@@ -24,6 +29,11 @@ describe("StudentCoursesTable tests", () => {
     axiosMock.resetHistory();
     queryClient.clear();
     mockToast.mockReset();
+  });
+
+  afterEach(() => {
+    useBackendSpy.mockClear();
+    useBackendMutationSpy.mockClear();
   });
 
   test("renders correctly with courses", async () => {
@@ -212,5 +222,30 @@ describe("StudentCoursesTable tests", () => {
     expect(
       screen.getByTestId("CoursesTable-cell-row-6-col-studentStatus-button"),
     ).toHaveTextContent("Join Course");
+  });
+  test("useBackend and useBackendMutation are called with correct cache query key", async () => {
+    axiosMock
+      .onGet("/api/courses/list")
+      .reply(200, coursesFixtures.oneCourseWithEachStatus);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <StudentCoursesTable testid={"CoursesTable"} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(useBackendSpy).toHaveBeenCalledWith(
+      ["/api/courses/list"],
+      { method: "GET", url: "/api/courses/list" },
+      [],
+    );
+
+    expect(useBackendMutationSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      { onSuccess: expect.any(Function), onError: expect.any(Function) },
+      ["/api/courses/list"],
+    );
   });
 });

--- a/frontend/src/tests/components/Settings/CanvasApiForm.test.jsx
+++ b/frontend/src/tests/components/Settings/CanvasApiForm.test.jsx
@@ -2,12 +2,16 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { test, vi } from "vitest";
+import { afterEach, test, vi } from "vitest";
 import CanvasApiForm from "main/components/Settings/CanvasApiForm";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import * as useBackendModule from "main/utils/useBackend";
 
 const mockedNavigate = vi.fn();
+
+const useBackendSpy = vi.spyOn(useBackendModule, "useBackend");
+
 vi.mock("react-router", async (importOriginal) => ({
   ...(await importOriginal()),
   useNavigate: () => mockedNavigate,
@@ -21,6 +25,9 @@ describe("CanvasApiForm tests", () => {
     axiosMock.reset();
     axiosMock.resetHistory();
     queryClient.clear();
+  });
+  afterEach(() => {
+    useBackendSpy.mockClear();
   });
 
   const expectedHeaders = ["Canvas Course ID", "Canvas API Token"];
@@ -274,5 +281,26 @@ describe("CanvasApiForm tests", () => {
     });
 
     expect(mockSubmitAction).toHaveBeenCalled();
+  });
+  test("useBackend is called with correct cache query key", async () => {
+    axiosMock.onGet(/\/api\/courses\/getCanvasInfo/).reply(200, {
+      courseId: "1",
+      canvasApiToken: "***************d1U",
+      canvasCourseId: "1234567",
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CanvasApiForm courseId={1} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(useBackendSpy).toHaveBeenCalledWith(
+      [`/api/courses/getCanvasInfo?courseId=1`],
+      { method: "GET", url: `/api/courses/getCanvasInfo?courseId=1` },
+      [],
+    );
   });
 });

--- a/frontend/src/tests/components/TabComponent/SettingsTabComponent.test.jsx
+++ b/frontend/src/tests/components/TabComponent/SettingsTabComponent.test.jsx
@@ -5,12 +5,13 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { expect, vi } from "vitest";
 import coursesFixtures from "fixtures/coursesFixtures";
+import * as useBackendModule from "main/utils/useBackend";
 
 const axiosMock = new AxiosMockAdapter(axios);
 const mockToast = vi.fn();
-beforeEach(() => {
-  axiosMock.resetHistory();
-});
+
+const useBackendMutationSpy = vi.spyOn(useBackendModule, "useBackendMutation");
+
 vi.mock("react-toastify", async (importOriginal) => {
   return {
     ...(await importOriginal()),
@@ -18,51 +19,78 @@ vi.mock("react-toastify", async (importOriginal) => {
   };
 });
 
-test("Settings tab component renders correctly", async () => {
-  axiosMock.onPut("/api/courses/updateCourseCanvasToken").reply(200);
-  const client = new QueryClient();
-  render(
-    <QueryClientProvider client={client}>
-      <SettingsTabComponent
-        courseId={coursesFixtures.severalCourses[0].id}
-        testIdPrefix="CanvasApiForm"
-      />
-    </QueryClientProvider>,
-  );
-
-  await screen.findByTestId("CanvasApiForm-submit");
-
-  expect(screen.getByText("Connect Canvas")).toBeInTheDocument();
-  expect(screen.getByLabelText("Canvas Course ID")).toBeInTheDocument();
-  expect(screen.getByLabelText("Canvas API Token")).toBeInTheDocument();
-  expect(screen.getByTestId("CanvasApiForm-submit")).toBeInTheDocument();
-  expect(screen.getByTestId("CanvasApiForm-canvasForm")).toBeInTheDocument();
-});
-
-test("Call PUT for Canvas credentials properly", async () => {
-  axiosMock.onPut("/api/courses/updateCourseCanvasToken").reply(200);
-  const client = new QueryClient();
-  render(
-    <QueryClientProvider client={client}>
-      <SettingsTabComponent courseId={coursesFixtures.severalCourses[0].id} />
-    </QueryClientProvider>,
-  );
-
-  await screen.findByTestId("CanvasApiForm-submit");
-
-  fireEvent.change(screen.getByLabelText("Canvas API Token"), {
-    target: { value: "test-token" },
+describe("SettingsTabComponent tests", () => {
+  beforeEach(() => {
+    axiosMock.resetHistory();
   });
-  fireEvent.change(screen.getByLabelText("Canvas Course ID"), {
-    target: { value: "test-id" },
+
+  afterEach(() => {
+    useBackendMutationSpy.mockClear();
   });
-  fireEvent.click(screen.getByTestId("CanvasApiForm-submit"));
-  await waitFor(() => expect(mockToast).toHaveBeenCalled());
-  expect(mockToast).toBeCalledWith("Canvas credentials successfully added.");
-  expect(axiosMock.history.put.length).toEqual(1);
-  expect(axiosMock.history.put[0].params).toEqual({
-    courseId: coursesFixtures.severalCourses[0].id,
-    canvasApiToken: "test-token",
-    canvasCourseId: "test-id",
+
+  test("Settings tab component renders correctly", async () => {
+    axiosMock.onPut("/api/courses/updateCourseCanvasToken").reply(200);
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <SettingsTabComponent
+          courseId={coursesFixtures.severalCourses[0].id}
+          testIdPrefix="CanvasApiForm"
+        />
+      </QueryClientProvider>,
+    );
+
+    await screen.findByTestId("CanvasApiForm-submit");
+
+    expect(screen.getByText("Connect Canvas")).toBeInTheDocument();
+    expect(screen.getByLabelText("Canvas Course ID")).toBeInTheDocument();
+    expect(screen.getByLabelText("Canvas API Token")).toBeInTheDocument();
+    expect(screen.getByTestId("CanvasApiForm-submit")).toBeInTheDocument();
+    expect(screen.getByTestId("CanvasApiForm-canvasForm")).toBeInTheDocument();
+  });
+
+  test("Call PUT for Canvas credentials properly", async () => {
+    axiosMock.onPut("/api/courses/updateCourseCanvasToken").reply(200);
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <SettingsTabComponent courseId={coursesFixtures.severalCourses[0].id} />
+      </QueryClientProvider>,
+    );
+
+    await screen.findByTestId("CanvasApiForm-submit");
+
+    fireEvent.change(screen.getByLabelText("Canvas API Token"), {
+      target: { value: "test-token" },
+    });
+    fireEvent.change(screen.getByLabelText("Canvas Course ID"), {
+      target: { value: "test-id" },
+    });
+    fireEvent.click(screen.getByTestId("CanvasApiForm-submit"));
+    await waitFor(() => expect(mockToast).toHaveBeenCalled());
+    expect(mockToast).toBeCalledWith("Canvas credentials successfully added.");
+    expect(axiosMock.history.put.length).toEqual(1);
+    expect(axiosMock.history.put[0].params).toEqual({
+      courseId: coursesFixtures.severalCourses[0].id,
+      canvasApiToken: "test-token",
+      canvasCourseId: "test-id",
+    });
+  });
+  test("useBackendMutation is called with correct cache query key", async () => {
+    const client = new QueryClient();
+
+    render(
+      <QueryClientProvider client={client}>
+        <SettingsTabComponent courseId={coursesFixtures.severalCourses[0].id} />
+      </QueryClientProvider>,
+    );
+
+    expect(useBackendMutationSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      { onSuccess: expect.any(Function) },
+      [
+        `/api/courses/getCanvasInfo?courseId=${coursesFixtures.severalCourses[0].id}`,
+      ],
+    );
   });
 });

--- a/frontend/src/tests/pages/Admin/AdminUsersPage.test.jsx
+++ b/frontend/src/tests/pages/Admin/AdminUsersPage.test.jsx
@@ -6,9 +6,12 @@ import usersFixtures from "fixtures/usersFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import mockConsole from "tests/testutils/mockConsole";
+import * as useBackendModule from "main/utils/useBackend";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const useBackendSpy = vi.spyOn(useBackendModule, "useBackend");
 
 describe("AdminUsersPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
@@ -24,6 +27,10 @@ describe("AdminUsersPage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
+  });
+
+  afterEach(() => {
+    useBackendSpy.mockClear();
   });
 
   test("renders without crashing on three users", async () => {
@@ -86,5 +93,25 @@ describe("AdminUsersPage tests", () => {
 
     expect(screen.getByTestId("OurPagination-1")).toBeInTheDocument();
     expect(screen.queryByTestId("OurPagination-2")).not.toBeInTheDocument();
+  });
+  test("useBackend is called with correct cache query key", async () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminUsersPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(useBackendSpy).toHaveBeenCalledWith(
+      [`/api/admin/users/0`],
+      {
+        method: "GET",
+        url: "/api/admin/users",
+        params: { page: 0, size: 50, sort: "id" },
+      },
+      { content: [], page: { totalPages: 1 } },
+    );
   });
 });

--- a/frontend/src/tests/pages/Admin/AdminsCreatePage.test.jsx
+++ b/frontend/src/tests/pages/Admin/AdminsCreatePage.test.jsx
@@ -5,7 +5,8 @@ import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import { vi } from "vitest";
+import { afterEach, vi } from "vitest";
+import * as useBackendModule from "main/utils/useBackend";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
@@ -29,6 +30,8 @@ vi.mock("react-router", async (importOriginal) => {
   };
 });
 
+const useBackendMutationSpy = vi.spyOn(useBackendModule, "useBackendMutation");
+
 describe("AdminsCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
@@ -42,6 +45,9 @@ describe("AdminsCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
+  });
+  afterEach(() => {
+    useBackendMutationSpy.mockClear();
   });
 
   const queryClient = new QueryClient();
@@ -104,5 +110,20 @@ describe("AdminsCreatePage tests", () => {
     expect(mockNavigate).toHaveBeenCalledWith({
       to: "/admin/admins",
     });
+  });
+  test("useBackendMutation is called with correct cache query key", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminsCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(useBackendMutationSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      { onSuccess: expect.any(Function) },
+      [`/api/admin/all`],
+    );
   });
 });

--- a/frontend/src/tests/pages/Admin/AdminsIndexPage.test.jsx
+++ b/frontend/src/tests/pages/Admin/AdminsIndexPage.test.jsx
@@ -10,6 +10,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { vi } from "vitest";
+import * as useBackendModule from "main/utils/useBackend";
 
 const mockToast = vi.fn();
 vi.mock("react-toastify", async (importOriginal) => {
@@ -20,6 +21,8 @@ vi.mock("react-toastify", async (importOriginal) => {
 });
 
 const axiosMock = new AxiosMockAdapter(axios);
+
+const useBackendSpy = vi.spyOn(useBackendModule, "useBackend");
 
 describe("AdminsIndexPage tests", () => {
   const getEndpoint = "/api/admin/all";
@@ -39,6 +42,10 @@ describe("AdminsIndexPage tests", () => {
   };
 
   const queryClient = new QueryClient();
+
+  afterEach(() => {
+    useBackendSpy.mockClear();
+  });
 
   test("Renders with New Admin Button", async () => {
     setupAdminUser();
@@ -170,5 +177,20 @@ describe("AdminsIndexPage tests", () => {
     expect(axiosMock.history.delete[0].params).toEqual({
       email: "instructor1@example.com",
     });
+  });
+  test("useBackend is called with correct cache query key", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(useBackendSpy).toHaveBeenCalledWith(
+      [`/api/admin/all`],
+      { method: "GET", url: "/api/admin/all" },
+      [],
+    );
   });
 });

--- a/frontend/src/tests/pages/Admin/InstructorsCreatePage.test.jsx
+++ b/frontend/src/tests/pages/Admin/InstructorsCreatePage.test.jsx
@@ -8,7 +8,8 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { vi } from "vitest";
+import { afterEach, vi } from "vitest";
+import * as useBackendModule from "main/utils/useBackend";
 
 const mockToast = vi.fn();
 vi.mock("react-toastify", async (importOriginal) => {
@@ -24,6 +25,8 @@ vi.mock("react-router", async (importOriginal) => ({
   useNavigate: () => mockedNavigate,
 }));
 
+const useBackendMutationSpy = vi.spyOn(useBackendModule, "useBackendMutation");
+
 describe("InstructorsCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
@@ -37,6 +40,10 @@ describe("InstructorsCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
+  });
+
+  afterEach(() => {
+    useBackendMutationSpy.mockClear();
   });
 
   const queryClient = new QueryClient();
@@ -146,5 +153,20 @@ describe("InstructorsCreatePage tests", () => {
     await waitFor(() => {
       expect(mockedNavigate).not.toHaveBeenCalledWith("/admin/instructors");
     });
+  });
+  test("useBackendMutation is called with correct cache query key", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <InstructorsCreatePage storybook={true} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(useBackendMutationSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      { onSuccess: expect.any(Function) },
+      [`/api/admin/instructors/all`],
+    );
   });
 });

--- a/frontend/src/tests/pages/Admin/InstructorsIndexPage.test.jsx
+++ b/frontend/src/tests/pages/Admin/InstructorsIndexPage.test.jsx
@@ -10,6 +10,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { vi } from "vitest";
+import * as useBackendModule from "main/utils/useBackend";
 
 const mockToast = vi.fn();
 vi.mock("react-toastify", async (importOriginal) => {
@@ -20,6 +21,8 @@ vi.mock("react-toastify", async (importOriginal) => {
 });
 
 const axiosMock = new AxiosMockAdapter(axios);
+
+const useBackendSpy = vi.spyOn(useBackendModule, "useBackend");
 
 describe("InstructorsIndexPage tests", () => {
   const testId = "InstructorsIndexPage";
@@ -36,6 +39,10 @@ describe("InstructorsIndexPage tests", () => {
   };
 
   const queryClient = new QueryClient();
+
+  afterEach(() => {
+    useBackendSpy.mockClear();
+  });
 
   test("Renders with New Instructor Button", async () => {
     setupAdminUser();
@@ -163,5 +170,20 @@ describe("InstructorsIndexPage tests", () => {
     expect(axiosMock.history.delete[0].params).toEqual({
       email: "instructor1@example.com",
     });
+  });
+  test("useBackend is called with correct cache query key", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <InstructorsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(useBackendSpy).toHaveBeenCalledWith(
+      [`/api/admin/instructors/get`],
+      { method: "GET", url: `/api/admin/instructors/get` },
+      [],
+    );
   });
 });

--- a/frontend/src/tests/pages/ArtifactSelectionPage.test.jsx
+++ b/frontend/src/tests/pages/ArtifactSelectionPage.test.jsx
@@ -7,9 +7,12 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import collectionNames from "fixtures/collectionNames";
 import { vi } from "vitest";
+import * as useBackendModule from "main/utils/useBackend";
 
 const axiosMock = new AxiosMockAdapter(axios);
 const queryClient = new QueryClient();
+
+const useBackendSpy = vi.spyOn(useBackendModule, "useBackend");
 
 const mockedNavigate = vi.fn();
 vi.mock("react-router", async (importOriginal) => ({
@@ -22,6 +25,7 @@ describe("ArtifactSelectionPage tests", () => {
     axiosMock.reset();
     axiosMock.resetHistory();
     queryClient.clear();
+    useBackendSpy.mockClear();
   });
 
   test("Tab assertions", () => {
@@ -95,5 +99,24 @@ describe("ArtifactSelectionPage tests", () => {
         ),
       ).toBe(true);
     });
+  });
+  test("useBackend is called with correct cache query key", async () => {
+    axiosMock
+      .onGet("/api/collections/list")
+      .reply(200, collectionNames.collectionNamesForOneCourse);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArtifactSelectionPage />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(useBackendSpy).toHaveBeenCalledWith(
+      [`/api/collections/list`],
+      { method: "GET", url: "/api/collections/list" },
+      [],
+    );
   });
 });

--- a/frontend/src/tests/pages/HomePageLoggedIn.test.jsx
+++ b/frontend/src/tests/pages/HomePageLoggedIn.test.jsx
@@ -10,9 +10,13 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { React } from "react";
 import { vi } from "vitest";
+import * as useBackendModule from "main/utils/useBackend";
 
 const axiosMock = new AxiosMockAdapter(axios);
 const queryClient = new QueryClient();
+
+const useBackendSpy = vi.spyOn(useBackendModule, "useBackend");
+const useBackendMutationSpy = vi.spyOn(useBackendModule, "useBackendMutation");
 
 const mockToast = vi.fn();
 vi.mock("react-toastify", async (importOriginal) => {
@@ -28,6 +32,10 @@ describe("HomePageLoggedIn tests", () => {
     axiosMock.resetHistory();
     queryClient.clear();
     mockToast.mockReset();
+  });
+  afterEach(() => {
+    useBackendSpy.mockClear();
+    useBackendMutationSpy.mockClear();
   });
 
   const setupUserOnly = () => {
@@ -428,5 +436,45 @@ describe("HomePageLoggedIn tests", () => {
     );
 
     await waitFor(() => expect(mockToast).toHaveBeenCalled());
+  });
+  test("useBackend and useBackendMutation are called with correct cache query key", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HomePageLoggedIn />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(useBackendSpy).toHaveBeenNthCalledWith(
+      1,
+      ["/api/courses/staffCourses"],
+      { method: "GET", url: "/api/courses/staffCourses" },
+      [],
+    );
+
+    expect(useBackendSpy).toHaveBeenNthCalledWith(
+      2,
+      ["/api/courses/allForInstructors"],
+      { method: "GET", url: "/api/courses/allForInstructors" },
+      [],
+      false,
+      {
+        enabled: false,
+      },
+    );
+
+    expect(useBackendMutationSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Function),
+      { onSuccess: expect.any(Function), onError: expect.any(Function) },
+      ["/api/courses/staffCourses"],
+    );
+    expect(useBackendMutationSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Function),
+      { onSuccess: expect.any(Function) },
+      ["/api/courses/allForInstructors"],
+    );
   });
 });

--- a/frontend/src/tests/pages/Instructors/CoursesIndexPage.test.jsx
+++ b/frontend/src/tests/pages/Instructors/CoursesIndexPage.test.jsx
@@ -10,7 +10,8 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { vi } from "vitest";
+import { afterEach, vi } from "vitest";
+import * as useBackendModule from "main/utils/useBackend";
 
 const mockToast = vi.fn();
 
@@ -22,6 +23,9 @@ vi.mock("react-toastify", async (importOriginal) => {
   };
 });
 
+const useBackendSpy = vi.spyOn(useBackendModule, "useBackend");
+const useBackendMutationSpy = vi.spyOn(useBackendModule, "useBackendMutation");
+
 describe("CoursesIndexPage tests", () => {
   const testId = "InstructorCoursesTable";
 
@@ -30,6 +34,11 @@ describe("CoursesIndexPage tests", () => {
     axiosMock.reset();
     axiosMock.resetHistory();
     queryClient.clear();
+  });
+
+  afterEach(() => {
+    useBackendSpy.mockClear();
+    useBackendMutationSpy.mockClear();
   });
 
   const setupAdminUser = () => {
@@ -241,5 +250,26 @@ describe("CoursesIndexPage tests", () => {
       "InstructorCoursesTable-header-delete-sort-header",
     );
     expect(deleteHeader).not.toBeInTheDocument();
+  });
+  test("useBackend and useBackendMutation are called with correct cache query key", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CoursesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(useBackendSpy).toHaveBeenCalledWith(
+      [`/api/courses/allForAdmins`],
+      { method: "GET", url: `/api/courses/allForAdmins` },
+      [],
+    );
+
+    expect(useBackendMutationSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      { onSuccess: expect.any(Function) },
+      [`/api/courses/allForAdmins`],
+    );
   });
 });


### PR DESCRIPTION
This PR is not associated with any issue in particular. 

This PR removes all instances (as far as I found) of Stryker disables specifically for the internal cache query key when using useBackend and useBackendMutation by adding new tests for applicable files based on [this](https://ucsb-cs156.github.io/topics/stryker/stryker_useBackend_stryker_exceptions.html#some-background) article from the CS156 website. 