### PR TITLE
Allowing Use of Differing Canvas Implementations

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/enums/School.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/enums/School.java
@@ -12,15 +12,15 @@ public enum School {
   CHICO_STATE(
       "Chico State",
       List.of("Chico State University", "Chico State", "CSUCS"),
-      "https://canvas.csuchico.edu/"),
+      "https://canvas.csuchico.edu/api/graphql"),
   OREGON_STATE(
       "Oregon State University",
       List.of("Oregon State University", "Oregon State", "OSU"),
-      "https://canvas.oregonstate.edu/"),
+      "https://canvas.oregonstate.edu/api/graphql"),
   UCSB(
       "UCSB",
       List.of("UC Santa Barbara", "University of California, Santa Barbara", "SB"),
-      "https://ucsb.instructure.com/");
+      "https://ucsb.instructure.com/api/graphql");
 
   private School(String displayName, List<String> alternateNames, String canvasImplementation) {
     this.displayName = displayName;

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/CanvasService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/CanvasService.java
@@ -23,13 +23,13 @@ import org.springframework.web.client.RestClient;
  * <p>Note that the Canvas API uses a GraphQL endpoint, which allows for more flexible queries
  * compared to traditional REST APIs.
  *
- * <p>For more information on the Canvas API, visit the official documentation at
- * https://canvas.instructure.com/doc/api/.
+ * <p>For more information on the Canvas API, visit the official documentation at <a
+ * href="https://canvas.instructure.com/doc/api/">...</a>.
  *
  * <p>You can typically interact with Canvas API GraphQL endpoints interactively by appending
  * /graphiql to the URL of the Canvas instance.
  *
- * <p>For example, for UCSB Canvas, use: https://ucsb.instructure.com/graphiql
+ * <p>For example, for UCSB Canvas, use: <a href="https://ucsb.instructure.com/graphiql">...</a>
  */
 @Service
 @Validated
@@ -38,11 +38,8 @@ public class CanvasService {
   private HttpSyncGraphQlClient graphQlClient;
   private ObjectMapper mapper;
 
-  private static final String CANVAS_GRAPHQL_URL = "https://ucsb.instructure.com/api/graphql";
-
   public CanvasService(ObjectMapper mapper, RestClient.Builder builder) {
-    this.graphQlClient =
-        HttpSyncGraphQlClient.builder(builder.baseUrl(CANVAS_GRAPHQL_URL).build()).build();
+    this.graphQlClient = HttpSyncGraphQlClient.builder(builder.build()).build();
     this.mapper = mapper;
     this.mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   }
@@ -66,6 +63,7 @@ public class CanvasService {
         graphQlClient
             .mutate()
             .header("Authorization", "Bearer " + course.getCanvasApiToken())
+            .url(course.getSchool().getCanvasImplementation())
             .build();
 
     List<CanvasGroupSet> groupSets =
@@ -109,6 +107,7 @@ public class CanvasService {
         graphQlClient
             .mutate()
             .header("Authorization", "Bearer " + course.getCanvasApiToken())
+            .url(course.getSchool().getCanvasImplementation())
             .build();
 
     List<CanvasStudent> students =
@@ -165,6 +164,7 @@ public class CanvasService {
         graphQlClient
             .mutate()
             .header("Authorization", "Bearer " + course.getCanvasApiToken())
+            .url(course.getSchool().getCanvasImplementation())
             .build();
 
     List<JsonNode> groups =

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/CanvasServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/CanvasServiceTests.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.enums.School;
 import edu.ucsb.cs156.frontiers.models.CanvasGroup;
 import edu.ucsb.cs156.frontiers.models.CanvasGroupSet;
 import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
@@ -46,6 +47,7 @@ public class CanvasServiceTests {
             .courseName("CS156")
             .canvasApiToken("test-api-token")
             .canvasCourseId("12345")
+            .school(School.UCSB)
             .build();
 
     // Create GraphQL response that matches what Canvas API would return
@@ -102,6 +104,7 @@ public class CanvasServiceTests {
             .courseName("CS156")
             .canvasApiToken("test-api-token")
             .canvasCourseId("12345")
+            .school(School.UCSB)
             .build();
 
     // GraphQL response with empty edges array
@@ -142,6 +145,7 @@ public class CanvasServiceTests {
             .courseName("CS156")
             .canvasApiToken("test-api-token")
             .canvasCourseId("12345")
+            .school(School.UCSB)
             .build();
 
     // Student with null integrationId - should use sisId
@@ -185,6 +189,7 @@ public class CanvasServiceTests {
             .courseName("CS156")
             .canvasApiToken("test-api-token")
             .canvasCourseId("12345")
+            .school(School.UCSB)
             .build();
 
     // Student with integrationId - should use integrationId over sisId
@@ -228,6 +233,7 @@ public class CanvasServiceTests {
             .courseName("CS156")
             .canvasApiToken("test-api-token")
             .canvasCourseId("12345")
+            .school(School.UCSB)
             .build();
 
     String graphqlResponse =
@@ -276,6 +282,7 @@ public class CanvasServiceTests {
             .courseName("CS156")
             .canvasApiToken("test-api-token")
             .canvasCourseId("12345")
+            .school(School.UCSB)
             .build();
 
     String graphqlResponse =
@@ -312,6 +319,7 @@ public class CanvasServiceTests {
             .courseName("CS156")
             .canvasApiToken("test-api-token")
             .canvasCourseId("12345")
+            .school(School.UCSB)
             .build();
 
     String graphqlResponse =
@@ -386,6 +394,7 @@ public class CanvasServiceTests {
             .courseName("CS156")
             .canvasApiToken("test-api-token")
             .canvasCourseId("12345")
+            .school(School.UCSB)
             .build();
 
     String graphqlResponse =
@@ -425,6 +434,7 @@ public class CanvasServiceTests {
             .courseName("CS156")
             .canvasApiToken("test-api-token")
             .canvasCourseId("12345")
+            .school(School.UCSB)
             .build();
 
     String graphqlResponse =


### PR DESCRIPTION
In this PR, I allow use of alternatate Canvas LMS implementations by making use of the School enum created in #607

I make an educated guess at the other universities' GraphQL endpoints and allow the `RestClient` in `CanvasService` to use the endpoints defined in the enum.

## Test Plan
1. Have a course with a linked canvas token & course id
2. Attempt to complete a canvas-required activity (load students or teams, etc)

Deployed to https://frontiers-daniel.dokku-00.cs.ucsb.edu/

Closes #532 
