### PR TITLE
Bump lib-jobs to v0.3.2 (job cancellation, startup recovery)

### DIFF
--- a/frontend/src/main/components/Jobs/JobsTable.jsx
+++ b/frontend/src/main/components/Jobs/JobsTable.jsx
@@ -1,8 +1,33 @@
 import React from "react";
 import OurTable from "main/components/OurTable";
 import { formatTime } from "main/utils/dateUtils";
+import { Button } from "react-bootstrap";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function JobsTable({ jobs }) {
+const CANCELLABLE_STATUSES = ["queued", "running"];
+
+export default function JobsTable({ jobs, onCancelled = () => {} }) {
+  const cellToAxiosParamsCancel = (cell) => ({
+    url: `/api/jobs/${cell.row.original.id}/cancel`,
+    method: "POST",
+  });
+
+  const cancelSuccess = () => {
+    toast("Cancellation requested.");
+    onCancelled();
+  };
+
+  // Stryker disable all : hard to test for query caching
+  const cancelMutation = useBackendMutation(cellToAxiosParamsCancel, {
+    onSuccess: cancelSuccess,
+  });
+  // Stryker restore all
+
+  const cancelCallback = (cell) => {
+    cancelMutation.mutate(cell);
+  };
+
   const columns = [
     {
       header: "id",
@@ -35,6 +60,21 @@ export default function JobsTable({ jobs }) {
     {
       header: "Status",
       accessorKey: "status",
+    },
+    {
+      header: "Cancel",
+      id: "cancel",
+      cell: ({ cell }) =>
+        CANCELLABLE_STATUSES.includes(cell.row.original.status) ? (
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={() => cancelCallback(cell)}
+            data-testid={`JobsTable-cell-row-${cell.row.index}-col-cancel-button`}
+          >
+            Cancel
+          </Button>
+        ) : null,
     },
     {
       header: "Log",

--- a/frontend/src/main/components/TabComponent/JobTabComponent.jsx
+++ b/frontend/src/main/components/TabComponent/JobTabComponent.jsx
@@ -30,7 +30,7 @@ export default function JobTabComponent({ courseId, testIdPrefix }) {
         Refresh
       </Button>
 
-      <JobsTable jobs={jobs} />
+      <JobsTable jobs={jobs} onCancelled={refetch} />
     </div>
   );
 }

--- a/frontend/src/main/pages/Admin/AdminJobsPage.jsx
+++ b/frontend/src/main/pages/Admin/AdminJobsPage.jsx
@@ -55,7 +55,7 @@ export default function AdminJobsPage() {
     purgeJobLogMutation.mutate();
   };
 
-  const { data: jobs } = useBackend(
+  const { data: jobs, refetch } = useBackend(
     ["/api/jobs/all"],
     {
       //Stryker disable next-line StringLiteral: axios default is GET
@@ -100,7 +100,7 @@ export default function AdminJobsPage() {
         ))}
       </Accordion>
       <h2 className="p-3">Job Status</h2>
-      <JobsTable jobs={jobs} />
+      <JobsTable jobs={jobs} onCancelled={refetch} />
       <Button variant="danger" onClick={purgeJobLog} data-testid="purgeJobLog">
         Purge Job Log
       </Button>

--- a/frontend/src/tests/components/Jobs/JobsTable.test.jsx
+++ b/frontend/src/tests/components/Jobs/JobsTable.test.jsx
@@ -1,19 +1,33 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import { vi } from "vitest";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
 import JobsTable from "main/components/Jobs/JobsTable";
 import { formatTime } from "main/utils/dateUtils";
-import { vi } from "vitest";
 
 vi.mock("main/utils/dateUtils", () => ({
   formatTime: vi.fn(),
 }));
+
+const axiosMock = new AxiosMockAdapter(axios);
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    toast: (x) => mockToast(x),
+  };
+});
 
 describe("JobsTable tests", () => {
   const queryClient = new QueryClient();
 
   beforeEach(() => {
     formatTime.mockReset();
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    mockToast.mockReset();
   });
 
   test("renders without crashing for empty table", () => {
@@ -62,6 +76,9 @@ describe("JobsTable tests", () => {
     expect(screen.getByText("Created")).toBeInTheDocument();
     expect(screen.getByText("Updated")).toBeInTheDocument();
     expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByTestId("JobsTable-header-cancel")).toHaveTextContent(
+      "Cancel",
+    );
     expect(screen.getByText("Log")).toBeInTheDocument();
 
     // Check that the job data is rendered
@@ -122,6 +139,9 @@ describe("JobsTable tests", () => {
     expect(screen.getByText("Created")).toBeInTheDocument();
     expect(screen.getByText("Updated")).toBeInTheDocument();
     expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByTestId("JobsTable-header-cancel")).toHaveTextContent(
+      "Cancel",
+    );
     expect(screen.getByText("Log")).toBeInTheDocument();
 
     // Check that the job data is rendered
@@ -147,5 +167,125 @@ describe("JobsTable tests", () => {
     expect(formatTime).toHaveBeenCalledTimes(2);
     expect(formatTime).toHaveBeenNthCalledWith(1, "2023-01-01T10:00:00");
     expect(formatTime).toHaveBeenNthCalledWith(2, "2023-01-01T10:05:00");
+  });
+
+  test.each(["queued", "running"])(
+    "shows a Cancel button for a %s job",
+    (status) => {
+      const jobsFixture = [
+        {
+          id: 5,
+          createdAt: "2023-11-01T12:00:00Z",
+          updatedAt: "2023-11-01T12:00:00Z",
+          status,
+          log: "",
+        },
+      ];
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <JobsTable jobs={jobsFixture} />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        screen.getByTestId("JobsTable-cell-row-0-col-cancel-button"),
+      ).toBeInTheDocument();
+    },
+  );
+
+  test.each(["complete", "error", "cancelling", "cancelled", "interrupted"])(
+    "does not show a Cancel button for a %s job",
+    (status) => {
+      const jobsFixture = [
+        {
+          id: 5,
+          createdAt: "2023-11-01T12:00:00Z",
+          updatedAt: "2023-11-01T12:00:00Z",
+          status,
+          log: "",
+        },
+      ];
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <JobsTable jobs={jobsFixture} />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        screen.queryByTestId("JobsTable-cell-row-0-col-cancel-button"),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  test("clicking Cancel requests cancellation and calls onCancelled", async () => {
+    axiosMock.onPost("/api/jobs/5/cancel").reply(200, {
+      id: 5,
+      status: "cancelling",
+    });
+    const onCancelled = vi.fn();
+    const jobsFixture = [
+      {
+        id: 5,
+        createdAt: "2023-11-01T12:00:00Z",
+        updatedAt: "2023-11-01T12:00:00Z",
+        status: "running",
+        log: "",
+      },
+    ];
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsTable jobs={jobsFixture} onCancelled={onCancelled} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const cancelButton = screen.getByTestId(
+      "JobsTable-cell-row-0-col-cancel-button",
+    );
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toEqual(1));
+    expect(mockToast).toBeCalledWith("Cancellation requested.");
+    expect(onCancelled).toHaveBeenCalledTimes(1);
+  });
+
+  test("clicking Cancel works without an onCancelled prop", async () => {
+    axiosMock.onPost("/api/jobs/5/cancel").reply(200, {
+      id: 5,
+      status: "cancelling",
+    });
+    const jobsFixture = [
+      {
+        id: 5,
+        createdAt: "2023-11-01T12:00:00Z",
+        updatedAt: "2023-11-01T12:00:00Z",
+        status: "running",
+        log: "",
+      },
+    ];
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsTable jobs={jobsFixture} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const cancelButton = screen.getByTestId(
+      "JobsTable-cell-row-0-col-cancel-button",
+    );
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toEqual(1));
+    expect(mockToast).toBeCalledWith("Cancellation requested.");
   });
 });

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     <dependency>
       <groupId>com.github.ucsb-cs156</groupId>
       <artifactId>lib-jobs</artifactId>
-      <version>v0.2.0</version>
+      <version>v0.3.2</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentOrStaffRepositoriesJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentOrStaffRepositoriesJob.java
@@ -41,6 +41,10 @@ public class CreateStudentOrStaffRepositoriesJob implements JobContextConsumer {
     if (creationOption == RepositoryCreationOption.STUDENTS_ONLY
         || creationOption == RepositoryCreationOption.STUDENTS_AND_STAFF) {
       for (RosterStudent student : course.getRosterStudents()) {
+        // A student not on GitHub or not yet an org member never calls repositoryService,
+        // and neither of those branches calls ctx.log() -- checkCancellation() gives this
+        // loop its own checkpoint independent of whether an iteration does anything at all.
+        ctx.checkCancellation();
         if (student.getGithubLogin() != null
             && (student.getOrgStatus() == OrgStatus.MEMBER
                 || student.getOrgStatus() == OrgStatus.OWNER)) {
@@ -53,6 +57,9 @@ public class CreateStudentOrStaffRepositoriesJob implements JobContextConsumer {
     if (creationOption == RepositoryCreationOption.STAFF_ONLY
         || creationOption == RepositoryCreationOption.STUDENTS_AND_STAFF) {
       for (CourseStaff staff : course.getCourseStaff()) {
+        // Same reasoning as the student loop above: a staff member not on GitHub or not yet
+        // an org member never logs, so this loop needs its own cancellation checkpoint too.
+        ctx.checkCancellation();
         if (staff.getGithubLogin() != null
             && (staff.getOrgStatus() == OrgStatus.MEMBER
                 || staff.getOrgStatus() == OrgStatus.OWNER)) {

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateTeamRepositoriesJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/CreateTeamRepositoriesJob.java
@@ -43,6 +43,9 @@ public class CreateTeamRepositoriesJob implements JobContextConsumer {
     }
 
     for (Team team : course.getTeams()) {
+      // A team skipped by teamRegex never logs anything -- checkCancellation() gives this
+      // loop its own checkpoint independent of whether an iteration does any work.
+      ctx.checkCancellation();
       if (teamRegex != null && !team.getName().matches(teamRegex)) {
         continue;
       }

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJob.java
@@ -31,6 +31,10 @@ public class MembershipAuditJob implements JobContextConsumer {
     ctx.log("Auditing membership for each course with an attached GitHub Organization...");
     Iterable<Course> courses = courseRepository.findAll();
     for (Course course : courses) {
+      // Nothing in this method's whole body logs per course -- the only ctx.log() calls are
+      // the opening line above and the closing "Done" below. checkCancellation() gives the
+      // course loop its own checkpoint independent of course count.
+      ctx.checkCancellation();
       if (course.getOrgName() != null && course.getInstallationId() != null) {
         Iterable<OrgMember> members = organizationMemberService.getOrganizationMembers(course);
         Iterable<OrgMember> admins = organizationMemberService.getOrganizationAdmins(course);
@@ -38,6 +42,9 @@ public class MembershipAuditJob implements JobContextConsumer {
         List<RosterStudent> rosterStudents = course.getRosterStudents();
         List<CourseStaff> courseStaff = course.getCourseStaff();
         for (int i = 0; i < rosterStudents.size(); i++) {
+          // Same reasoning as the course loop: this loop never logs per student, so a large
+          // roster gives cancellation no other opportunity to fire.
+          ctx.checkCancellation();
           Integer studentGithubId = rosterStudents.get(i).getGithubId();
           String studentGithubLogin = rosterStudents.get(i).getGithubLogin();
           if (studentGithubId != null && studentGithubLogin != null) {
@@ -69,6 +76,8 @@ public class MembershipAuditJob implements JobContextConsumer {
         rosterStudentRepository.saveAll(rosterStudents);
 
         for (int i = 0; i < courseStaff.size(); i++) {
+          // Same reasoning as the roster-students loop above.
+          ctx.checkCancellation();
           Integer staffGithubId = courseStaff.get(i).getGithubId();
           String staffGithubLogin = courseStaff.get(i).getGithubLogin();
           if (staffGithubId != null && staffGithubLogin != null) {

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/PullTeamsFromGithubJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/PullTeamsFromGithubJob.java
@@ -86,6 +86,12 @@ public class PullTeamsFromGithubJob implements JobContextConsumer {
     int unchanged = 0;
 
     for (GithubTeamInfo githubTeam : githubTeams) {
+      // The common case on a re-sync is a team that's already up to date on every field and
+      // has no membership changes either -- that iteration never calls ctx.log() at all.
+      // checkCancellation() gives this loop its own checkpoint independent of how many teams
+      // in a row turn out to be unchanged (this is the same failure mode that drove lib-jobs
+      // v0.3.2: see SyncCourseWithPlRepoJob in proj-scaffold).
+      ctx.checkCancellation();
       Team localTeam = localByGithubId.get(githubTeam.id());
       if (localTeam == null) {
         localTeam = localByName.get(githubTeam.name());
@@ -150,6 +156,11 @@ public class PullTeamsFromGithubJob implements JobContextConsumer {
         Team currentTeam = localTeam;
         githubMemberships.forEach(
             (githubLogin, membershipStatus) -> {
+              // Same reasoning as the outer team loop: a member with no status change never
+              // logs. checkCancellation() throws JobCancelledException, which is unchecked --
+              // required here since BiConsumer's functional interface can't declare checked
+              // exceptions.
+              ctx.checkCancellation();
               RosterStudent student = localStudentsByGithubLogin.get(githubLogin);
               if (student == null) {
                 return;

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/RemoveStudentsJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/RemoveStudentsJob.java
@@ -25,6 +25,10 @@ public class RemoveStudentsJob implements JobContextConsumer {
   @Override
   public void accept(JobContext c) throws Exception {
     for (RosterStudent student : students) {
+      // A student whose course has no linked org, or who has no GitHub login/id, never calls
+      // c.log() -- checkCancellation() gives this loop its own checkpoint independent of
+      // whether an iteration does anything at all.
+      c.checkCancellation();
       if (student.getCourse().getOrgName() != null
           && student.getCourse().getInstallationId() != null) {
         if (student.getGithubLogin() != null && student.getGithubId() != null) {

--- a/src/main/java/edu/ucsb/cs156/frontiers/jobs/UpdateOrgMembershipJob.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/jobs/UpdateOrgMembershipJob.java
@@ -32,6 +32,9 @@ public class UpdateOrgMembershipJob implements JobContextConsumer {
     ctx.log("Processing...");
     Iterable<OrgMember> members = organizationMemberService.getOrganizationMembers(course);
     for (OrgMember member : members) {
+      // This loop never calls ctx.log() -- only the opening "Processing..." and closing "Done"
+      // lines do. checkCancellation() gives it its own checkpoint independent of member count.
+      ctx.checkCancellation();
       Optional<RosterStudent> student =
           rosterStudentRepository.findByCourseAndGithubId(course, member.getGithubId());
       if (student.isPresent()) {

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/GithubTeamService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/GithubTeamService.java
@@ -10,6 +10,7 @@ import edu.ucsb.cs156.frontiers.entities.Team;
 import edu.ucsb.cs156.frontiers.enums.TeamStatus;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -38,6 +39,18 @@ public class GithubTeamService {
 
   public record GithubTeamMemberInfo(String login) {}
 
+  /*
+   * A RestTemplate built with no timeout blocks its calling thread forever on a hung external
+   * call. That's a real incident lib-jobs' single-threaded jobsExecutor hit on another app
+   * (proj-scaffold): a job stuck this way permanently wedged the executor, with no way to recover
+   * short of restarting the app (see lib-jobs DESIGN.md 9 -- cooperative job cancellation only
+   * helps a job that reaches another checkpoint, which a truly hung thread never will). Generous
+   * but finite: long enough to never trip on legitimate slowness, short enough to guarantee a job
+   * can't hang forever.
+   */
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(60);
+
   private final JwtService jwtService;
   private final ObjectMapper objectMapper;
   private final RestTemplate restTemplate;
@@ -47,7 +60,7 @@ public class GithubTeamService {
     this.jwtService = jwtService;
     this.objectMapper = objectMapper;
     this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    this.restTemplate = builder.build();
+    this.restTemplate = builder.connectTimeout(CONNECT_TIMEOUT).readTimeout(READ_TIMEOUT).build();
   }
 
   /**

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/JwtService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/JwtService.java
@@ -11,6 +11,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -35,6 +36,18 @@ public class JwtService {
   @Value("${app.client.id:no-client-id}")
   private String clientId;
 
+  /*
+   * A RestTemplate built with no timeout blocks its calling thread forever on a hung external
+   * call. That's a real incident lib-jobs' single-threaded jobsExecutor hit on another app
+   * (proj-scaffold): a job stuck this way permanently wedged the executor, with no way to recover
+   * short of restarting the app (see lib-jobs DESIGN.md 9 -- cooperative job cancellation only
+   * helps a job that reaches another checkpoint, which a truly hung thread never will). Generous
+   * but finite: long enough to never trip on legitimate slowness, short enough to guarantee a job
+   * can't hang forever.
+   */
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(60);
+
   private final RestTemplate restTemplate;
 
   private final ObjectMapper objectMapper;
@@ -45,7 +58,8 @@ public class JwtService {
       RestTemplateBuilder restTemplateBuilder,
       ObjectMapper objectMapper,
       DateTimeProvider dateTimeProvider) {
-    this.restTemplate = restTemplateBuilder.build();
+    this.restTemplate =
+        restTemplateBuilder.connectTimeout(CONNECT_TIMEOUT).readTimeout(READ_TIMEOUT).build();
     this.objectMapper = objectMapper;
     this.dateTimeProvider = dateTimeProvider;
   }

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationLinkerService.java
@@ -9,6 +9,7 @@ import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
 import edu.ucsb.cs156.frontiers.models.CourseWarning;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -23,6 +24,18 @@ import org.springframework.web.client.RestTemplate;
 
 @Service
 public class OrganizationLinkerService {
+  /*
+   * A RestTemplate built with no timeout blocks its calling thread forever on a hung external
+   * call. That's a real incident lib-jobs' single-threaded jobsExecutor hit on another app
+   * (proj-scaffold): a job stuck this way permanently wedged the executor, with no way to recover
+   * short of restarting the app (see lib-jobs DESIGN.md 9 -- cooperative job cancellation only
+   * helps a job that reaches another checkpoint, which a truly hung thread never will). Generous
+   * but finite: long enough to never trip on legitimate slowness, short enough to guarantee a job
+   * can't hang forever.
+   */
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(60);
+
   private RestTemplate restTemplate;
 
   @Autowired JwtService jwtService;
@@ -32,7 +45,8 @@ public class OrganizationLinkerService {
   @Autowired DateTimeProvider provider;
 
   public OrganizationLinkerService(RestTemplateBuilder restTemplateBuilder) {
-    restTemplate = restTemplateBuilder.build();
+    restTemplate =
+        restTemplateBuilder.connectTimeout(CONNECT_TIMEOUT).readTimeout(READ_TIMEOUT).build();
   }
 
   /**

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/OrganizationMemberService.java
@@ -13,6 +13,7 @@ import edu.ucsb.cs156.frontiers.models.OrgMember;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +34,18 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class OrganizationMemberService {
 
+  /*
+   * A RestTemplate built with no timeout blocks its calling thread forever on a hung external
+   * call. That's a real incident lib-jobs' single-threaded jobsExecutor hit on another app
+   * (proj-scaffold): a job stuck this way permanently wedged the executor, with no way to recover
+   * short of restarting the app (see lib-jobs DESIGN.md 9 -- cooperative job cancellation only
+   * helps a job that reaches another checkpoint, which a truly hung thread never will). Generous
+   * but finite: long enough to never trip on legitimate slowness, short enough to guarantee a job
+   * can't hang forever.
+   */
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(60);
+
   private final JwtService jwtService;
   private final ObjectMapper objectMapper;
   private final RestTemplate restTemplate;
@@ -47,7 +60,7 @@ public class OrganizationMemberService {
     this.objectMapper = objectMapper;
     this.rosterStudentRepository = rosterStudentRepository;
     this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    this.restTemplate = builder.build();
+    this.restTemplate = builder.connectTimeout(CONNECT_TIMEOUT).readTimeout(READ_TIMEOUT).build();
   }
 
   /**

--- a/src/main/java/edu/ucsb/cs156/frontiers/services/RepositoryService.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/services/RepositoryService.java
@@ -11,6 +11,7 @@ import edu.ucsb.cs156.frontiers.enums.RepositoryPermissions;
 import edu.ucsb.cs156.frontiers.repositories.TeamRepository;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -25,6 +26,18 @@ import org.springframework.web.client.RestTemplate;
 @Service
 @Slf4j
 public class RepositoryService {
+  /*
+   * A RestTemplate built with no timeout blocks its calling thread forever on a hung external
+   * call. That's a real incident lib-jobs' single-threaded jobsExecutor hit on another app
+   * (proj-scaffold): a job stuck this way permanently wedged the executor, with no way to recover
+   * short of restarting the app (see lib-jobs DESIGN.md 9 -- cooperative job cancellation only
+   * helps a job that reaches another checkpoint, which a truly hung thread never will). Generous
+   * but finite: long enough to never trip on legitimate slowness, short enough to guarantee a job
+   * can't hang forever.
+   */
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(60);
+
   private final JwtService jwtService;
   private final GithubTeamService githubTeamService;
   private final TeamRepository teamRepository;
@@ -133,7 +146,8 @@ public class RepositoryService {
     this.jwtService = jwtService;
     this.githubTeamService = githubTeamService;
     this.teamRepository = teamRepository;
-    this.restTemplate = restTemplateBuilder.build();
+    this.restTemplate =
+        restTemplateBuilder.connectTimeout(CONNECT_TIMEOUT).readTimeout(READ_TIMEOUT).build();
     this.mapper = mapper;
   }
 

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentOrStaffRepositoriesJobTest.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/CreateStudentOrStaffRepositoriesJobTest.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.frontiers.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
@@ -14,8 +15,11 @@ import edu.ucsb.cs156.frontiers.enums.RepositoryCreationOption;
 import edu.ucsb.cs156.frontiers.enums.RepositoryPermissions;
 import edu.ucsb.cs156.frontiers.services.RepositoryService;
 import edu.ucsb.cs156.jobs.entities.Job;
+import edu.ucsb.cs156.jobs.errors.JobCancelledException;
+import edu.ucsb.cs156.jobs.repositories.JobsRepository;
 import edu.ucsb.cs156.jobs.services.JobContext;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -365,5 +369,93 @@ public class CreateStudentOrStaffRepositoriesJobTest {
             contains("repo-prefix"),
             eq(false),
             eq(RepositoryPermissions.WRITE));
+  }
+
+  // ────────────────────── checkCancellation checkpoints ──────────────────────
+  // A student/staff with no GitHub login, or not yet an org member, never calls
+  // repositoryService and never logs -- without their own ctx.checkCancellation() checkpoints,
+  // these loops would give cancellation no opportunity to fire no matter how many students or
+  // staff they skip over. accept() always logs 4 lines (repositoryPrefix/isPrivate/permissions/
+  // creationOption) before either loop, and each ctx.log() call internally checks cancellation
+  // too -- so these tests report "running" for exactly those 4 preceding checkpoints, then
+  // "cancelling" from the loop's own check onward, and assert both that JobCancelledException is
+  // thrown AND that repositoryService was never called -- the second assertion is what actually
+  // distinguishes the real code from a mutant that removes the checkpoint, since ctx.log("Done")
+  // at the end would otherwise throw the same exception type.
+
+  private static Job runningJob() {
+    return Job.builder().id(99L).status("running").build();
+  }
+
+  private static Job cancellingJob() {
+    return Job.builder().id(99L).status("cancelling").build();
+  }
+
+  @Test
+  public void checkCancellation_stops_the_student_loop_before_calling_repositoryService()
+      throws Exception {
+    Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+    RosterStudent student =
+        RosterStudent.builder().githubLogin("studentLogin").orgStatus(OrgStatus.MEMBER).build();
+    course.setRosterStudents(List.of(student));
+
+    JobsRepository jobsRepository = mock(JobsRepository.class);
+    when(jobsRepository.findById(99L))
+        .thenReturn(
+            Optional.of(runningJob()),
+            Optional.of(runningJob()),
+            Optional.of(runningJob()),
+            Optional.of(runningJob()),
+            Optional.of(cancellingJob()));
+    Job job = Job.builder().id(99L).build();
+    JobContext cancellingCtx = new JobContext(null, job, null, jobsRepository);
+
+    var repoJob =
+        CreateStudentOrStaffRepositoriesJob.builder()
+            .repositoryService(service)
+            .repositoryPrefix("repo-prefix")
+            .course(course)
+            .isPrivate(false)
+            .permissions(RepositoryPermissions.WRITE)
+            .creationOption(RepositoryCreationOption.STUDENTS_ONLY)
+            .build();
+
+    assertThrows(JobCancelledException.class, () -> repoJob.accept(cancellingCtx));
+
+    verify(service, never()).createStudentRepository(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void checkCancellation_stops_the_staff_loop_before_calling_repositoryService()
+      throws Exception {
+    Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+    CourseStaff staff =
+        CourseStaff.builder().githubLogin("staffLogin").orgStatus(OrgStatus.MEMBER).build();
+    course.setCourseStaff(List.of(staff));
+
+    JobsRepository jobsRepository = mock(JobsRepository.class);
+    when(jobsRepository.findById(99L))
+        .thenReturn(
+            Optional.of(runningJob()),
+            Optional.of(runningJob()),
+            Optional.of(runningJob()),
+            Optional.of(runningJob()),
+            Optional.of(cancellingJob()));
+    Job job = Job.builder().id(99L).build();
+    JobContext cancellingCtx = new JobContext(null, job, null, jobsRepository);
+
+    var repoJob =
+        CreateStudentOrStaffRepositoriesJob.builder()
+            .repositoryService(service)
+            .repositoryPrefix("repo-prefix")
+            .course(course)
+            .isPrivate(false)
+            .permissions(RepositoryPermissions.WRITE)
+            .creationOption(RepositoryCreationOption.STAFF_ONLY)
+            .build();
+
+    assertThrows(JobCancelledException.class, () -> repoJob.accept(cancellingCtx));
+
+    verify(service, never()).createStaffRepository(any(), any(), any(), any(), any());
   }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/CreateTeamRepositoriesJobTest.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/CreateTeamRepositoriesJobTest.java
@@ -17,8 +17,11 @@ import edu.ucsb.cs156.frontiers.enums.RepositoryPermissions;
 import edu.ucsb.cs156.frontiers.services.GithubTeamService;
 import edu.ucsb.cs156.frontiers.services.RepositoryService;
 import edu.ucsb.cs156.jobs.entities.Job;
+import edu.ucsb.cs156.jobs.errors.JobCancelledException;
+import edu.ucsb.cs156.jobs.repositories.JobsRepository;
 import edu.ucsb.cs156.jobs.services.JobContext;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -263,5 +266,42 @@ public class CreateTeamRepositoriesJobTest {
         .createTeamRepository(eq(course), eq(team1), any(), any(), any(), any());
     verify(service, never())
         .createTeamRepository(eq(course), eq(team2), any(), any(), any(), any());
+  }
+
+  // ────────────────────── checkCancellation checkpoint ──────────────────────
+  // A team skipped by teamRegex never logs anything -- without its own ctx.checkCancellation()
+  // checkpoint, this loop would give cancellation no opportunity to fire no matter how many
+  // teams it skips. Exactly 1 real checkpoint precedes the loop's own check: accept()'s opening
+  // "Creating team repositories..." log line.
+
+  @Test
+  public void checkCancellation_stops_the_team_loop_before_calling_repositoryService()
+      throws Exception {
+    Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+    Team team = Team.builder().name("test-team1").build();
+    course.setTeams(List.of(team));
+    when(githubTeamService.getOrgId("ucsb-cs156", course)).thenReturn(1);
+
+    JobsRepository jobsRepository = mock(JobsRepository.class);
+    Job runningJob = Job.builder().id(99L).status("running").build();
+    Job cancellingJob = Job.builder().id(99L).status("cancelling").build();
+    when(jobsRepository.findById(99L))
+        .thenReturn(Optional.of(runningJob), Optional.of(cancellingJob));
+    Job job = Job.builder().id(99L).build();
+    JobContext cancellingCtx = new JobContext(null, job, null, jobsRepository);
+
+    var repoJob =
+        CreateTeamRepositoriesJob.builder()
+            .repositoryService(service)
+            .githubTeamService(githubTeamService)
+            .repositoryPrefix("repo-prefix")
+            .course(course)
+            .isPrivate(false)
+            .permissions(RepositoryPermissions.WRITE)
+            .build();
+
+    assertThrows(JobCancelledException.class, () -> repoJob.accept(cancellingCtx));
+
+    verify(service, never()).createTeamRepository(any(), any(), any(), any(), any(), any());
   }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/MembershipAuditJobTests.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.frontiers.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -17,8 +18,11 @@ import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
 import edu.ucsb.cs156.jobs.entities.Job;
+import edu.ucsb.cs156.jobs.errors.JobCancelledException;
+import edu.ucsb.cs156.jobs.repositories.JobsRepository;
 import edu.ucsb.cs156.jobs.services.JobContext;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -485,5 +489,118 @@ public class MembershipAuditJobTests {
         .saveAll(eq(List.of(studentUpdated, student2NotUpdated)));
     verify(courseStaffRepository).saveAll(eq(List.of(courseStaff1Updated, courseStaff2NotUpdated)));
     verifyNoMoreInteractions(courseStaffRepository, rosterStudentRepository);
+  }
+
+  // ────────────────────── checkCancellation checkpoints ──────────────────────
+  // Nothing in this method's whole body logs per course, per student, or per staff member --
+  // the only ctx.log() calls are the opening line and the closing "Done". Without their own
+  // checkCancellation() checkpoints, the course/student/staff loops would give cancellation no
+  // opportunity to fire no matter how many courses/students/staff they process. These tests
+  // mock a JobsRepository that reports "running" for exactly the calls known to precede the
+  // checkpoint under test, then "cancelling" from then on, and assert both that
+  // JobCancelledException is thrown AND that a downstream call the checkpoint should have
+  // pre-empted was never made.
+
+  private static Job runningJob() {
+    return Job.builder().id(99L).status("running").build();
+  }
+
+  private static Job cancellingJob() {
+    return Job.builder().id(99L).status("cancelling").build();
+  }
+
+  @Test
+  public void checkCancellation_stops_the_course_loop_before_fetching_org_members()
+      throws Exception {
+    Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+    doReturn(List.of(course)).when(courseRepository).findAll();
+
+    JobsRepository jobsRepository = mock(JobsRepository.class);
+    // 1 real checkpoint precedes the course loop's own check: accept()'s opening log line.
+    when(jobsRepository.findById(99L))
+        .thenReturn(Optional.of(runningJob()), Optional.of(cancellingJob()));
+    Job job = Job.builder().id(99L).build();
+    JobContext cancellingCtx = new JobContext(null, job, null, jobsRepository);
+
+    var matchJob =
+        MembershipAuditJob.builder()
+            .rosterStudentRepository(rosterStudentRepository)
+            .organizationMemberService(organizationMemberService)
+            .courseRepository(courseRepository)
+            .courseStaffRepository(courseStaffRepository)
+            .build();
+
+    assertThrows(JobCancelledException.class, () -> matchJob.accept(cancellingCtx));
+
+    verify(organizationMemberService, never()).getOrganizationMembers(any());
+  }
+
+  @Test
+  public void checkCancellation_stops_the_student_loop_before_saving_the_roster() throws Exception {
+    Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+    RosterStudent student =
+        RosterStudent.builder().studentId("banana").githubId(123456).course(course).build();
+    course.setRosterStudents(List.of(student));
+    course.setCourseStaff(List.of());
+    doReturn(List.of(course)).when(courseRepository).findAll();
+    doReturn(List.of()).when(organizationMemberService).getOrganizationMembers(eq(course));
+    doReturn(List.of()).when(organizationMemberService).getOrganizationAdmins(eq(course));
+    doReturn(List.of()).when(organizationMemberService).getOrganizationInvitees(eq(course));
+
+    JobsRepository jobsRepository = mock(JobsRepository.class);
+    // 2 real checkpoints precede the student loop's own check under this setup: accept()'s
+    // opening log line, and the course loop's own checkCancellation() (checked above).
+    when(jobsRepository.findById(99L))
+        .thenReturn(
+            Optional.of(runningJob()), Optional.of(runningJob()), Optional.of(cancellingJob()));
+    Job job = Job.builder().id(99L).build();
+    JobContext cancellingCtx = new JobContext(null, job, null, jobsRepository);
+
+    var matchJob =
+        MembershipAuditJob.builder()
+            .rosterStudentRepository(rosterStudentRepository)
+            .organizationMemberService(organizationMemberService)
+            .courseRepository(courseRepository)
+            .courseStaffRepository(courseStaffRepository)
+            .build();
+
+    assertThrows(JobCancelledException.class, () -> matchJob.accept(cancellingCtx));
+
+    verify(rosterStudentRepository, never()).saveAll(any());
+  }
+
+  @Test
+  public void checkCancellation_stops_the_staff_loop_before_saving_the_staff_list()
+      throws Exception {
+    Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+    CourseStaff staff = CourseStaff.builder().githubId(781).course(course).build();
+    course.setRosterStudents(List.of());
+    course.setCourseStaff(List.of(staff));
+    doReturn(List.of(course)).when(courseRepository).findAll();
+    doReturn(List.of()).when(organizationMemberService).getOrganizationMembers(eq(course));
+    doReturn(List.of()).when(organizationMemberService).getOrganizationAdmins(eq(course));
+    doReturn(List.of()).when(organizationMemberService).getOrganizationInvitees(eq(course));
+
+    JobsRepository jobsRepository = mock(JobsRepository.class);
+    // 2 real checkpoints precede the staff loop's own check under this setup (an empty roster
+    // means the student loop never runs, and rosterStudentRepository.saveAll() doesn't consume
+    // a checkpoint): accept()'s opening log line, and the course loop's own checkCancellation().
+    when(jobsRepository.findById(99L))
+        .thenReturn(
+            Optional.of(runningJob()), Optional.of(runningJob()), Optional.of(cancellingJob()));
+    Job job = Job.builder().id(99L).build();
+    JobContext cancellingCtx = new JobContext(null, job, null, jobsRepository);
+
+    var matchJob =
+        MembershipAuditJob.builder()
+            .rosterStudentRepository(rosterStudentRepository)
+            .organizationMemberService(organizationMemberService)
+            .courseRepository(courseRepository)
+            .courseStaffRepository(courseStaffRepository)
+            .build();
+
+    assertThrows(JobCancelledException.class, () -> matchJob.accept(cancellingCtx));
+
+    verify(courseStaffRepository, never()).saveAll(any());
   }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/PullTeamsFromGithubJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/PullTeamsFromGithubJobTests.java
@@ -15,6 +15,8 @@ import edu.ucsb.cs156.frontiers.repositories.TeamRepository;
 import edu.ucsb.cs156.frontiers.services.GithubTeamService;
 import edu.ucsb.cs156.frontiers.services.GithubTeamService.GithubTeamInfo;
 import edu.ucsb.cs156.jobs.entities.Job;
+import edu.ucsb.cs156.jobs.errors.JobCancelledException;
+import edu.ucsb.cs156.jobs.repositories.JobsRepository;
 import edu.ucsb.cs156.jobs.services.JobContext;
 import java.util.Arrays;
 import java.util.List;
@@ -811,5 +813,119 @@ public class PullTeamsFromGithubJobTests {
                         && tm.getRosterStudent().equals(memberStudent)
                         && tm.getTeamStatus().equals(TeamStatus.TEAM_MEMBER)));
     assertTrue(jobStarted.getLog().contains("created: 0, updated: 1, unchanged: 0"));
+  }
+
+  // ────────────────────── checkCancellation checkpoints ──────────────────────
+  // The common case on a re-sync is a team that's already up to date on every field with no
+  // membership changes either -- that iteration never calls ctx.log() at all. Without their own
+  // checkCancellation() checkpoints, neither the outer team loop nor the inner per-member
+  // forEach would give cancellation an opportunity to fire during such a silent stretch. These
+  // tests mock a JobsRepository that reports "running" for exactly the calls known to precede
+  // the checkpoint under test, then "cancelling" from then on, and assert both that
+  // JobCancelledException is thrown AND that a downstream call the checkpoint should have
+  // pre-empted was never made.
+
+  private static Job runningJob() {
+    return Job.builder().id(99L).status("running").build();
+  }
+
+  private static Job cancellingJob() {
+    return Job.builder().id(99L).status("cancelling").build();
+  }
+
+  @Test
+  public void checkCancellation_stops_the_team_loop_before_looking_up_the_local_team()
+      throws Exception {
+    Long courseId = 1L;
+    Course course =
+        Course.builder()
+            .id(courseId)
+            .courseName("Test Course")
+            .orgName("test-org")
+            .installationId("123")
+            .build();
+    List<GithubTeamInfo> githubTeams = Arrays.asList(new GithubTeamInfo(111, "team-a", "team-a"));
+
+    when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
+    when(githubTeamService.getAllTeams(course)).thenReturn(githubTeams);
+    when(teamRepository.findByCourseId(courseId)).thenReturn(Arrays.asList());
+
+    JobsRepository jobsRepository = mock(JobsRepository.class);
+    // 2 real checkpoints precede the team loop's own check: accept()'s opening "Starting..." and
+    // "Processing course..." log lines.
+    when(jobsRepository.findById(99L))
+        .thenReturn(
+            Optional.of(runningJob()), Optional.of(runningJob()), Optional.of(cancellingJob()));
+    Job job = Job.builder().id(99L).build();
+    JobContext cancellingCtx = new JobContext(null, job, null, jobsRepository);
+
+    PullTeamsFromGithubJob job2 =
+        PullTeamsFromGithubJob.builder()
+            .courseId(courseId)
+            .courseRepository(courseRepository)
+            .teamRepository(teamRepository)
+            .teamMemberRepository(teamMemberRepository)
+            .githubTeamService(githubTeamService)
+            .build();
+
+    assertThrows(JobCancelledException.class, () -> job2.accept(cancellingCtx));
+
+    verify(teamRepository, never()).save(any());
+  }
+
+  @Test
+  public void checkCancellation_stops_the_member_loop_before_looking_up_the_team_member()
+      throws Exception {
+    Long courseId = 1L;
+    RosterStudent existingStudent = RosterStudent.builder().githubLogin("existing-login").build();
+    Course course =
+        Course.builder()
+            .id(courseId)
+            .courseName("Test Course")
+            .orgName("test-org")
+            .installationId("123")
+            .rosterStudents(Arrays.asList(existingStudent))
+            .build();
+    // Already up to date on every field -- teamCreated=false and teamUnchanged stays true, so
+    // this iteration of the outer loop reaches the member-processing block with no log call.
+    Team localTeam =
+        Team.builder()
+            .name("team-a")
+            .githubTeamId(111)
+            .githubTeamSlug("team-a")
+            .course(course)
+            .build();
+    List<GithubTeamInfo> githubTeams = Arrays.asList(new GithubTeamInfo(111, "team-a", "team-a"));
+
+    when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
+    when(githubTeamService.getAllTeams(course)).thenReturn(githubTeams);
+    when(teamRepository.findByCourseId(courseId)).thenReturn(Arrays.asList(localTeam));
+    when(githubTeamService.getTeamMemberships("team-a", course))
+        .thenReturn(Map.of("existing-login", TeamStatus.TEAM_MEMBER));
+
+    JobsRepository jobsRepository = mock(JobsRepository.class);
+    // 3 real checkpoints precede the member loop's own check under this setup: accept()'s two
+    // opening log lines, and the outer team loop's own checkCancellation() (checked above).
+    when(jobsRepository.findById(99L))
+        .thenReturn(
+            Optional.of(runningJob()),
+            Optional.of(runningJob()),
+            Optional.of(runningJob()),
+            Optional.of(cancellingJob()));
+    Job job = Job.builder().id(99L).build();
+    JobContext cancellingCtx = new JobContext(null, job, null, jobsRepository);
+
+    PullTeamsFromGithubJob job2 =
+        PullTeamsFromGithubJob.builder()
+            .courseId(courseId)
+            .courseRepository(courseRepository)
+            .teamRepository(teamRepository)
+            .teamMemberRepository(teamMemberRepository)
+            .githubTeamService(githubTeamService)
+            .build();
+
+    assertThrows(JobCancelledException.class, () -> job2.accept(cancellingCtx));
+
+    verify(teamMemberRepository, never()).findByTeamAndRosterStudent(any(), any());
   }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/RemoveStudentsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/RemoveStudentsJobTests.java
@@ -7,17 +7,23 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
+import edu.ucsb.cs156.jobs.entities.Job;
+import edu.ucsb.cs156.jobs.errors.JobCancelledException;
+import edu.ucsb.cs156.jobs.repositories.JobsRepository;
 import edu.ucsb.cs156.jobs.services.JobContext;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -207,5 +213,41 @@ public class RemoveStudentsJobTests {
     // Assert
     verify(organizationMemberService, never()).removeOrganizationMember(any(RosterStudent.class));
     verify(rosterStudentRepository, never()).save(any(RosterStudent.class));
+  }
+
+  // A student whose course has no linked org, or who has no GitHub login/id, never calls
+  // c.log() -- without its own checkCancellation() checkpoint, this loop would give
+  // cancellation no opportunity to fire no matter how many students it skips. This test uses a
+  // real JobContext (not the mocked jobContext field above, which can't observe the checkpoint)
+  // backed by a JobsRepository that reports "cancelling" immediately -- the loop's own check is
+  // the very first checkCancellation-consuming call, since accept() never logs before it.
+  @Test
+  public void checkCancellation_stops_the_student_loop_before_calling_removeOrganizationMember()
+      throws Exception {
+    Course course = Course.builder().orgName("testOrg").installationId("123456").build();
+    RosterStudent student1 =
+        RosterStudent.builder()
+            .course(course)
+            .githubLogin("testLogin1")
+            .githubId(123545)
+            .orgStatus(OrgStatus.MEMBER)
+            .build();
+
+    removeStudentsJob =
+        RemoveStudentsJob.builder()
+            .organizationMemberService(organizationMemberService)
+            .rosterStudentRepository(rosterStudentRepository)
+            .students(List.of(student1))
+            .build();
+
+    JobsRepository jobsRepository = mock(JobsRepository.class);
+    Job cancellingJob = Job.builder().id(99L).status("cancelling").build();
+    when(jobsRepository.findById(99L)).thenReturn(Optional.of(cancellingJob));
+    Job job = Job.builder().id(99L).build();
+    JobContext cancellingCtx = new JobContext(null, job, null, jobsRepository);
+
+    assertThrows(JobCancelledException.class, () -> removeStudentsJob.accept(cancellingCtx));
+
+    verify(organizationMemberService, never()).removeOrganizationMember(any(RosterStudent.class));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/jobs/UpdateOrgMembershipJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/jobs/UpdateOrgMembershipJobTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.frontiers.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -13,6 +14,8 @@ import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
 import edu.ucsb.cs156.jobs.entities.Job;
+import edu.ucsb.cs156.jobs.errors.JobCancelledException;
+import edu.ucsb.cs156.jobs.repositories.JobsRepository;
 import edu.ucsb.cs156.jobs.services.JobContext;
 import java.util.List;
 import java.util.Optional;
@@ -139,5 +142,37 @@ public class UpdateOrgMembershipJobTests {
     assertEquals(expected, jobStarted.getLog());
 
     verify(rosterStudentRepository, times(0)).save(any());
+  }
+
+  // This loop never calls ctx.log() -- only the opening "Processing..." and closing "Done"
+  // lines do. Without its own checkCancellation() checkpoint, it would give cancellation no
+  // opportunity to fire no matter how many members it processes. 1 real checkpoint precedes the
+  // loop's own check: accept()'s opening "Processing..." log line.
+  @Test
+  public void checkCancellation_stops_the_member_loop_before_calling_findByCourseAndGithubId()
+      throws Exception {
+    OrgMember orgMember1 = OrgMember.builder().githubId(123456).githubLogin("division7").build();
+    List<OrgMember> orgMembers = List.of(orgMember1);
+    Course course = Course.builder().orgName("ucsb-cs156").installationId("1234").build();
+    doReturn(orgMembers).when(organizationMemberService).getOrganizationMembers(eq(course));
+
+    JobsRepository jobsRepository = mock(JobsRepository.class);
+    Job runningJob = Job.builder().id(99L).status("running").build();
+    Job cancellingJob = Job.builder().id(99L).status("cancelling").build();
+    when(jobsRepository.findById(99L))
+        .thenReturn(Optional.of(runningJob), Optional.of(cancellingJob));
+    Job job = Job.builder().id(99L).build();
+    JobContext cancellingCtx = new JobContext(null, job, null, jobsRepository);
+
+    var matchJob =
+        UpdateOrgMembershipJob.builder()
+            .rosterStudentRepository(rosterStudentRepository)
+            .organizationMemberService(organizationMemberService)
+            .course(course)
+            .build();
+
+    assertThrows(JobCancelledException.class, () -> matchJob.accept(cancellingCtx));
+
+    verify(rosterStudentRepository, never()).findByCourseAndGithubId(any(), anyInt());
   }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/services/GithubTeamServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/services/GithubTeamServiceTests.java
@@ -37,6 +37,8 @@ public class GithubTeamServiceTests {
 
   @BeforeEach
   public void setup() {
+    when(restTemplateBuilder.connectTimeout(any())).thenReturn(restTemplateBuilder);
+    when(restTemplateBuilder.readTimeout(any())).thenReturn(restTemplateBuilder);
     when(restTemplateBuilder.build()).thenReturn(restTemplate);
     objectMapper = new ObjectMapper();
     githubTeamService = new GithubTeamService(jwtService, objectMapper, restTemplateBuilder);


### PR DESCRIPTION
## Summary
- Bumps `lib-jobs` from v0.2.0 to v0.3.2, adopting cooperative job cancellation (`POST /api/jobs/{id}/cancel`), the startup-recovery sweep for jobs orphaned by an app restart (marked `interrupted`), and the public `checkCancellation()` checkpoint API.
- Added `ctx.checkCancellation()` checkpoints to 6 job classes whose loops don't call `ctx.log()` on every iteration, so a cancel request wouldn't otherwise get noticed during a long silent stretch:
  - `CreateStudentOrStaffRepositoriesJob` (student/staff loops)
  - `CreateTeamRepositoriesJob` (team loop)
  - `MembershipAuditJob` (course/student/staff loops)
  - `PullTeamsFromGithubJob` (team loop and its per-member `forEach` lambda — the common re-sync case of an already-up-to-date team is exactly the silent-loop pattern that drove lib-jobs v0.3.2 in the first place)
  - `RemoveStudentsJob` (student loop)
  - `UpdateOrgMembershipJob` (member loop)

  Each checkpoint has a dedicated pitest-driven test asserting both that `JobCancelledException` is thrown and that a downstream call the checkpoint should have pre-empted was never made.
- Added connect/read timeouts (10s/60s) to all 5 `RestTemplate` construction sites (`OrganizationMemberService`, `JwtService`, `OrganizationLinkerService`, `RepositoryService`, `GithubTeamService`), matching the fix scaffold/courses/dining each applied — an untimed HTTP call in a job body can permanently wedge lib-jobs' single-threaded executor.
- Added a Cancel button to `JobsTable` (red, shown for queued/running jobs, POSTs to `/api/jobs/{id}/cancel`), wired via `onCancelled` into both `AdminJobsPage`'s `refetch` and `JobTabComponent`'s `refetch`, since frontiers has both an admin-global jobs view and a per-course jobs tab.
- Checked for the `AsyncJobTestsIT`-style mocked-`JobsRepository` bug — clean, no such pattern in frontiers' tests.

## Test plan
- [x] `mvn test`: 707 tests, 0 failures
- [x] `mvn verify`: jacoco 100% coverage, all checks met
- [x] `mvn org.pitest:pitest-maven:mutationCoverage`: 1120/1120 mutations killed (100%)
- [x] `npx vitest run`: 515 tests, 100% coverage
- [x] `eslint` / `prettier --check`: clean
- [ ] Live smoke test on dokku: launch a job, cancel it via the new UI button, confirm it reaches `cancelled`; restart the app with a job left `running` and confirm the startup sweep marks it `interrupted`; specifically re-verify cancelling `PullTeamsFromGithubJob` during a mostly-unchanged re-sync reaches `cancelled` promptly (the regression scenario for v0.3.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)