### PR TITLE
Swagger Version Bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.5.0</version>
+      <version>2.8.14</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.liquibase/liquibase-maven-plugin -->


### PR DESCRIPTION
In this PR, I bump the swagger version to `2.8.14`, which is compatible with Spring Boot `3.4.x`.

This rids us of these warnings when you open swagger:

```
2026-03-08T15:03:37.574-07:00  WARN 11466 --- [io-8080-exec-10] o.s.core.service.GenericResponseService  : Json Processing Exception occurred: additionalProperties must be either a Boolean or a Schema instance
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 3741] (through reference chain: io.swagger.v3.oas.models.responses.ApiResponses["400"]->io.swagger.v3.oas.models.responses.ApiResponse["content"]->io.swagger.v3.oas.models.media.Content["*/*"]->io.swagger.v3.oas.models.media.MediaType["schema"]->io.swagger.v3.oas.models.media.Schema["oneOf"]->java.util.ArrayList[0]->io.swagger.v3.oas.models.media.Schema["additionalProperties"])
```

## Testing Plan
Try out a couple of Swagger endpoints

Deployed to https://proj-frontiers-division7.dokku-00.cs.ucsb.edu/
