### PR TITLE
Bump lib-jobs to v0.3.3 (defensive: job-chaining transaction fix)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     <dependency>
       <groupId>com.github.ucsb-cs156</groupId>
       <artifactId>lib-jobs</artifactId>
-      <version>v0.3.2</version>
+      <version>v0.3.3</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
## Summary

- Bumps the `lib-jobs` dependency from v0.3.2 to v0.3.3 in `pom.xml`. Pure version bump, no app-code changes.
- v0.3.3 fixes a transaction-visibility race in `JobService.runAsJob()`: when one job's own `accept()` method calls `jobService.runAsJob(childJob)` to chain a second job, and the app's `jobsExecutor` thread pool has more than one thread, the child job's initial database row could get silently stranded at status `queued` forever even though its actual work completed normally.
- Frontiers does not currently chain jobs. Confirmed via `git grep runAsJob` and `git grep JobService` scoped to `src/main/java/edu/ucsb/cs156/frontiers/jobs/`: none of frontiers' 16 job classes reference `JobService`/`runAsJob` at all. Every other `runAsJob` call site in the app is either a controller launch endpoint or `ScheduledJobs.runMembershipAuditJobBasedOnCron`'s `@Scheduled` cron trigger — neither runs inside another job's own transaction. This bump is purely defensive, closing the gap in case chaining is added later; it fixes no currently-live bug in frontiers.

## Test plan
- [x] `mvn test`: 707 tests, 0 failures
- [x] `mvn verify`: jacoco 100% coverage, all checks met
- [x] frontend tests: 515 tests passing, 100% coverage (statements/branches/functions/lines); eslint clean
- [ ] Live smoke test not needed -- pure dependency version bump, no behavior change for this app

🤖 Generated with [Claude Code](https://claude.com/claude-code)