### PR TITLE
Apply Minimum Package Age of 7 Days

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,2 @@
 ignore-platform=true
+min-release-age=7


### PR DESCRIPTION
In the wake of many recent supply chain dependency vulnerabilities, @smmzhu suggested we add a minimum dependency age to help prevent against the usage of malicious dependencies.

`min-release-age=7` corresponds to 7 days.

requires npm 11; appears to still behave when on npm 10.