### PR TITLE
Add team slug field to Team entity + db migration

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/Team.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/Team.java
@@ -37,5 +37,8 @@ public class Team {
   @Column(nullable = true)
   private Integer githubTeamId;
 
+  @Column(nullable = true)
+  private String githubTeamSlug;
+
   private Integer canvasId;
 }

--- a/src/main/resources/db/migration/changes/013-add-github-team-slug.json
+++ b/src/main/resources/db/migration/changes/013-add-github-team-slug.json
@@ -1,0 +1,26 @@
+{ "databaseChangeLog": [
+  {
+    "changeSet": {
+      "id": "013-add-github-team-slug-to-team",
+      "author": "DerekKirschbaum",
+      "changes": [
+        {
+          "addColumn": {
+            "tableName": "TEAM",
+            "columns": [
+              {
+                "column": {
+                  "name": "GITHUB_TEAM_SLUG",
+                  "type": "VARCHAR(255)",
+                  "constraints": {
+                    "nullable": true
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+]}


### PR DESCRIPTION
In this PR we add the githubTeamSlug field to the Team entity, and create the necessary database migration file. This is necessary for updating our current usage of Github's REST API endpoints for team repository creation, as we currently are using deprecated endpoints. This will also enable us to replace instances in our codebase where we use the team name in place of the team slug, which could potentially lead to buggy interactions as these variables are not necessarily the same.

## Testing Plan
1. ssh into dokku from the command line.
2. Connect to postgres: `dokku postgres:connect frontiers-derek-db`
3. Check for the new github_team_slug column in the teams table: `\d team` `select id, name, github_team_id, github_team_slug from team;`

Deployed to: https://frontiers-derek.dokku-00.cs.ucsb.edu/