### PR TITLE
Improving Integration Test Start Time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -542,6 +542,7 @@
                     </condition>
                     <condition property="frontend.build.skip">
                       <and>
+                        <istrue value="${frontend.dependency.skip}" />
                         <uptodate>
                           <srcfiles dir="${project.basedir}/frontend/node_modules" includes="**/*" />
                           <srcfiles dir="${project.basedir}/frontend/src" includes="**/*" />
@@ -549,7 +550,6 @@
                           <srcfiles file="${project.basedir}/frontend/vite.config.js" />
                           <mapper type="merge" to="${project.build.outputDirectory}/public/index.html" />
                         </uptodate>
-                        <istrue value="${frontend.dependency.skip}" />
                       </and>
                     </condition>
 

--- a/pom.xml
+++ b/pom.xml
@@ -533,22 +533,33 @@
                 </goals>
                 <configuration>
                   <target>
-                    <condition property="frontend.skip">
+                    <condition property="frontend.dependency.skip">
                       <uptodate>
-                        <srcfiles dir="${project.basedir}/frontend/src" includes="**/*" />
-                        <srcfiles dir="${project.basedir}/frontend/build" includes="**/*" />
-                        <srcfiles dir="${project.basedir}/frontend/node_modules" includes="**/*" />
                         <srcfiles file="${project.basedir}/frontend/package.json" />
                         <srcfiles file="${project.basedir}/frontend/package-lock.json" />
-                        <srcfiles file="${project.basedir}/frontend/vite.config.js" />
                         <mapper type="merge" to="${project.build.outputDirectory}/public/index.html" />
                       </uptodate>
+                    </condition>
+                    <condition property="frontend.build.skip">
+                      <and>
+                        <uptodate>
+                          <srcfiles dir="${project.basedir}/frontend/node_modules" includes="**/*" />
+                          <srcfiles dir="${project.basedir}/frontend/src" includes="**/*" />
+                          <srcfiles dir="${project.basedir}/frontend/build" includes="**/*" />
+                          <srcfiles file="${project.basedir}/frontend/vite.config.js" />
+                          <mapper type="merge" to="${project.build.outputDirectory}/public/index.html" />
+                        </uptodate>
+                        <istrue value="${frontend.dependency.skip}" />
+                      </and>
                     </condition>
 
                     <condition property="build.message"
                       value="No frontend changes detected - skipping npm build"
                       else="Frontend changes detected - will rebuild">
-                      <istrue value="${frontend.skip}" />
+                      <and>
+                        <istrue value="${frontend.build.skip}" />
+                        <istrue value="${frontend.dependency.skip}" />
+                      </and>
                     </condition>
                     <echo message="${build.message}" level="info" />
                   </target>
@@ -563,7 +574,7 @@
                   <goal>run</goal>
                 </goals>
                 <configuration>
-                  <skip>${frontend.skip}</skip>
+                  <skip>${frontend.build.skip}</skip>
                   <target>
                     <copy todir="${project.build.outputDirectory}/public" failonerror="false">
                       <fileset dir="${project.basedir}/frontend/build" />
@@ -582,7 +593,6 @@
             <configuration>
               <workingDirectory>frontend</workingDirectory>
               <installDirectory>${project.build.directory}</installDirectory>
-              <skip>${frontend.skip}</skip>
             </configuration>
             <executions>
               <execution>
@@ -592,6 +602,7 @@
                 </goals>
                 <configuration>
                   <nodeVersion>${app.frontend.nodeVersion}</nodeVersion>
+                  <skip>${frontend.dependency.skip}</skip>
                 </configuration>
               </execution>
               <execution>
@@ -601,6 +612,7 @@
                 </goals>
                 <configuration>
                   <arguments>ci</arguments>
+                  <skip>${frontend.dependency.skip}</skip>
                 </configuration>
               </execution>
               <execution>
@@ -610,6 +622,7 @@
                 </goals>
                 <configuration>
                   <arguments>run build</arguments>
+                  <skip>${frontend.build.skip}</skip>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
In this PR, I improve the start time for integration tests by further granularizing when maven attempts to reinstall the node, npm, and the project's frontend dependencies.

If `package-lock.json` or `package.json` are newer than the last time the project was copied to the build directory, maven will attempt to reinstall npm, node, and run `npm install`.

If the dependencies changed, or the frontend code changes, maven will rebuild the project and re-copy it to the directory.

As a result, maven no longer runs `npm ci` every single time you make a code change to the frontend while attempting to work with integration tests.

Deployed to https://frontiers-daniel.dokku-00.cs.ucsb.edu/
