### PR TITLE
Add update_spreadsheet input to deploy workflow

### DIFF
--- a/.github/workflows/45-deploy-pr-to-dokku.yml
+++ b/.github/workflows/45-deploy-pr-to-dokku.yml
@@ -26,7 +26,8 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/ucsb-cs156/workflows/actions/workflows/45-sync-a-PR.yml/dispatches \
             -f ref='main' \
-            -f "inputs[pr_url]=$PR_URL"
+            -f "inputs[pr_url]=$PR_URL" \
+            -f "inputs[update_spreadsheet]=true"
           else
             echo "not deploy label - skipping"
           fi


### PR DESCRIPTION
In this PR, I add the optional input to the deploy-a-pr callback to allow the workflow to automatically update the spreadsheet:

https://docs.google.com/spreadsheets/d/1-IQJ0kTyenqZFeS1qeUZvD6oKls2WnlYwSts9IwwtHQ/edit?gid=0#gid=0

Sister PR to https://github.com/ucsb-cs156/workflows/pull/14; Merge the workflows PR first

# How to use this. (Steps to Test)

(1) You have a PR for proj-frontiers that you want to deploy
(2) Go to the [spreadsheet](https://docs.google.com/spreadsheets/d/1-IQJ0kTyenqZFeS1qeUZvD6oKls2WnlYwSts9IwwtHQ/edit?gid=0#gid=0) and identify an available dokku instance.
(3) Copy the URL of the dokku instance (e.g. https://frontiers-qa3.dokku-00.cs.ucsb.edu) 
(4) Paste into the PR description
(5) Add the Dokku Deploy tag
(6) The Github Action will both deploy the branch to that dokku instance, *and* update the spreadsheet automatically with the PR number and the PR url.